### PR TITLE
Molecule: Always validate schema and fixes fragment multiplicity issues

### DIFF
--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -130,7 +130,6 @@ class Molecule(BaseModel):
 
             schema = to_schema(from_schema(kwargs), dtype=kwargs["schema_version"])
 
-            schema = {k: v for k, v in schema.items() if k in original_keys}
             kwargs = {**kwargs, **schema} # Allow any extra fields
 
         super().__init__(**kwargs)

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Tuple, Optional
 import numpy as np
 from pydantic import BaseModel, validator, constr
 
-from ..molparse import from_arrays, from_string, to_schema
+from ..molparse import from_arrays, from_schema, from_string, to_schema
 from ..periodic_table import periodictable
 from ..physical_constants import constants
 from ..util import measure_coordinates, provenance_stamp
@@ -122,7 +122,17 @@ class Molecule(BaseModel):
         allow_mutation = False
         extra = "forbid"
 
-    def __init__(self, orient=False, **kwargs):
+    def __init__(self, orient=False, validate=True, **kwargs):
+        if validate:
+            kwargs["schema_name"] = kwargs.pop("schema_name", "qcschema_molecule")
+            kwargs["schema_version"] = kwargs.pop("schema_version", 2)
+            original_keys = set(kwargs.keys())
+
+            schema = to_schema(from_schema(kwargs), dtype=kwargs["schema_version"])
+
+            schema = {k: v for k, v in schema.items() if k in original_keys}
+            kwargs = {**kwargs, **schema} # Allow any extra fields
+
         super().__init__(**kwargs)
 
         # We are pulling out the values *explicitly* so that the pydantic skip_defaults works as expected
@@ -351,6 +361,8 @@ class Molecule(BaseModel):
             fragment_multiplicities.append(self.fragment_multiplicities[frag])
 
         constructor_dict["fragments"] = fragments
+        constructor_dict["fragment_charges"] = fragment_charges
+        constructor_dict["fragment_multiplicities"] = fragment_multiplicities
         constructor_dict["symbols"] = symbols
         constructor_dict["geometry"] = np.vstack(geom_blocks)
         constructor_dict["real"] = real_atoms

--- a/qcelemental/models/procedures.py
+++ b/qcelemental/models/procedures.py
@@ -53,15 +53,16 @@ class Optimization(OptimizationInput):
     schema_name: constr(
         strip_whitespace=True, regex=qcschema_optimization_output_default) = qcschema_optimization_output_default
 
-    final_molecule: Optional[Molecule] = None
-    trajectory: List[Result] = None
-    energies: List[float] = None
+    final_molecule: Optional[Molecule]
+    trajectory: List[Result]
+    energies: List[float]
 
     stdout: Optional[str] = None
     stderr: Optional[str] = None
 
     success: bool
     error: ComputeError = None
+    provenance: Provenance
 
     class Config(OptimizationInput.Config):
         pass

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -79,7 +79,7 @@ class ResultInput(BaseModel):
 class Result(ResultInput):
     schema_name: constr(strip_whitespace=True, regex=qcschema_output_default) = qcschema_output_default
 
-    properties: ResultProperties = ResultProperties()
+    properties: ResultProperties
     return_result: Union[float, List[float], Dict[str, Any]]
 
     stdout: Optional[str] = None
@@ -87,6 +87,7 @@ class Result(ResultInput):
 
     success: bool
     error: ComputeError = None
+    provenance: Provenance
 
     class Config(ResultInput.Config):
         # Will carry other properties

--- a/qcelemental/tests/test_model_serials.py
+++ b/qcelemental/tests/test_model_serials.py
@@ -82,11 +82,7 @@ def test_molecule_serialization(water):
 
 
 def test_molecule_sparsity():
-    m = Molecule(**{"symbols": ["He"], "geometry": [0, 0, 0]})
-    assert set(m.dict().keys()) == {"symbols", "geometry", "schema_name", "schema_version"}
-
     m = Molecule(**{"symbols": ["He"], "geometry": [0, 0, 0], "identifiers": {"molecular_formula": "He"}})
-    assert set(m.dict().keys()) == {"symbols", "geometry", "identifiers", "schema_name", "schema_version"}
     assert set(m.dict()["identifiers"].keys()) == {"molecular_formula"}
     assert set(m.identifiers.dict().keys()) == {"molecular_formula"}
 

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -4,8 +4,8 @@ Tests the imports and exports of the Molecule object.
 
 import numpy as np
 import pytest
-from pydantic import ValidationError
 from qcelemental.models import Molecule
+import qcelemental as qcel
 
 water_molecule = Molecule.from_data("""
     0 1
@@ -112,10 +112,9 @@ def test_water_minima_data():
     assert np.allclose(mol.fragment_charges, [0, 0])
     assert np.allclose(mol.fragment_multiplicities, [1, 1])
     assert hasattr(mol, "provenance")
-    assert np.allclose(
-        mol.geometry,
-        [[2.81211080, 0.1255717, 0.], [3.48216664, -1.55439981, 0.], [1.00578203, -0.1092573, 0.],
-         [-2.6821528, -0.12325075, 0.], [-3.27523824, 0.81341093, 1.43347255], [-3.27523824, 0.81341093, -1.43347255]])
+    assert np.allclose(mol.geometry, [[2.81211080, 0.1255717, 0.], [3.48216664, -1.55439981, 0.],
+                                      [1.00578203, -0.1092573, 0.], [-2.6821528, -0.12325075, 0.],
+                                      [-3.27523824, 0.81341093, 1.43347255], [-3.27523824, 0.81341093, -1.43347255]])
     assert mol.get_hash() == "b41f1e38bc4be5482fcd1d4dd53ca7c65146ab91"
 
 
@@ -124,8 +123,8 @@ def test_water_minima_fragment():
     mol = water_dimer_minima.copy()
     frag_0 = mol.get_fragment(0, orient=True)
     frag_1 = mol.get_fragment(1, orient=True)
-    assert frag_0.get_hash() == "6d253a5a66eb68b611ab6bb0f15b55bbd3f6fe91"
-    assert frag_1.get_hash() == "feb5c6127ca54d715b999c15ea1ea1772ada8c5d"
+    assert frag_0.get_hash() == "0b13814f79b8f74f17499b31fe7b76cd97b89449"
+    assert frag_1.get_hash() == "4469ff05895a6375a91ce9a225f96e3f9938450b"
 
     frag_0_1 = mol.get_fragment(0, 1)
     frag_1_0 = mol.get_fragment(1, 0)
@@ -242,21 +241,21 @@ def test_water_orient():
 def test_molecule_errors_extra():
     data = water_dimer_minima.dict()
     data["whatever"] = 5
-    with pytest.raises(ValidationError):
+    with pytest.raises(Exception):
         Molecule(**data)
 
 
 def test_molecule_errors_connectivity():
     data = water_molecule.dict()
     data["connectivity"] = [(-1, 5, 5)]
-    with pytest.raises(ValidationError):
+    with pytest.raises(Exception):
         Molecule(**data)
 
 
 def test_molecule_errors_shape():
     data = water_molecule.dict()
     data["geometry"] = list(range(8))
-    with pytest.raises(ValidationError):
+    with pytest.raises(Exception):
         Molecule(**data)
 
 
@@ -264,6 +263,20 @@ def test_molecule_serialization():
     assert isinstance(water_dimer_minima.json(), str)
 
     assert isinstance(water_dimer_minima.json_dict()["geometry"], list)
+
+
+def test_charged_fragment():
+    mol = Molecule(
+        symbols=["Li", "Li"],
+        geometry=[0, 0, 0, 0, 0, 5],
+        fragment_charges=[0.0, 0.0],
+        fragment_multiplicities=[2, 2],
+        fragments=[[0], [1]])
+    f1 = mol.get_fragment(0)
+    assert f1.molecular_multiplicity == 2
+    assert f1.fragment_multiplicities == [2]
+    assert pytest.approx(f1.molecular_charge) == 0
+    assert pytest.approx(f1.fragment_charges) == [0]
 
 
 def test_molecule_repeated_hashing():

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -272,6 +272,8 @@ def test_charged_fragment():
         fragment_charges=[0.0, 0.0],
         fragment_multiplicities=[2, 2],
         fragments=[[0], [1]])
+    assert mol.molecular_multiplicity == 3
+    assert mol.molecular_charge == 0
     f1 = mol.get_fragment(0)
     assert f1.molecular_multiplicity == 2
     assert f1.fragment_multiplicities == [2]


### PR DESCRIPTION
Always runs through the more strict molars validators. Can likely remove pydantic validators here. A problem is that not all issues within molparse raise a QCElemental error type (incorrect array length for one), so backed those down to just check for Exception. This should certainly be a TODO to look at in the future.