### PR TITLE
Add the new Results and ResultsInput models to Repo

### DIFF
--- a/qcelemental/__init__.py
+++ b/qcelemental/__init__.py
@@ -5,6 +5,7 @@ Main init for QCElemental
 from .datum import Datum
 from .exceptions import (NotAnElementError, ValidationError, MoleculeFormatError, ChoicesError, DataUnavailableError)
 from . import molparse
+from . import models
 
 # Handle singletons, not their classes or modules
 from .periodic_table import periodictable

--- a/qcelemental/models/__init__.py
+++ b/qcelemental/models/__init__.py
@@ -5,4 +5,5 @@ except ImportError:
                       "`conda install pydantic -c conda-forge` or `pip install pydantic`")
 
 from .molecule import Molecule
+from .results import Results, ResultsInput
 from .common_models import Provenance

--- a/qcelemental/models/__init__.py
+++ b/qcelemental/models/__init__.py
@@ -5,5 +5,5 @@ except ImportError:
                       "`conda install pydantic -c conda-forge` or `pip install pydantic`")
 
 from .molecule import Molecule
-from .results import Results, ResultsInput
+from .results import Result, ResultInput
 from .common_models import Provenance

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -64,6 +64,7 @@ class Error(BaseModel):
 
 class ResultsInput(BaseModel):
     """The MolSSI Quantum Chemistry Schema"""
+    id: str = None
     molecule: Molecule
     driver: DriverEnum
     model: Model

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -1,0 +1,80 @@
+from enum import Enum
+from pydantic import BaseModel, constr
+from typing import List, Union
+from .molecule import Molecule
+from .common_models import Provenance
+from ..util import provenance_stamp
+
+
+class DriverEnum(str, Enum):
+    energy = 'energy'
+    gradient = 'gradient'
+    hessian = 'hessian'
+
+
+class Model(BaseModel):
+    method: str
+    basis: str = None
+    # basis_spec: BasisSpec = None  # This should be exclusive with basis, but for now will be omitted
+
+
+class Properties(BaseModel):
+    scf_one_electron_energy: float
+    scf_two_electron_energy: float
+    nuclear_repulsion_energy: float
+    scf_vv10_energy: float
+    scf_xc_energy: float
+    scf_dispersion_correction_energy: float
+    scf_dipole_moment: List[float]
+    scf_total_energy: float
+    scf_iterations: int
+    mp2_same_spin_correlation_energy: float
+    mp2_opposite_spin_correlation_energy: float
+    mp2_singles_energy: float
+    mp2_doubles_energy: float
+    mp2_total_correlation_energy: float
+    mp2_total_energy: float
+    calcinfo_nbasis: int
+    calcinfo_nmo: int
+    calcinfo_nalpha: int
+    calcinfo_nbeta: int
+    calcinfo_natom: int
+    return_energy: float
+
+    class Config:
+        allow_extra = False
+
+
+class ErrorType(str, Enum):
+    convergence_error = "convergence_error"
+    file_error = "file_error"
+    memory_error = "memory_error"
+
+
+class Error(BaseModel):
+    """The type of error message raised"""
+    error_type: ErrorType
+    error_message: str
+
+    class Config:
+        allow_extra = False
+
+
+### Primary models
+
+class ResultsInput(BaseModel):
+    """The MolSSI Quantum Chemistry Schema"""
+    molecule: Molecule
+    driver: DriverEnum
+    model: Model
+    schema_name: constr(strip_whitespace=True, regex='qc_schema_input') = "qc_schema_input"  # IDEs complain, its fine
+    schema_version: int = 1
+    keywords: dict = {}
+    provenance: Provenance = provenance_stamp(__name__)
+
+
+class Results(ResultsInput):
+    properties: Properties
+    success: bool
+    error: Error = None
+    return_result: Union[float, List[float]]

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from pydantic import BaseModel, constr
-from typing import List, Union
+from typing import List, Union, Dict
 from .molecule import Molecule
 from .common_models import Provenance
 from ..util import provenance_stamp
@@ -42,7 +42,7 @@ class Properties(BaseModel):
     return_energy: float = None
 
     class Config:
-        allow_extra = False
+        allow_extra = True  # Not yet fully validated, but will accept extra for now
 
 
 class ErrorEnum(str, Enum):
@@ -53,7 +53,7 @@ class ErrorEnum(str, Enum):
 
 class Error(BaseModel):
     """The type of error message raised"""
-    error_type: ErrorEnum
+    error_type: Dict[str, str]  # Error enumeration not yet strict
     error_message: str
 
     class Config:
@@ -82,3 +82,7 @@ class Results(ResultsInput):
     success: bool
     error: Error = None
     return_result: Union[float, List[float]]
+
+    class Config(ResultsInput.Config):
+        # Will carry the allow_mutation flag
+        allow_extra = True  # Permits arbitrary fields

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -62,7 +62,7 @@ class Error(BaseModel):
 
 ### Primary models
 
-class ResultsInput(BaseModel):
+class ResultInput(BaseModel):
     """The MolSSI Quantum Chemistry Schema"""
     id: str = None
     molecule: Molecule
@@ -77,12 +77,12 @@ class ResultsInput(BaseModel):
         allow_mutation = False
 
 
-class Results(ResultsInput):
+class Result(ResultInput):
     properties: Properties
     success: bool
     error: Error = None
     return_result: Union[float, List[float]]
 
-    class Config(ResultsInput.Config):
+    class Config(ResultInput.Config):
         # Will carry the allow_mutation flag
         allow_extra = True  # Permits arbitrary fields

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -19,33 +19,33 @@ class Model(BaseModel):
 
 
 class Properties(BaseModel):
-    scf_one_electron_energy: float
-    scf_two_electron_energy: float
-    nuclear_repulsion_energy: float
-    scf_vv10_energy: float
-    scf_xc_energy: float
-    scf_dispersion_correction_energy: float
-    scf_dipole_moment: List[float]
-    scf_total_energy: float
-    scf_iterations: int
-    mp2_same_spin_correlation_energy: float
-    mp2_opposite_spin_correlation_energy: float
-    mp2_singles_energy: float
-    mp2_doubles_energy: float
-    mp2_total_correlation_energy: float
-    mp2_total_energy: float
-    calcinfo_nbasis: int
-    calcinfo_nmo: int
-    calcinfo_nalpha: int
-    calcinfo_nbeta: int
-    calcinfo_natom: int
-    return_energy: float
+    scf_one_electron_energy: float = None
+    scf_two_electron_energy: float = None
+    nuclear_repulsion_energy: float = None
+    scf_vv10_energy: float = None
+    scf_xc_energy: float = None
+    scf_dispersion_correction_energy: float = None
+    scf_dipole_moment: List[float] = None
+    scf_total_energy: float = None
+    scf_iterations: int = None
+    mp2_same_spin_correlation_energy: float = None
+    mp2_opposite_spin_correlation_energy: float = None
+    mp2_singles_energy: float = None
+    mp2_doubles_energy: float = None
+    mp2_total_correlation_energy: float = None
+    mp2_total_energy: float = None
+    calcinfo_nbasis: int = None
+    calcinfo_nmo: int = None
+    calcinfo_nalpha: int = None
+    calcinfo_nbeta: int = None
+    calcinfo_natom: int = None
+    return_energy: float = None
 
     class Config:
         allow_extra = False
 
 
-class ErrorType(str, Enum):
+class ErrorEnum(str, Enum):
     convergence_error = "convergence_error"
     file_error = "file_error"
     memory_error = "memory_error"
@@ -53,7 +53,7 @@ class ErrorType(str, Enum):
 
 class Error(BaseModel):
     """The type of error message raised"""
-    error_type: ErrorType
+    error_type: ErrorEnum
     error_message: str
 
     class Config:
@@ -72,6 +72,9 @@ class ResultsInput(BaseModel):
     schema_version: int = 1
     keywords: dict = {}
     provenance: Provenance = provenance_stamp(__name__)
+
+    class Config:
+        allow_mutation = False
 
 
 class Results(ResultsInput):


### PR DESCRIPTION
Outstanding issues:
* `basis_spec`'s are omitted for now to get this model in. @dgasmith indicates this is probably fine for now
* Missing tests. Do we have a good place to pull some sample data from that isn't me just writing the dicts that also does not have to execute any computation though something like QCEngine?