### PR TITLE
make `python setup.py test` work

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,3 +27,6 @@ style = pep440
 versionfile_source = qcelemental/_version.py
 versionfile_build = qcelemental/_version.py
 tag_prefix = ''
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
 import os
+import sys
 import setuptools
 import versioneer
 
 short_description = "QCElemental is a resource module for quantum chemistry containing physical"
 "constants and periodic table data from NIST and molecule handlers."
+
+# from https://github.com/pytest-dev/pytest-runner#conditional-requirement
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 try:
     with open("README.md", "r") as handle:
@@ -24,9 +29,7 @@ if __name__ == "__main__":
         packages=setuptools.find_packages(exclude=['*checkup*']),
         include_package_data=True,
         package_data={'': [os.path.join('qcelemental', 'data', '*.json')]},
-        setup_requires=[
-            'pytest-runner'
-        ],
+        setup_requires=[] + pytest_runner,
         install_requires=[
             'numpy',
             'pint',

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ if __name__ == "__main__":
         packages=setuptools.find_packages(exclude=['*checkup*']),
         include_package_data=True,
         package_data={'': [os.path.join('qcelemental', 'data', '*.json')]},
+        setup_requires=[
+            'pytest-runner'
+        ],
         install_requires=[
             'numpy',
             'pint',


### PR DESCRIPTION
we've always run `pytest` directly. `setup.py` was calling unittest, hence the error. followed [this](https://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner) to make it work. fixes #38.