### PR TITLE
Molecular Visualization

### DIFF
--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -101,7 +101,7 @@ class Molecule(BaseModel):
 
     # Extra
     provenance: Provenance = provenance_stamp(__name__)
-    id: Optional[str] = None
+    id: Optional[Any] = None
     extras: Dict[str, Any] = None
 
     class Config:
@@ -658,8 +658,18 @@ class Molecule(BaseModel):
                 break
         return new_geometry
 
+
     def __str__(self):
         return self.pretty_print()
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}(name='{self.name}' formula='{self.get_molecular_formula()}')>"
+
+    def _repr_html_(self):
+        try:
+            return self.show()._repr_html_()
+        except ModuleNotFoundError:
+            return f"<p>{repr(self)[1:-1]}</p>"
 
     @staticmethod
     def _inertial_tensor(geom, *, weight):

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -214,7 +214,7 @@ class Molecule(BaseModel):
 
 ### Non-Pydantic API functions
 
-    def show(self, style: Union[str, Dict[str, Any]] = "ball_and_stick",
+    def show(self, *, style: Union[str, Dict[str, Any]] = "ball_and_stick",
              canvas: Tuple[int, int] = (400, 400)) -> 'py3Dmol.view':
         """Creates a 3D representation of a moleucle that can be manipulated in Jupyter Notebooks and exported as images (`.png`).
 
@@ -658,12 +658,11 @@ class Molecule(BaseModel):
                 break
         return new_geometry
 
-
     def __str__(self):
         return self.pretty_print()
 
     def __repr__(self):
-        return f"<{self.__class__.__name__}(name='{self.name}' formula='{self.get_molecular_formula()}')>"
+        return f"<{self.__class__.__name__}(name='{self.name}' formula='{self.get_molecular_formula()}' hash='{self.get_hash()[:7]}')>"
 
     def _repr_html_(self):
         try:

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -214,8 +214,8 @@ class Molecule(BaseModel):
 
 ### Non-Pydantic API functions
 
-    def visualize(self, *, style: Union[str, Dict[str, Any]] = "ball_and_stick",
-                  canvas: Tuple[int, int] = (400, 400)) -> 'py3Dmol.view':
+    def show(self, style: Union[str, Dict[str, Any]] = "ball_and_stick",
+             canvas: Tuple[int, int] = (400, 400)) -> 'py3Dmol.view':
         """Creates a 3D representation of a moleucle that can be manipulated in Jupyter Notebooks and exported as images (`.png`).
 
         Parameters
@@ -254,9 +254,23 @@ class Molecule(BaseModel):
         xyzview.zoomTo()
         return xyzview
 
-    def measure(self, measurements, *, degrees=True):
+    def measure(self, measurements: Union[List[int], List[List[int]]], *,
+                degrees: bool = True) -> Union[float, List[float]]:
         """
-        Takes a measurement of the molecule from the indicies provided.
+        Takes a measurement of the moleucle from the indicies provided.
+
+        Parameters
+        ----------
+        measurements : Union[List[int], List[List[int]]]
+            Either a single list of indices or multiple. Return a distance, angle, or dihedral depending if
+            2, 3, or 4 indices is provided, respectively. Values are returned in Bohr (distance) or degree.
+        degrees : bool, optional
+            Returns degrees by default, radians otherwise.
+
+        Returns
+        -------
+        Union[float, List[float]]
+            Either a value or list of the measured values.
         """
 
         return measure_coordinates(self.geometry, measurements, degrees=degrees)
@@ -716,18 +730,17 @@ class Molecule(BaseModel):
 
         return int(nel)
 
-    def align(
-            self,
-            ref_mol,
-            *,
-            do_plot=False,
-            verbose=0,
-            atoms_map=False,
-            run_resorting=False,
-            mols_align=False,
-            run_to_completion=False,
-            uno_cutoff=1.e-3,
-            run_mirror=False):
+    def align(self,
+              ref_mol,
+              *,
+              do_plot=False,
+              verbose=0,
+              atoms_map=False,
+              run_resorting=False,
+              mols_align=False,
+              run_to_completion=False,
+              uno_cutoff=1.e-3,
+              run_mirror=False):
         """Finds shift, rotation, and atom reordering of `concern_mol` (self)
         that best aligns with `ref_mol`.
 
@@ -840,19 +853,18 @@ class Molecule(BaseModel):
 
         return amol, {'rmsd': rmsd, 'mill': solution}
 
-    def scramble(
-            self,
-            *,
-            do_shift: bool=True,
-            do_rotate=True,
-            do_resort=True,
-            deflection=1.0,
-            do_mirror=False,
-            do_plot=False,
-            do_test=False,
-            run_to_completion=False,
-            run_resorting=False,
-            verbose=0):
+    def scramble(self,
+                 *,
+                 do_shift: bool = True,
+                 do_rotate=True,
+                 do_resort=True,
+                 deflection=1.0,
+                 do_mirror=False,
+                 do_plot=False,
+                 do_test=False,
+                 run_to_completion=False,
+                 run_resorting=False,
+                 verbose=0):
         """Generate a Molecule with random or directed translation, rotation, and atom shuffling.
         Optionally, check that the aligner returns the opposite transformation.
 

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -402,6 +402,6 @@ def test_nuclearrepulsionenergy_nelectrons():
 
 
 @using_py3dmol
-def test_visualize():
+def test_show():
 
-    water_dimer_minima.visualize()
+    water_dimer_minima.show()


### PR DESCRIPTION
Moves visualize to `show` command. Reason for this is I think the base should `show` so that it is easier to type out many different types of visualization for a single object while keeping `visualize` to bring up more of a dashboard like object portal side. Examples:
 - `show_trajectories/show_final_moleucle/show_changes` for optimizations.
 - `show_ternary/show_statistics/etc` on reactiondatasets.
 - `show_statistics/show_torsions/show_counts/etc` on torsion drive datasets.

For the reactiondatasets `visualize()` would bring up a widget of show statistics that would offer user clickable options rather than having to sift and write your own `method=[B3lyp,....]` lines. `visualize` would still of course use `show` commands under the hood.

Any thoughts on this name change?

Also adds better repr and automatic molecular visualization in notebooks.