### PR TITLE
Update testing.py

### DIFF
--- a/qcelemental/testing.py
+++ b/qcelemental/testing.py
@@ -126,13 +126,13 @@ def compare_values(expected,
 
     else:
         if xptd.shape == ():
-            xptd_str = f'{xptd:.{digits1}f}'
+            xptd_str = f'{float(xptd):.{digits1}f}'
         else:
             xptd_str = np.array_str(xptd, max_line_width=120, precision=12, suppress_small=True)
             xptd_str = '\n'.join('    ' + ln for ln in xptd_str.splitlines())
 
         if cptd.shape == ():
-            cptd_str = f'{cptd:.{digits1}f}'
+            cptd_str = f'{float(cptd):.{digits1}f}'
         else:
             cptd_str = np.array_str(cptd, max_line_width=120, precision=12, suppress_small=True)
             cptd_str = '\n'.join('    ' + ln for ln in cptd_str.splitlines())


### PR DESCRIPTION
As-was failed on Macs for both cases below, breaking some psi4 tests.

Linux:
```
>>> digits1=3
>>> aa=np.array(1.0)
>>> aa.shape
()
>>> f'{aa:.{digits1}f}'
'1.000'
>>> bb=np.array([1.0])
>>> bb.shape
(1,)
>>> f'{bb:.{digits1}f}'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported format string passed to numpy.ndarray.__format__
```