### PR TITLE
Molpro: Added dtype molpro to molecule.to_string function.

### DIFF
--- a/qcelemental/molparse/to_string.py
+++ b/qcelemental/molparse/to_string.py
@@ -152,12 +152,6 @@ def to_string(molrec: Dict,
 
         atoms = _atoms_formatter(molrec, geom, atom_format, ghost_format, width, prec, 2)
 
-        ghost_atoms = []
-        nat = geom.shape[0]
-        for iat in range(nat):
-            if not molrec['real'][iat]:
-                ghost_atoms.append(str(iat+1))
-
         first_line = f"""{{{umap.get(units.lower())}}}"""
         second_line = """geometry={"""
         end_bracket = """}"""
@@ -165,9 +159,12 @@ def to_string(molrec: Dict,
         smol.extend(atoms)
         smol.append(end_bracket)
 
-        if len(ghost_atoms) != 0:
-            ghost_line = f"""dummy,{",".join(ghost_atoms)}"""
+        if False in molrec['real']:
+            ghost_line = 'dummy,' + ','.join([str(idx + 1) for idx, real in enumerate(molrec['real']) if not real])
             smol.append(ghost_line)
+
+        smol.append(f"set,charge={molrec['molecular_charge']}")
+        smol.append(f"set,multiplicity={molrec['molecular_multiplicity']}")
 
     elif dtype == 'nwchem':
 

--- a/qcelemental/tests/test_molparse_to_string.py
+++ b/qcelemental/tests/test_molparse_to_string.py
@@ -107,6 +107,28 @@ units bohr
 no_reorient
 """,
 
+"ans2_molpro_au": """{bohr}
+geometry={
+Co                    0.000000000000     0.000000000000     0.000000000000
+H                     2.000000000000     0.000000000000     0.000000000000
+H                    -2.000000000000     0.000000000000     0.000000000000
+}
+dummy,2
+set,charge=0.0
+set,multiplicity=3
+""",
+
+"ans2_molpro_ang": """{angstrom}
+geometry={
+Co                    0.000000000000     0.000000000000     0.000000000000
+H                     1.058354421340     0.000000000000     0.000000000000
+H                    -1.058354421340     0.000000000000     0.000000000000
+}
+dummy,2
+set,charge=0.0
+set,multiplicity=3
+""",
+
 }  # yapf: disable
 
 
@@ -123,10 +145,13 @@ no_reorient
     (("subject2", {'dtype': 'terachem', 'units': 'angstrom'}), "ans2_terachem_ang"),
     (("subject2", {'dtype': 'terachem'}), "ans2_terachem_au"),
     (("subject2", {'dtype': 'psi4', 'units': 'bohr'}), "ans2_psi4_au"),
+    (("subject2", {'dtype': 'molpro', 'units': 'bohr'}), "ans2_molpro_au"),
+    (("subject2", {'dtype': 'molpro', 'units': 'angstrom'}), "ans2_molpro_ang"),
 ])  # yapf: disable
 def test_to_string_xyz(inp, expected):
     molrec = qcelemental.molparse.from_string(_results[inp[0]])
     smol = qcelemental.molparse.to_string(molrec['qm'], **inp[1])
+    print(smol)
 
     assert compare(_results[expected], smol)
 


### PR DESCRIPTION
Added molpro dtype to molecule.to_string so I can update the `MolproHarness` `build_input`