### PR TITLE
Pydantic Datum class

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,12 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
+- (:pr:`??`) Converts `qcel.Datum` to Pydantic model. Changes
+  (a) comment, doi, glossary fields must be accessed by keyword,
+  (b) `to_dict()` becomes `dict()` and instead of label, units, data only,
+  now comment, doi, glossary present _if_ non-default,
+  (c) complex values no longer list-ified by `to_dict()`.
+
 0.2.6 / 2019-02-18
 ------------------
 

--- a/qcelemental/covalent_radii.py
+++ b/qcelemental/covalent_radii.py
@@ -5,7 +5,7 @@ Contains covalent radii
 import collections
 from decimal import Decimal
 
-from . import datum
+from .datum import Datum, print_variables
 from .exceptions import DataUnavailableError
 from .periodic_table import periodictable
 
@@ -43,7 +43,7 @@ class CovalentRadii:
             self.native_units = alvarez_2008_covalent_radii["units"]
 
             for cr in alvarez_2008_covalent_radii["covalent_radii"]:
-                self.cr[cr[0]] = datum.Datum(cr[0], self.native_units, Decimal(cr[1]), cr[2], doi=self.doi)
+                self.cr[cr[0]] = Datum(cr[0], self.native_units, Decimal(cr[1]), comment=cr[2], doi=self.doi)
         else:
             raise KeyError("Context set as '{}', only contexts {'ALVAREZ2008', } are currently supported")
 
@@ -61,7 +61,7 @@ class CovalentRadii:
         # add alternate names to help QC programs
         for alias in aliases:
             ident, units, value, comment = alias
-            self.cr[ident.capitalize()] = datum.Datum(ident, units, value, comment)
+            self.cr[ident.capitalize()] = Datum(ident, units, value, comment=comment)
 
     def __str__(self):
         return "CovalentRadii(context='{}')".format(self.name)
@@ -125,7 +125,7 @@ class CovalentRadii:
     def string_representation(self):
         """Print name, value, and units of all covalent radii."""
 
-        return datum.print_variables(self.cr)
+        return print_variables(self.cr)
 
     def write_c_header(self, filename='covrad.h', missing=2.0):
         """Write C header file defining covalent radii array.

--- a/qcelemental/datum.py
+++ b/qcelemental/datum.py
@@ -50,10 +50,10 @@ class Datum(BaseModel):
     @validator('data')
     def must_be_numerical(cls, v, values, **kwargs):
         try:
-            ident = 1.0 * v
+            1.0 * v
         except TypeError:
             try:
-                ident = Decimal('1.0') * v
+                Decimal('1.0') * v
             except TypeError:
                 raise ValueError('Datum data should be float, Decimal, or np.ndarray')
 

--- a/qcelemental/physical_constants/context.py
+++ b/qcelemental/physical_constants/context.py
@@ -49,7 +49,7 @@ class PhysicalConstantsContext:
                     v["quantity"],
                     v["unit"],
                     Decimal(v["value"]),
-                    'uncertainty={}'.format(v["uncertainty"]),
+                    comment='uncertainty={}'.format(v["uncertainty"]),
                     doi=self.doi)
         else:
             raise KeyError("Context set as '{}', only contexts {'CODATA2014', } are currently supported")
@@ -60,7 +60,7 @@ class PhysicalConstantsContext:
 
         # Extra relationships
         self.pc['calorie-joule relationship'] = Datum('calorie-joule relationship', 'J', Decimal('4.184'),
-                                                      'uncertainty=(exact)')
+                                                      comment='uncertainty=(exact)')
 
         aliases = [
             ('h',                    'J',              self.pc['hertz-joule relationship'].data,                             'The Planck constant (Js)'),
@@ -97,7 +97,7 @@ class PhysicalConstantsContext:
         # add alternate names for constants or derived values to help QC programs
         for alias in aliases:
             ident, units, value, comment = alias
-            self.pc[ident.lower()] = Datum(ident, units, value, comment)
+            self.pc[ident.lower()] = Datum(ident, units, value, comment=comment)
 
         # add constants as directly callable member data
         for qca in self.pc.values():

--- a/qcelemental/testing.py
+++ b/qcelemental/testing.py
@@ -222,7 +222,7 @@ def _compare_recursive(expected, computed, atol, rtol, _prefix=False):
     name = _prefix or "root"
     prefix = name + "."
 
-    if isinstance(expected, (str, int, bool)):
+    if isinstance(expected, (str, int, bool, complex)):
         if expected != computed:
             errors.append((name, "Value {} did not match {}.".format(expected, computed)))
 

--- a/qcelemental/tests/test_constants.py
+++ b/qcelemental/tests/test_constants.py
@@ -66,7 +66,7 @@ def test_access_2f():
 
 def test_access_2g():
     ref = {'label': 'Hartree energy in eV', 'units': 'eV', 'data': Decimal('27.21138602')}
-    dqca = qcelemental.constants.get('Hartree energy in eV', return_tuple=True).to_dict()
+    dqca = qcelemental.constants.get('Hartree energy in eV', return_tuple=True).dict()
 
     for itm in ref:
         assert ref[itm] == dqca[itm]

--- a/qcelemental/tests/test_covalentradii.py
+++ b/qcelemental/tests/test_covalentradii.py
@@ -54,7 +54,7 @@ def test_get(inp, expected):
 
 def test_get_tuple():
     ref = {'label': 'Mn', 'units': 'angstrom', 'data': Decimal('1.61')}
-    dqca = qcelemental.covalentradii.get('manganese', return_tuple=True).to_dict()
+    dqca = qcelemental.covalentradii.get('manganese', return_tuple=True).dict()
 
     for itm in ref:
         assert ref[itm] == dqca[itm]


### PR DESCRIPTION
Converts `qcel.Datum` to Pydantic model. Changes
  * (a) comment, doi, glossary fields must be accessed by keyword,
  * (b) `to_dict()` becomes `dict()` and instead of label, units, data only, now comment, doi, glossary present _if_ non-default,
  * (c) complex values no longer list-ified by `to_dict()`.