### PR TITLE
Add the python binary directory to which's PATH

### DIFF
--- a/qcelemental/util/importing.py
+++ b/qcelemental/util/importing.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 
 
 def which_import(module, *, return_bool=False):
@@ -40,7 +41,7 @@ def which(command, *, return_bool=False):
         When `return_bool=True`, returns whether or not found.
 
     """
-    lenv = {'PATH': ':' + os.environ.get('PATH')}
+    lenv = {'PATH': ':' + os.environ.get('PATH') + ":" + os.path.dirname(sys.executable)}
     lenv = {k: v for k, v in lenv.items() if v is not None}
 
     ans = shutil.which(command, mode=os.F_OK | os.X_OK, path=lenv['PATH'])


### PR DESCRIPTION
Appends the directory of the executing Python bin to the path of the
search for which function. This should help with a corner case
on clusters which don't export the PATH variable correctly on nodes
of the executing environment since the absolute Python binary's path
ensures proper imports.

Supersedes molssi/qcengine#64