### PR TITLE
QCFractal: Updates models for compat

### DIFF
--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -58,16 +58,17 @@ class NPArray(np.ndarray):
 
 class Identifiers(BaseModel):
     """Canonical chemical identifiers"""
-    molecule_hash: str = None
-    molecular_formula: str = None
-    smiles: str = None
-    inchi: str = None
-    inchikey: str = None
-    canonical_explicit_hydrogen_smiles: str = None
-    canonical_isomeric_explicit_hydrogen_mapped_smiles: str = None
-    canonical_isomeric_explicit_hydrogen_smiles: str = None
-    canonical_isomeric_smiles: str = None
-    canonical_smiles: str = None
+
+    # molecule_hash: str = None
+    # molecular_formula: str = None
+    # smiles: str = None
+    # inchi: str = None
+    # inchikey: str = None
+    # canonical_explicit_hydrogen_smiles: str = None
+    # canonical_isomeric_explicit_hydrogen_mapped_smiles: str = None
+    # canonical_isomeric_explicit_hydrogen_smiles: str = None
+    # canonical_isomeric_smiles: str = None
+    # canonical_smiles: str = None
 
     class Config:
         allow_extra = True
@@ -80,6 +81,7 @@ class Molecule(BaseModel):
 
     # Required data
     symbols: List[str]
+    # geometry: List[float]
     geometry: NPArray
 
     # Molecule data
@@ -111,9 +113,7 @@ class Molecule(BaseModel):
     id: str = None
 
     class Config:
-        json_encoders = {
-            **ndarray_encoder
-        }
+        json_encoders = {**ndarray_encoder}
         allow_mutation = False
         ignore_extra = False
 
@@ -212,12 +212,17 @@ class Molecule(BaseModel):
     def dict(self, *args, **kwargs):
         if "include" not in kwargs:
             kwargs["include"] = self._Internals.provided_fields
+
         return super().dict(*args, **kwargs)
 
     def json(self, *args, **kwargs):
-        if "include" not in kwargs:
-            kwargs["include"] = self._Internals.provided_fields
-        return super().json(*args, **kwargs)
+        as_dict = kwargs.pop("as_dict", False)
+
+        ret = super().json(*args, **kwargs)
+        if as_dict:
+            return json.loads(ret)
+        else:
+            return ret
 
 ### Non-Pydantic API functions
 
@@ -468,6 +473,7 @@ class Molecule(BaseModel):
         if dtype in ["string", "psi4", "psi4+", "xyz", "xyz+"]:
             input_dict = to_schema(from_string(data)["qm"], dtype=1)["molecule"]
         elif dtype == "numpy":
+            data = np.asarray(data)
             data = {
                 "geom": data[:, 1:],
                 "elez": data[:, 0],
@@ -517,7 +523,7 @@ class Molecule(BaseModel):
                 dtype = "json"
             else:
                 raise KeyError("No dtype provided and ext '{}' not understood.".format(ext))
-            print("Inferring data type to be {} from file extension".format(dtype))
+            # print("Inferring data type to be {} from file extension".format(dtype))
 
         if dtype == "psi4":
             with open(filename, "r") as infile:

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -210,8 +210,10 @@ class Molecule(BaseModel):
         ]
 
     def dict(self, *args, **kwargs):
-        if "include" not in kwargs:
+        if ("include" not in kwargs) or (("include" in kwargs) and (kwargs["include"] is None)):
             kwargs["include"] = self._Internals.provided_fields
+            if self.id is None:
+                kwargs["include"] -= {"id"}
 
         return super().dict(*args, **kwargs)
 

--- a/qcelemental/models/procedures.py
+++ b/qcelemental/models/procedures.py
@@ -8,8 +8,7 @@ from typing import Any, Dict, List
 
 class InputSpecification(BaseModel):
     driver: DriverEnum
-    schema_name: constr(strip_whitespace=True,
-                        regex=qcschema_input_default) = qcschema_input_default
+    schema_name: constr(strip_whitespace=True, regex=qcschema_input_default) = qcschema_input_default
     schema_version: int = 1
     model: Model
     keywords: Dict[str, Any] = {}
@@ -20,8 +19,8 @@ class InputSpecification(BaseModel):
 
 
 class OptimizationInput(BaseModel):
-    schema_name: constr(strip_whitespace=True,
-                        regex=qcschema_optimization_input_default) = qcschema_optimization_input_default
+    schema_name: constr(
+        strip_whitespace=True, regex=qcschema_optimization_input_default) = qcschema_optimization_input_default
     schema_version: int = 1
     keywords: Dict[str, Any] = {}
     input_specification: InputSpecification
@@ -30,19 +29,25 @@ class OptimizationInput(BaseModel):
     class Config:
         allow_extra = True
         allow_mutation = False
-        json_encoders = {
-            **ndarray_encoder
-        }
+        json_encoders = {**ndarray_encoder}
 
 
 class Optimization(OptimizationInput):
     id: str = None
-    schema_name: constr(strip_whitespace=True,
-                        regex=qcschema_optimization_output_default) = qcschema_optimization_output_default
+    schema_name: constr(
+        strip_whitespace=True, regex=qcschema_optimization_output_default) = qcschema_optimization_output_default
     final_molecule: Molecule
     trajectory: List[Result] = None
     energies: List[float] = None
     success: bool
     error: ComputeError = None
 
-    # Config carries from the Input
+    def dict(self, *args, **kwargs):
+        if self.id is None:
+            excl = kwargs.setdefault("exclude", [])
+            if isinstance(excl, list):
+                excl.append("id")
+            elif isinstance(excl, set):
+                excl |= {"id"}
+
+        return super().dict(*args, **kwargs)

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -42,14 +42,14 @@ class ErrorEnum(str, Enum):
 
 ### Primary models
 
+
 class ResultInput(BaseModel):
     """The MolSSI Quantum Chemistry Schema"""
     id: str = None
     molecule: Molecule
     driver: DriverEnum
     model: Model
-    schema_name: constr(strip_whitespace=True,
-                        regex=qcschema_input_default) = qcschema_input_default
+    schema_name: constr(strip_whitespace=True, regex=qcschema_input_default) = qcschema_input_default
     schema_version: int = 1
     keywords: dict = {}
     provenance: Provenance = provenance_stamp(__name__)
@@ -57,14 +57,22 @@ class ResultInput(BaseModel):
     class Config:
         allow_mutation = False
         allow_extra = True
-        json_encoders = {
-            **ndarray_encoder
-        }
+        json_encoders = {**ndarray_encoder}
+
+    def dict(self, *args, **kwargs):
+        if self.id is None:
+            excl = kwargs.setdefault("exclude", [])
+            if isinstance(excl, list):
+                excl.append("id")
+            elif isinstance(excl, set):
+                excl |= {"id"}
+
+
+        return super().dict(*args, **kwargs)
 
 
 class Result(ResultInput):
-    schema_name: constr(strip_whitespace=True,
-                        regex=qcschema_output_default) = qcschema_output_default
+    schema_name: constr(strip_whitespace=True, regex=qcschema_output_default) = qcschema_output_default
     properties: Properties = Properties()
     success: bool
     error: ComputeError = None
@@ -80,5 +88,4 @@ class Result(ResultInput):
         if v.lower().strip() in [qcschema_input_default, qcschema_output_default]:
             return qcschema_output_default
         raise ValueError("Only {0} or {1} is allowed for schema_name, "
-                         "which will be converted to {0}".format(qcschema_output_default,
-                                                                 qcschema_input_default))
+                         "which will be converted to {0}".format(qcschema_output_default, qcschema_input_default))

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -67,7 +67,6 @@ class ResultInput(BaseModel):
             elif isinstance(excl, set):
                 excl |= {"id"}
 
-
         return super().dict(*args, **kwargs)
 
 


### PR DESCRIPTION
Two big changes:
 - Ensure `id` is not pulled through as None in `dict`.
 - Allows `BaseModel.json` to have a `as_dict` attribute which returns a dictionary.

