### PR TITLE
derint fn and fix_symmetry in Molecule model

### DIFF
--- a/qcelemental/models/common_models.py
+++ b/qcelemental/models/common_models.py
@@ -33,14 +33,12 @@ class DriverEnum(str, Enum):
     hessian = 'hessian'
     properties = 'properties'
 
-    def derint(self):
-        # debatable whether properties should be 0, None, 9, ...
-        if self in ['energy', 'properties']:
+    def derivative_int(self):
+        egh = ['energy', 'gradient', 'hessian', 'third', 'fourth', 'fifth']
+        if self == 'properties':
             return 0
-        elif self == 'gradient':
-            return 1
-        elif self == 'hessian':
-            return 2
+        else:
+            return egh.index(self)
 
 
 class ComputeError(BaseModel):

--- a/qcelemental/models/common_models.py
+++ b/qcelemental/models/common_models.py
@@ -33,6 +33,15 @@ class DriverEnum(str, Enum):
     hessian = 'hessian'
     properties = 'properties'
 
+    def derint(self):
+        # debatable whether properties should be 0, None, 9, ...
+        if self in ['energy', 'properties']:
+            return 0
+        elif self == 'gradient':
+            return 1
+        elif self == 'hessian':
+            return 2
+
 
 class ComputeError(BaseModel):
     """The type of error message raised"""

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -111,6 +111,7 @@ class Molecule(BaseModel):
     # Orientation
     fix_com: bool = False
     fix_orientation: bool = False
+    fix_symmetry: str = None
 
     # Extra
     provenance: Provenance = provenance_stamp(__name__)

--- a/qcelemental/tests/test_model_serials.py
+++ b/qcelemental/tests/test_model_serials.py
@@ -75,6 +75,13 @@ def opti_success(water, result_input, res_success):
     }
 
 
+def test_driverenum_derivative_int(water, result_input):
+    res = ResultInput(molecule=water, **result_input)
+
+    assert res.driver == 'gradient'
+    assert res.driver.derivative_int() == 1
+
+
 def test_molecule_serialization(water):
     assert isinstance(water.dict(), dict)
     assert isinstance(water.json(), str)


### PR DESCRIPTION
- [x] psi was failing with for pbeh3c because model didn't have the optional `fix_symmetry` as allowed field
- [x] added a `derint` fn so one can do ready numeric comparisons on `DriverEnum`