### PR TITLE
Improved import time

### DIFF
--- a/qcelemental/__init__.py
+++ b/qcelemental/__init__.py
@@ -16,8 +16,7 @@ del physical_constants
 del covalent_radii
 
 # Handle versioneer
-from ._version import get_versions
-versions = get_versions()
-__version__ = versions['version']
-__git_revision__ = versions['full-revisionid']
-del get_versions, versions
+from .extras import get_information
+__version__ = get_information('version')
+__git_revision__ = get_information('git_revision')
+del get_information

--- a/qcelemental/extras.py
+++ b/qcelemental/extras.py
@@ -1,0 +1,22 @@
+"""
+Misc information and runtime information.
+"""
+
+from . import _version
+
+__all__ = ["get_information"]
+
+versions = _version.get_versions()
+
+__info = {"version": versions['version'], "git_revision": versions['full-revisionid']}
+
+
+def get_information(key):
+    """
+    Obtains a variety of runtime information about QCFractal.
+    """
+    key = key.lower()
+    if key not in __info:
+        raise KeyError("Information key '{}' not understood.".format(key))
+
+    return __info[key]

--- a/qcelemental/extras.py
+++ b/qcelemental/extras.py
@@ -13,7 +13,7 @@ __info = {"version": versions['version'], "git_revision": versions['full-revisio
 
 def get_information(key):
     """
-    Obtains a variety of runtime information about QCFractal.
+    Obtains a variety of runtime information about QCElemental.
     """
     key = key.lower()
     if key not in __info:

--- a/qcelemental/molparse/pubchem.py
+++ b/qcelemental/molparse/pubchem.py
@@ -16,9 +16,6 @@
 
 import re
 import json
-from urllib.request import urlopen, Request
-from urllib.parse import quote
-from urllib.error import URLError
 
 from ..exceptions import ValidationError
 
@@ -38,6 +35,9 @@ class PubChemObj():
 
     def get_sdf(self):
         """Function to return the SDF (structure-data file) of the PubChem object."""
+        from urllib.request import urlopen, Request
+        from urllib.parse import quote
+        from urllib.error import URLError
         if (len(self.dataSDF) == 0):
             url = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/{}/SDF?record_type=3d'.format(
                 quote(str(self.cid)))
@@ -119,6 +119,9 @@ def get_pubchem_results(name):
     input string. Builds a PubChemObj object if found.
 
     """
+    from urllib.request import urlopen
+    from urllib.parse import quote
+    from urllib.error import URLError
     if name.isdigit():
         print("\tSearching PubChem database for CID {}".format(name))
         url = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/{}/property/IUPACName,MolecularFormula,Charge/JSON'.format(

--- a/qcelemental/physical_constants/__init__.py
+++ b/qcelemental/physical_constants/__init__.py
@@ -2,9 +2,10 @@
 Units handlers
 """
 
-try:
-    import pint
-except ImportError:
+# Ensure pint exists
+import importlib
+pint_loader = importlib.find_loader('pint')
+if pint_loader is None:
     raise ImportError("""Python module pint not found. Solve by installing it: `conda install pint -c conda-forge` or `pip install pint`""")
 
 from .context import constants, PhysicalConstantsContext

--- a/qcelemental/physical_constants/context.py
+++ b/qcelemental/physical_constants/context.py
@@ -5,10 +5,9 @@ Contains relevant physical constants
 from decimal import Decimal
 import collections
 
-import pint
-
 from .. import datum
 from . import ureg
+
 
 class PhysicalConstantsContext:
     """CODATA 2014 physical constants set from NIST.
@@ -47,13 +46,17 @@ class PhysicalConstantsContext:
             # physical constant loop
             for k, v in self.raw_codata.items():
                 self.pc[k] = datum.Datum(
-                    v["quantity"], v["unit"], Decimal(v["value"]), 'uncertainty={}'.format(v["uncertainty"]), doi=self.doi)
+                    v["quantity"],
+                    v["unit"],
+                    Decimal(v["value"]),
+                    'uncertainty={}'.format(v["uncertainty"]),
+                    doi=self.doi)
         else:
             raise KeyError("Context set as '{}', only contexts {'CODATA2014', } are currently supported")
 
         self.name = context
         self.year = int(context.replace("CODATA", ""))
-        self.ureg = ureg.build_units_registry(self)
+        self._ureg = None
 
         # Extra relationships
         self.pc['calorie-joule relationship'] = datum.Datum('calorie-joule relationship', 'J',
@@ -103,6 +106,13 @@ class PhysicalConstantsContext:
 
     def __str__(self):
         return "PhysicalConstantsContext(context='{}')".format(self.name)
+
+    @property
+    def ureg(self):
+        if self._ureg is None:
+            self._ureg = ureg.build_units_registry(self)
+
+        return self._ureg
 
     def get(self, physical_constant, return_tuple=False):
         """Access a physical constant, `physical_constant`.
@@ -155,7 +165,6 @@ class PhysicalConstantsContext:
 #       na                        'Avogadro constant'                         = 6.02214179E23        # Avogadro's number
 #       me                        'electron mass'                             = 9.10938215E-31       # Electron rest mass (in kg)
 
-
     def conversion_factor(self, base_unit, conv_unit):
         """
         Provides the conversion factor from one unit to another using the current NIST 2014CODATA.
@@ -188,6 +197,7 @@ class PhysicalConstantsContext:
         """
 
         # Add a little magic incase the incoming values have scalars
+        import pint
 
         factor = 1.0
 

--- a/qcelemental/physical_constants/ureg.py
+++ b/qcelemental/physical_constants/ureg.py
@@ -2,8 +2,6 @@
 A wrapper for the pint ureg data
 """
 
-import pint
-
 # We only want the ureg builder exposed
 __all__ = ["build_units_registry"]
 
@@ -16,6 +14,8 @@ def build_units_registry(context):
     context : PhysicalConstantsContext
         The context to use for the values.
     """
+    import pint
+
     phys_const = context.raw_codata
     ureg = pint.UnitRegistry(on_redefinition="ignore")
 

--- a/qcelemental/tests/test_molparse_to_string.py
+++ b/qcelemental/tests/test_molparse_to_string.py
@@ -1,4 +1,3 @@
-import pint
 import pytest
 from utils import *
 
@@ -107,6 +106,7 @@ def test_to_string_xyz(inp, expected):
     ("subject1", {'dtype': 'xyz', 'units': 'kg', 'prec': 8, 'atom_format': '{elea}{elem}{elbl}'}),
 ])  # yapf: disable
 def test_to_string_error(inp):
+    import pint
     molrec = qcelemental.molparse.from_string(_results[inp[0]])
 
     with pytest.raises(pint.errors.DimensionalityError):

--- a/qcelemental/util/internal.py
+++ b/qcelemental/util/internal.py
@@ -1,4 +1,4 @@
-from .._version import get_versions
+from qcelemental.extras import get_information
 
 
 def provenance_stamp(routine):
@@ -8,4 +8,4 @@ def provenance_stamp(routine):
     generating routine's name is passed in through `routine`.
 
     """
-    return {'creator': 'QCElemental', 'version': get_versions()['version'], 'routine': routine}
+    return {'creator': 'QCElemental', 'version': get_information('version'), 'routine': routine}


### PR DESCRIPTION
The `qcelemental` load times are ~1 second due to pint which is a bit much for trying things out. Here, I lazy load pint so initial load is now down to 0.4 seconds (pint problems!).

If I additionally remove `molparse` and `models` from the `__init__.py` I move down to 0.2 seconds (effectively the minimum). If we consider this a use case where folks will not be using the models this might be something that we should consider. Any opinions here?