### PR TITLE
Pydantic Bump

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,5 +13,3 @@ comment:
   require_changes: false
   branches: null
   behavior: default
-  flags: null
-  paths: null

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -8,7 +8,7 @@ dependencies:
   - nomkl
   - python
   - pint
-  - pydantic>=0.30.1
+  - pydantic>=0.32
 
     # Optional depends
   - networkx

--- a/devtools/conda-envs/minimal_pins.yaml
+++ b/devtools/conda-envs/minimal_pins.yaml
@@ -8,7 +8,7 @@ dependencies:
   - nomkl
   - python
   - pint
-  - pydantic=0.30.1
+  - pydantic=0.32
 
     # Testing
   - pytest=4.0.0

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -82,10 +82,10 @@ Raw JSON can also be parsed back into a model:
     >
 
 The standard ``dict`` operation returns all internal representations which may be classes or other complex structures.
-To return a JSON-like dictionary the ``json_dict`` function can be used:
+To return a JSON-like dictionary the ``dict`` function can be used:
 
 .. code-block:: python
 
-    >>> mol.json_dict()
+    >>> mol.dict(encoding='json')
     {'symbols': ['He'], 'geometry': [0.0, 0.0, 0.0]}
 

--- a/qcelemental/__init__.py
+++ b/qcelemental/__init__.py
@@ -4,7 +4,7 @@ Main init for QCElemental
 
 from .datum import Datum
 from .exceptions import (NotAnElementError, ValidationError, MoleculeFormatError, ChoicesError, DataUnavailableError)
-from .testing import (compare, compare_values)
+from .testing import (compare, compare_values, compare_recursive)
 from . import molparse
 from . import molutil
 from . import models

--- a/qcelemental/data/__init__.py
+++ b/qcelemental/data/__init__.py
@@ -2,6 +2,6 @@ import json
 import os
 import pathlib
 
+from .alvarez_2008_covalent_radii import alvarez_2008_covalent_radii
 from .nist_2011_atomic_weights import nist_2011_atomic_weights
 from .nist_2014_codata import nist_2014_codata
-from .alvarez_2008_covalent_radii import alvarez_2008_covalent_radii

--- a/qcelemental/models/__init__.py
+++ b/qcelemental/models/__init__.py
@@ -6,6 +6,7 @@ except ImportError:  # pragma: no cover
 
 from . import types
 from .align import AlignmentMill
+from .basemodels import ProtoModel
 from .common_models import ComputeError, FailedOperation, Provenance
 from .molecule import Molecule
 from .procedures import Optimization, OptimizationInput

--- a/qcelemental/models/align.py
+++ b/qcelemental/models/align.py
@@ -57,7 +57,7 @@ class AlignmentMill(ProtoModel):
         text.append('Rotation:')
         text.append('{}'.format(self.rotation))
         text.append('-' * width)
-        return ('\n'.join(text))
+        return ('\n'.join(x.rstrip() for x in text))
 
     def align_coordinates(self, geom, *, reverse=False) -> Array:
         """suitable for geometry or displaced geometry"""

--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -140,7 +140,7 @@ class ProtoModel(BaseModel):
         bool
             True if the objects match.
         """
-        return compare_recursive(self, other)
+        return compare_recursive(self, other, **kwargs)
 
     def to_string(self):  # lgtm [py/inheritance/incorrect-overridden-signature]
         return f"{self.__class__.__name__}"

--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -1,11 +1,11 @@
 import json
-from typing import Any, Dict, Optional, Set, Union
 from pathlib import Path
+from typing import Any, Dict, Optional, Set, Union
 
 import numpy as np
 from pydantic import BaseModel
 
-from qcelemental.util import msgpack_dumps, msgpack_loads
+from qcelemental.util import deserialize, serialize
 
 
 class ProtoModel(BaseModel):
@@ -17,7 +17,7 @@ class ProtoModel(BaseModel):
         serialize_skip_defaults = False
 
     @classmethod
-    def parse_raw(cls, data: Union[bytes, str], *, content_type: str = None) -> 'Model':
+    def parse_raw(cls, data: Union[bytes, str], *, encoding: str = None) -> 'Model':
         """
         Parses raw string or bytes into a Model object.
 
@@ -25,8 +25,8 @@ class ProtoModel(BaseModel):
         ----------
         data : Union[bytes, str]
             A serialized data blob to be deserialized into a Model.
-        content_type : str, optional
-            The type of the serialized array, available types are: {'json', 'msgpack', 'pickle'}
+        encoding : str, optional
+            The type of the serialized array, available types are: {'json', 'json-ext', 'msgpack-ext', 'pickle'}
 
         Returns
         -------
@@ -34,32 +34,32 @@ class ProtoModel(BaseModel):
             The requested model from a serialized format.
         """
 
-        if content_type is None:
+        if encoding is None:
             if isinstance(data, str):
-                content_type = "json"
+                encoding = "json"
             elif isinstance(data, bytes):
-                content_type = "msgpack"
+                encoding = "msgpack-ext"
             else:
-                raise TypeError("Input is neither str nor bytes, please specify a content_type.")
+                raise TypeError("Input is neither str nor bytes, please specify a encoding.")
 
-        if content_type.endswith(('json', 'javascript', 'pickle')):
-            return super().parse_raw(data, content_type=content_type)
-        elif content_type == "msgpack":
-            obj = cls._parse_msgpack(data)
+        if encoding.endswith(('json', 'javascript', 'pickle')):
+            return super().parse_raw(data, content_type=encoding)
+        elif encoding in ["msgpack-ext", "json-ext"]:
+            obj = deserialize(data, encoding)
         else:
-            raise TypeError(f"Content type '{content_type}' not understood.")
+            raise TypeError(f"Content type '{encoding}' not understood.")
 
         return cls.parse_obj(obj)
 
     @classmethod
-    def parse_file(cls, path: Union[str, Path], *, content_type: str = None) -> 'Model':
+    def parse_file(cls, path: Union[str, Path], *, encoding: str = None) -> 'Model':
         """Parses a file into a Model object.
 
         Parameters
         ----------
         path : Union[str, Path]
             The path to the file.
-        content_type : str, optional
+        encoding : str, optional
             The type of the files, available types are: {'json', 'msgpack', 'pickle'}. Attempts to
             automatically infer the file type from disk.
 
@@ -70,35 +70,44 @@ class ProtoModel(BaseModel):
 
         """
         path = Path(path)
-        if content_type is None:
+        if encoding is None:
             if path.suffix in [".json", ".js"]:
-                content_type = "json"
+                encoding = "json"
             elif path.suffix in [".msgpack"]:
-                content_type = "msgpack"
+                encoding = "msgpack-ext"
             elif path.suffix in [".pickle"]:
-                content_type = "pickle"
+                encoding = "pickle"
             else:
-                raise TypeError("Could not infer `content_type`, please provide a `content_type` for this file.")
+                raise TypeError("Could not infer `encoding`, please provide a `encoding` for this file.")
 
-        return cls.parse_raw(path.read_bytes(), content_type=content_type)
+        return cls.parse_raw(path.read_bytes(), encoding=encoding)
 
     def dict(self, *args, **kwargs):
+        encoding = kwargs.pop("encoding", None)
+
         kwargs["exclude"] = (kwargs.get("exclude", None) or set()) | self.__config__.serialize_default_excludes
         kwargs.setdefault("skip_defaults", self.__config__.serialize_skip_defaults)
-        return super().dict(*args, **kwargs)
+        data = super().dict(*args, **kwargs)
 
-    def json_dict(self, *args, **kwargs):
-        return json.loads(self.json(*args, **kwargs))
+        if encoding is None:
+            return data
+        elif encoding == "json":
+            return json.loads(serialize(data, encoding="json"))
+        else:
+            raise KeyError(f"Unknown encoding type '{encoding}', valid encoding types: 'json'.")
 
-    def msgpack(self,
+    def serialize(self,
+                encoding: str,
                 *,
                 include: Optional[Set[str]] = None,
                 exclude: Optional[Set[str]] = None,
-                skip_defaults: bool = False) -> bytes:
-        """Generates a msgpack serialized representation of the model
+                skip_defaults: bool = False) -> Union[bytes, str]:
+        """Generates a serialized representation of the model
 
         Parameters
         ----------
+        encoding : str
+            The serialization type, available types are: {'json', 'json-ext', 'msgpack-ext'}
         include : Optional[Set[str]], optional
             Fields to be included in the serialization.
         exclude : Optional[Set[str]], optional
@@ -108,16 +117,12 @@ class ProtoModel(BaseModel):
 
         Returns
         -------
-        bytes
-            The msgpack serialization of the model.
+        Union[bytes, str]
+            The serialized model.
         """
         data = self.dict(include=include, exclude=exclude, skip_defaults=skip_defaults)
 
-        return msgpack_dumps(data)
+        return serialize(data, encoding=encoding)
 
-    @classmethod
-    def _parse_msgpack(cls, data: bytes) -> Dict[str, Any]:
-        return msgpack_loads(data)
-
-    def to_string(self): # lgtm [py/inheritance/incorrect-overridden-signature]
+    def to_string(self):  # lgtm [py/inheritance/incorrect-overridden-signature]
         return f"{self.__class__.__name__}"

--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -5,8 +5,8 @@ from typing import Any, Dict, Optional, Set, Union
 import numpy as np
 from pydantic import BaseModel
 
-from qcelemental.util import deserialize, serialize
 from qcelemental.testing import compare_recursive
+from qcelemental.util import deserialize, serialize
 
 
 class ProtoModel(BaseModel):

--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -41,7 +41,7 @@ class ProtoModel(BaseModel):
             elif isinstance(data, bytes):
                 encoding = "msgpack-ext"
             else:
-                raise TypeError("Input is neither str nor bytes, please specify a encoding.")
+                raise TypeError("Input is neither str nor bytes, please specify an encoding.")
 
         if encoding.endswith(('json', 'javascript', 'pickle')):
             return super().parse_raw(data, content_type=encoding)
@@ -62,7 +62,7 @@ class ProtoModel(BaseModel):
             The path to the file.
         encoding : str, optional
             The type of the files, available types are: {'json', 'msgpack', 'pickle'}. Attempts to
-            automatically infer the file type from disk.
+            automatically infer the file type from the file extension if None.
 
         Returns
         -------

--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -6,6 +6,7 @@ import numpy as np
 from pydantic import BaseModel
 
 from qcelemental.util import deserialize, serialize
+from qcelemental.testing import compare_recursive
 
 
 class ProtoModel(BaseModel):
@@ -82,7 +83,7 @@ class ProtoModel(BaseModel):
 
         return cls.parse_raw(path.read_bytes(), encoding=encoding)
 
-    def dict(self, *args, **kwargs):
+    def dict(self, *args, **kwargs) -> Dict[str, Any]:
         encoding = kwargs.pop("encoding", None)
 
         kwargs["exclude"] = (kwargs.get("exclude", None) or set()) | self.__config__.serialize_default_excludes
@@ -97,11 +98,11 @@ class ProtoModel(BaseModel):
             raise KeyError(f"Unknown encoding type '{encoding}', valid encoding types: 'json'.")
 
     def serialize(self,
-                encoding: str,
-                *,
-                include: Optional[Set[str]] = None,
-                exclude: Optional[Set[str]] = None,
-                skip_defaults: bool = False) -> Union[bytes, str]:
+                  encoding: str,
+                  *,
+                  include: Optional[Set[str]] = None,
+                  exclude: Optional[Set[str]] = None,
+                  skip_defaults: bool = False) -> Union[bytes, str]:
         """Generates a serialized representation of the model
 
         Parameters
@@ -123,6 +124,23 @@ class ProtoModel(BaseModel):
         data = self.dict(include=include, exclude=exclude, skip_defaults=skip_defaults)
 
         return serialize(data, encoding=encoding)
+
+    def compare(self, other: 'Model', **kwargs) -> bool:
+        """Compares the current object to the provided object recursively.
+
+        Parameters
+        ----------
+        other : Model
+            The model to compare to.
+        **kwargs
+            Additional kwargs to pass to ``qcelemental.compare_recursive``.
+
+        Returns
+        -------
+        bool
+            True if the objects match.
+        """
+        return compare_recursive(self, other)
 
     def to_string(self):  # lgtm [py/inheritance/incorrect-overridden-signature]
         return f"{self.__class__.__name__}"

--- a/qcelemental/models/common_models.py
+++ b/qcelemental/models/common_models.py
@@ -2,8 +2,8 @@ from enum import Enum
 from typing import Any, Dict, Optional
 
 import numpy as np
-
 from pydantic import Schema
+
 from .basemodels import ProtoModel
 
 # Encoders, to be deprecated

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -424,7 +424,7 @@ class Molecule(ProtoModel):
         """
         return Molecule(orient=True, **self.dict())
 
-    def compare(self, other, bench=None):
+    def compare(self, other):
         """
         Checks if two molecules are identical. This is a molecular identity defined
         by scientific terms, and not programing terms, so it's less rigorous than
@@ -437,9 +437,6 @@ class Molecule(ProtoModel):
             pass
         else:
             raise TypeError("Comparison molecule not understood of type '{}'.".format(type(other)))
-
-        if bench is None:
-            bench = self
 
         match = True
         match &= np.array_equal(bench.symbols, other.symbols)

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -440,15 +440,15 @@ class Molecule(ProtoModel):
 
         match = True
         match &= np.array_equal(self.symbols, other.symbols)
-        match &= np.allclose(self.masses, other.masses, atol=MASS_NOISE)
-        match &= np.equal(self.real, other.real).all()
-        match &= np.equal(self.fragments, other.fragments).all()
-        match &= np.allclose(self.fragment_charges, other.fragment_charges, atol=CHARGE_NOISE)
-        match &= np.equal(self.fragment_multiplicities, other.fragment_multiplicities).all()
+        match &= np.allclose(self.masses, other.masses, atol=(10**-MASS_NOISE))
+        match &= np.array_equal(self.real, other.real)
+        match &= np.array_equal(self.fragments, other.fragments)
+        match &= np.allclose(self.fragment_charges, other.fragment_charges, atol=(10**-CHARGE_NOISE))
+        match &= np.array_equal(self.fragment_multiplicities, other.fragment_multiplicities)
 
-        match &= np.allclose(self.molecular_charge, other.molecular_charge, atol=CHARGE_NOISE)
-        match &= np.equal(self.molecular_multiplicity, other.molecular_multiplicity).all()
-        match &= np.allclose(self.geometry, other.geometry, atol=GEOMETRY_NOISE)
+        match &= np.allclose(self.molecular_charge, other.molecular_charge, atol=(10**-CHARGE_NOISE))
+        match &= np.array_equal(self.molecular_multiplicity, other.molecular_multiplicity)
+        match &= np.allclose(self.geometry, other.geometry, atol=(10**-GEOMETRY_NOISE))
         return match
 
     def pretty_print(self):
@@ -844,7 +844,7 @@ class Molecule(ProtoModel):
             flags = "wb"
         elif dtype in ["numpy"]:
             elements = np.array(self.atomic_numbers).reshape(-1, 1)
-            npmol = np.hstack((elements, self.geometry))
+            npmol = np.hstack((elements, self.geometry * constants.conversion_factor("bohr", "angstroms")))
 
             np.save(filename, npmol)
             return

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -272,7 +272,7 @@ class Molecule(ProtoModel):
 
         # We are pulling out the values *explicitly* so that the pydantic skip_defaults works as expected
         # All attributes set bellow are equivalent to the default set.
-        values = self.__values__
+        values = self.__dict__
 
         natoms = values["geometry"].shape[0]
         if validate:

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -745,6 +745,7 @@ class Molecule(ProtoModel):
 
         if dtype in ["string", "psi4", "psi4+", "xyz", "xyz+"]:
             input_dict = to_schema(from_string(data)["qm"], dtype=2)
+            validate = True
         elif dtype == "numpy":
             data = np.asarray(data)
             data = {
@@ -754,6 +755,7 @@ class Molecule(ProtoModel):
                 "fragment_separators": kwargs.pop("frags", [])
             }
             input_dict = to_schema(from_arrays(**data), dtype=2)
+            validate = True
         elif dtype == "msgpack":
             input_dict = cls._parse_msgpack(data)
         elif dtype == "json":

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -439,16 +439,16 @@ class Molecule(ProtoModel):
             raise TypeError("Comparison molecule not understood of type '{}'.".format(type(other)))
 
         match = True
-        match &= np.array_equal(bench.symbols, other.symbols)
-        match &= np.allclose(bench.masses, other.masses, atol=MASS_NOISE)
-        match &= np.equal(bench.real, other.real).all()
-        match &= np.equal(bench.fragments, other.fragments).all()
-        match &= np.allclose(bench.fragment_charges, other.fragment_charges, atol=CHARGE_NOISE)
-        match &= np.equal(bench.fragment_multiplicities, other.fragment_multiplicities).all()
+        match &= np.array_equal(self.symbols, other.symbols)
+        match &= np.allclose(self.masses, other.masses, atol=MASS_NOISE)
+        match &= np.equal(self.real, other.real).all()
+        match &= np.equal(self.fragments, other.fragments).all()
+        match &= np.allclose(self.fragment_charges, other.fragment_charges, atol=CHARGE_NOISE)
+        match &= np.equal(self.fragment_multiplicities, other.fragment_multiplicities).all()
 
-        match &= np.allclose(bench.molecular_charge, other.molecular_charge, atol=CHARGE_NOISE)
-        match &= np.equal(bench.molecular_multiplicity, other.molecular_multiplicity).all()
-        match &= np.allclose(bench.geometry, other.geometry, atol=GEOMETRY_NOISE)
+        match &= np.allclose(self.molecular_charge, other.molecular_charge, atol=CHARGE_NOISE)
+        match &= np.equal(self.molecular_multiplicity, other.molecular_multiplicity).all()
+        match &= np.allclose(self.geometry, other.geometry, atol=GEOMETRY_NOISE)
         return match
 
     def pretty_print(self):

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -9,13 +9,13 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from pydantic import constr, validator, Schema
+from pydantic import Schema, constr, validator
 
 from ..molparse import from_arrays, from_schema, from_string, to_schema, to_string
 from ..periodic_table import periodictable
 from ..physical_constants import constants
 from ..testing import compare, compare_values
-from ..util import deserialize, measure_coordinates, provenance_stamp, which_import, auto_gen_docs_on_demand
+from ..util import auto_gen_docs_on_demand, deserialize, measure_coordinates, provenance_stamp, which_import
 from .basemodels import ProtoModel
 from .common_models import Provenance, qcschema_molecule_default
 from .types import Array

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -5,8 +5,7 @@ from pydantic import constr, validator
 
 from ..util import provenance_stamp
 from .basemodels import ProtoModel
-from .common_models import (ComputeError, DriverEnum, Model, Provenance, qcschema_input_default,
-                            qcschema_output_default)
+from .common_models import ComputeError, DriverEnum, Model, Provenance, qcschema_input_default, qcschema_output_default
 from .molecule import Molecule
 from .types import Array
 

--- a/qcelemental/molparse/__init__.py
+++ b/qcelemental/molparse/__init__.py
@@ -1,7 +1,7 @@
-from .from_arrays import from_arrays, from_input_arrays
-from .from_string import from_string
-from .nucleus import reconcile_nucleus, parse_nucleus_label
 from .chgmult import validate_and_fill_chgmult
-from .to_string import to_string
+from .from_arrays import from_arrays, from_input_arrays
+from .from_schema import contiguize_from_fragment_pattern, from_schema
+from .from_string import from_string
+from .nucleus import parse_nucleus_label, reconcile_nucleus
 from .to_schema import to_schema
-from .from_schema import from_schema, contiguize_from_fragment_pattern
+from .to_string import to_string

--- a/qcelemental/molparse/from_arrays.py
+++ b/qcelemental/molparse/from_arrays.py
@@ -1,6 +1,6 @@
-from copy import deepcopy
 import pprint
 import re
+from copy import deepcopy
 
 import numpy as np
 

--- a/qcelemental/molparse/from_string.py
+++ b/qcelemental/molparse/from_string.py
@@ -2,9 +2,9 @@ import pprint
 import re
 from typing import Dict, Tuple, Union
 
-from . import pubchem
 from ..exceptions import ChoicesError, MoleculeFormatError, ValidationError
 from ..util import filter_comments, provenance_stamp
+from . import pubchem
 from .from_arrays import from_input_arrays
 from .regex import CARTXYZ, CHGMULT, ENDL, NUCLEUS, NUMBER, SEP
 

--- a/qcelemental/molparse/nucleus.py
+++ b/qcelemental/molparse/nucleus.py
@@ -1,10 +1,10 @@
 import re
-from typing import List, Tuple
 from functools import lru_cache
+from typing import List, Tuple
 
-from .regex import NUCLEUS
 from ..exceptions import NotAnElementError, ValidationError
 from ..periodic_table import periodictable
+from .regex import NUCLEUS
 
 _nucleus = re.compile(r'\A' + NUCLEUS + r'\Z', re.IGNORECASE | re.VERBOSE)
 

--- a/qcelemental/molutil/__init__.py
+++ b/qcelemental/molutil/__init__.py
@@ -1,2 +1,1 @@
-from .align import B787, kabsch_align, compute_scramble
-
+from .align import B787, compute_scramble, kabsch_align

--- a/qcelemental/molutil/align.py
+++ b/qcelemental/molutil/align.py
@@ -1,6 +1,6 @@
-import time
-import itertools
 import collections
+import itertools
+import time
 
 import numpy as np
 
@@ -8,7 +8,7 @@ from ..exceptions import ValidationError
 from ..models import AlignmentMill
 from ..physical_constants import constants
 from ..testing import compare_values
-from ..util import (distance_matrix, linear_sum_assignment, random_rotation_matrix, uno, which_import)
+from ..util import distance_matrix, linear_sum_assignment, random_rotation_matrix, uno, which_import
 
 
 def _nre(Z, geom):

--- a/qcelemental/molutil/test_align.py
+++ b/qcelemental/molutil/test_align.py
@@ -12,10 +12,6 @@ from ..tests.addons import using_networkx
 
 pp = pprint.PrettyPrinter(width=120)
 
-
-
-
-
 ss22_12 = """
 C    -1.2471894   -1.1718212   -0.6961388
 C    -1.2471894   -1.1718212    0.6961388

--- a/qcelemental/molutil/test_align.py
+++ b/qcelemental/molutil/test_align.py
@@ -1,15 +1,18 @@
-import pytest
-from ..tests.addons import using_networkx
-
 import math
 import pprint
-pp = pprint.PrettyPrinter(width=120)
 
 import numpy as np
 import pydantic
+import pytest
 
 import qcelemental as qcel
-from qcelemental.testing import compare, compare_values, compare_recursive, compare_molrecs
+from qcelemental.testing import compare, compare_molrecs, compare_recursive, compare_values
+
+from ..tests.addons import using_networkx
+
+pp = pprint.PrettyPrinter(width=120)
+
+
 
 
 
@@ -267,8 +270,8 @@ def test_scramble_identity():
     mill = qcel.molutil.compute_scramble(4, do_resort=False, do_shift=False, do_rotate=False, deflection=1.0, do_mirror=False)
 
     mill_str = """----------------------------------------
-             AlignmentMill              
-                  eye                   
+             AlignmentMill
+                  eye
 ----------------------------------------
 Mirror:   False
 Atom Map: [0 1 2 3]
@@ -289,7 +292,7 @@ Rotation:
 
     assert compare_recursive(mill_dict, mill.dict())
     mill_dict['rotation'] = [1., 0., 0., 0., 1., 0., 0., 0., 1.]
-    assert compare_recursive(mill_dict, mill.json_dict())
+    assert compare_recursive(mill_dict, mill.dict(encoding="json"))
 
 
 def test_scramble_specific():
@@ -301,7 +304,7 @@ def test_scramble_specific():
                                                      [ 0.84393258,  0.29465774,  0.44827962]])
 
     mill_str = """----------------------------------------
-             AlignmentMill              
+             AlignmentMill
 ----------------------------------------
 Mirror:   False
 Atom Map: [1 2 0 3]
@@ -320,7 +323,7 @@ def test_hessian_align():
 
     rmill = """
 ----------------------------------------
-             AlignmentMill              
+             AlignmentMill
 ----------------------------------------
 Mirror:   False
 Atom Map: [0 1 2 3]
@@ -516,4 +519,3 @@ def test_vector_gradient_align():
     assert compare_values(c4_hooh_dipder_x, p2c_dipder_x, atol=1.e-5)
     assert compare_values(c4_hooh_dipder_y, p2c_dipder_y, atol=1.e-5)
     assert compare_values(c4_hooh_dipder_z, p2c_dipder_z, atol=1.e-5)
-

--- a/qcelemental/physical_constants/__init__.py
+++ b/qcelemental/physical_constants/__init__.py
@@ -4,11 +4,12 @@ Units handlers
 
 # Ensure pint exists
 from importlib.util import find_spec
+
+from .context import PhysicalConstantsContext, constants
+
 spec = find_spec('pint')
 if spec is None:
     raise ModuleNotFoundError(
         """Python module pint not found. Solve by installing it: `conda install pint -c conda-forge` or `pip install pint`"""
     )  # pragma: no cover
 del spec, find_spec
-
-from .context import constants, PhysicalConstantsContext

--- a/qcelemental/physical_constants/context.py
+++ b/qcelemental/physical_constants/context.py
@@ -4,8 +4,8 @@ Contains relevant physical constants
 
 import collections
 from decimal import Decimal
-from typing import Union
 from functools import lru_cache
+from typing import Union
 
 from ..datum import Datum, print_variables
 from .ureg import build_units_registry

--- a/qcelemental/testing.py
+++ b/qcelemental/testing.py
@@ -6,6 +6,7 @@ import pprint
 pp = pprint.PrettyPrinter(width=120)
 import sys
 from typing import Callable
+from pydantic import BaseModel
 
 import numpy as np
 
@@ -224,16 +225,10 @@ def compare(expected,
             cptd_str = np.array_str(cptd, max_line_width=120, precision=12, suppress_small=True)
             cptd_str = '\n'.join('    ' + ln for ln in cptd_str.splitlines())
 
-        print()
-        print(str(cptd)[:138])
-        print(str(xptd)[:138])
         try:
             diff = cptd - xptd
         except TypeError:
-            diff_str = f"{sum(x == y for x, y in zip(str(cptd), str(xptd)))} / {len(str(xptd))}"
-        except:
             diff_str = '(n/a)'
-
         else:
             if xptd.shape == ():
                 diff_str = f'{diff}'
@@ -256,6 +251,13 @@ def _compare_recursive(expected, computed, atol, rtol, _prefix=False):
     errors = []
     name = _prefix or "root"
     prefix = name + "."
+
+    # Initial conversions if required
+    if isinstance(expected, BaseModel):
+        expected = expected.dict()
+
+    if isinstance(computed, BaseModel):
+        computed = computed.dict()
 
     if isinstance(expected, (str, int, bool, complex)):
         if expected != computed:

--- a/qcelemental/testing.py
+++ b/qcelemental/testing.py
@@ -224,10 +224,16 @@ def compare(expected,
             cptd_str = np.array_str(cptd, max_line_width=120, precision=12, suppress_small=True)
             cptd_str = '\n'.join('    ' + ln for ln in cptd_str.splitlines())
 
+        print()
+        print(str(cptd)[:138])
+        print(str(xptd)[:138])
         try:
             diff = cptd - xptd
         except TypeError:
+            diff_str = f"{sum(x == y for x, y in zip(str(cptd), str(xptd)))} / {len(str(xptd))}"
+        except:
             diff_str = '(n/a)'
+
         else:
             if xptd.shape == ():
                 diff_str = f'{diff}'

--- a/qcelemental/testing.py
+++ b/qcelemental/testing.py
@@ -3,12 +3,14 @@ import copy
 import logging
 import math
 import pprint
-pp = pprint.PrettyPrinter(width=120)
 import sys
 from typing import Callable
-from pydantic import BaseModel
 
 import numpy as np
+from pydantic import BaseModel
+
+pp = pprint.PrettyPrinter(width=120)
+
 
 
 def _handle_return(passfail: bool, label: str, message: str, return_message: bool, quiet: bool = False):

--- a/qcelemental/tests/addons.py
+++ b/qcelemental/tests/addons.py
@@ -12,6 +12,7 @@ def internet_connection():
     except OSError:
         return False
 
+
 using_web = pytest.mark.skipif(internet_connection() is False, reason="Could not connect to the internet")
 
 using_msgpack = pytest.mark.skipif(
@@ -29,3 +30,5 @@ using_scipy = pytest.mark.skipif(
 using_py3dmol = pytest.mark.skipif(
     which_import('py3Dmol', return_bool=True) is False,
     reason='Not detecting module py3Dmol. Install package if necessary and add to envvar PYTHONPATH')
+
+serialize_extensions = ["json", "json-ext", pytest.param("msgpack-ext", marks=using_msgpack)]

--- a/qcelemental/tests/test_model_serials.py
+++ b/qcelemental/tests/test_model_serials.py
@@ -6,7 +6,7 @@ from qcelemental.models import (ComputeError, FailedOperation, Molecule, Optimiz
                                 ResultInput, ResultProperties)
 from qcelemental.util import provenance_stamp
 
-from .addons import using_msgpack
+from .addons import serialize_extensions, using_msgpack
 
 
 @pytest.fixture
@@ -87,16 +87,11 @@ def test_driverenum_derivative_int(water, result_input):
 def test_molecule_serialization_types(water):
     assert isinstance(water.dict(), dict)
     assert isinstance(water.json(), str)
-    assert isinstance(water.json_dict(), dict)
 
-
-def test_molecule_serialization_json(water):
-    assert water.compare(Molecule.parse_raw(water.json()))
-
-
-@using_msgpack
-def test_molecule_serialization_msgpack(water):
-    assert water.compare(Molecule.parse_raw(water.msgpack()))
+@pytest.mark.parametrize("encoding", serialize_extensions)
+def test_molecule_serialization(water, encoding):
+    blob = water.serialize(encoding)
+    assert water.compare(Molecule.parse_raw(blob, encoding=encoding))
 
 
 @pytest.mark.parametrize("dtype, filext", [
@@ -134,12 +129,10 @@ def test_result_pass_serialization(water, result_input, res_success):
     res_in = ResultInput(molecule=water, **result_input)
     assert isinstance(res_in.dict(), dict)
     assert isinstance(res_in.json(), str)
-    assert isinstance(res_in.json_dict(), dict)
 
     res_out = Result(molecule=water, **result_input, **res_success)
     assert isinstance(res_out.dict(), dict)
     assert isinstance(res_out.json(), str)
-    assert isinstance(res_out.json_dict(), dict)
 
 
 def test_result_sparsity(water, result_input, res_success):
@@ -160,12 +153,10 @@ def test_optimization_pass_serialization(water, opti_input, opti_success):
     opti_in = OptimizationInput(initial_molecule=water, **opti_input)
     assert isinstance(opti_in.dict(), dict)
     assert isinstance(opti_in.json(), str)
-    assert isinstance(opti_in.json_dict(), dict)
 
     opti_out = Optimization(initial_molecule=water, **opti_input, **opti_success)
     assert isinstance(opti_out.dict(), dict)
     assert isinstance(opti_out.json(), str)
-    assert isinstance(opti_out.json_dict(), dict)
 
 
 def test_failed_operation(water, result_input):

--- a/qcelemental/tests/test_model_serials.py
+++ b/qcelemental/tests/test_model_serials.py
@@ -12,7 +12,7 @@ from qcelemental.util import provenance_stamp
 from .addons import serialize_extensions, using_msgpack
 
 
-class TestModel(ProtoModel):
+class TrialModel(ProtoModel):
     a: Array[float] = np.array(3)
     b: List[Array[float]] = [np.random.rand(3)]
     c: Dict[str, int] = {"hi": 3}
@@ -89,7 +89,7 @@ def opti_success(water, result_input, res_success):
 
 @pytest.mark.parametrize("encoding", serialize_extensions)
 def test_proto_file(tmp_path, encoding):
-    obj = TestModel(a=np.array(3), b=[np.random.rand(3)], c={"hi": 3}, d={"hi": np.random.rand(3)})
+    obj = TrialModel(a=np.array(3), b=[np.random.rand(3)], c={"hi": 3}, d={"hi": np.random.rand(3)})
 
     p = tmp_path / ("data.dat")
     if "msgpack" in encoding:
@@ -97,7 +97,7 @@ def test_proto_file(tmp_path, encoding):
     else:
         p.write_text(obj.serialize(encoding))
 
-    obj2 = TestModel.parse_file(p, encoding=encoding)
+    obj2 = TrialModel.parse_file(p, encoding=encoding)
 
     assert obj.compare(obj2)
 

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -38,10 +38,10 @@ def test_molecule_data_constructor_numpy():
     npwater = np.hstack((ele, water_psi.geometry))
 
     water_from_np = Molecule.from_data(npwater, name="water dimer", dtype="numpy", frags=[3])
-    assert water_psi.compare(water_psi, water_from_np)
+    assert water_psi.compare(water_from_np)
 
     water_from_np = Molecule.from_data(npwater, name="water dimer", frags=[3])
-    assert water_psi.compare(water_psi, water_from_np)
+    assert water_psi.compare(water_from_np)
     assert water_psi.get_molecular_formula() == "H4O2"
 
 
@@ -50,10 +50,10 @@ def test_molecule_data_constructor_dict():
 
     # Check the JSON construct/deconstruct
     water_from_json = Molecule.from_data(water_psi.dict())
-    assert water_psi.compare(water_psi, water_from_json)
+    assert water_psi.compare(water_from_json)
 
     water_from_json = Molecule.from_data(water_psi.json(), "json")
-    assert water_psi.compare(water_psi, water_from_json)
+    assert water_psi.compare(water_from_json)
     assert water_psi.compare(Molecule.from_data(water_psi.to_string("psi4"), dtype="psi4"))
 
     assert water_psi.get_hash() == '3c4b98f515d64d1adc1648fe1fe1d6789e978d34'  # copied from schema_version=1
@@ -88,11 +88,11 @@ def test_molecule_np_constructors():
     npneon = np.hstack((ele, neon_from_psi.geometry))
     neon_from_np = Molecule.from_data(npneon, name="neon tetramer", dtype="numpy", frags=[1, 2, 3], units="bohr")
 
-    assert neon_from_psi.compare(neon_from_psi, neon_from_np)
+    assert neon_from_psi.compare(neon_from_np)
 
     # Check the JSON construct/deconstruct
     neon_from_json = Molecule.from_data(neon_from_psi.json(), dtype="json")
-    assert neon_from_psi.compare(neon_from_psi, neon_from_json)
+    assert neon_from_psi.compare(neon_from_json)
     assert neon_from_json.get_molecular_formula() == "Ne4"
 
 

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -9,7 +9,7 @@ import qcelemental as qcel
 from qcelemental.models import Molecule
 from qcelemental.testing import compare, compare_values
 
-from .addons import using_msgpack, using_py3dmol
+from .addons import serialize_extensions, using_msgpack, using_py3dmol
 
 water_molecule = Molecule.from_data("""
     0 1
@@ -267,16 +267,15 @@ def test_molecule_errors_shape():
 def test_molecule_json_serialization():
     assert isinstance(water_dimer_minima.json(), str)
 
-    assert isinstance(water_dimer_minima.json_dict()["geometry"], list)
+    assert isinstance(water_dimer_minima.dict(encoding="json")["geometry"], list)
 
     assert water_dimer_minima.compare(Molecule.from_data(water_dimer_minima.json(), dtype="json"))
 
 
-@using_msgpack
-def test_molecule_msgpack_serialization():
-    assert isinstance(water_dimer_minima.msgpack(), bytes)
-
-    assert water_dimer_minima.compare(Molecule.from_data(water_dimer_minima.msgpack(), dtype="msgpack"))
+@pytest.mark.parametrize("encoding", serialize_extensions)
+def test_molecule_serialization(encoding):
+    blob = water_dimer_minima.serialize(encoding)
+    assert water_dimer_minima.compare(Molecule.parse_raw(blob, encoding=encoding))
 
 
 def test_charged_fragment():

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -35,7 +35,7 @@ water_dimer_minima = Molecule.from_data("""
 def test_molecule_data_constructor_numpy():
     water_psi = water_dimer_minima.copy()
     ele = np.array(water_psi.atomic_numbers).reshape(-1, 1)
-    npwater = np.hstack((ele, water_psi.geometry))
+    npwater = np.hstack((ele, water_psi.geometry * qcel.constants.conversion_factor("Bohr", "angstrom")))
 
     water_from_np = Molecule.from_data(npwater, name="water dimer", dtype="numpy", frags=[3])
     assert water_psi.compare(water_from_np)
@@ -94,6 +94,14 @@ def test_molecule_np_constructors():
     neon_from_json = Molecule.from_data(neon_from_psi.json(), dtype="json")
     assert neon_from_psi.compare(neon_from_json)
     assert neon_from_json.get_molecular_formula() == "Ne4"
+
+
+def test_molecule_compare():
+    water_molecule2 = water_molecule.copy()
+    assert water_molecule2.compare(water_molecule)
+
+    water_molecule3 = water_molecule.copy(update={"geometry": (water_molecule.geometry + np.array([0.1, 0, 0]))})
+    assert water_molecule.compare(water_molecule3) is False
 
 
 def test_water_minima_data():

--- a/qcelemental/tests/test_utils.py
+++ b/qcelemental/tests/test_utils.py
@@ -1,7 +1,8 @@
+from typing import Any, Dict, List, Optional, Tuple, Union
+
 import numpy as np
 import pytest
 from pydantic import BaseModel, Schema
-from typing import Optional, Union, List, Tuple, Dict, Any
 
 import qcelemental as qcel
 from qcelemental.testing import compare_recursive, compare_values
@@ -217,7 +218,7 @@ def test_dihedral2():
 
 def test_auto_gen_doc(doc_fixture):
     assert "this is complicated" not in doc_fixture.__doc__
-    qcelemental.util.auto_gen_docs_on_demand(doc_fixture, allow_failure=False, ignore_reapply=False)
+    qcel.util.auto_gen_docs_on_demand(doc_fixture, allow_failure=False, ignore_reapply=False)
     assert "this is complicated" in doc_fixture.__doc__
     assert "z3 : float, Optional" in doc_fixture.__doc__
     # Check that docstring does not get duplicated for some reason
@@ -226,19 +227,19 @@ def test_auto_gen_doc(doc_fixture):
 
 def test_auto_gen_doc_exiting(doc_fixture):
     doc_fixture.__doc__ = "Parameters\n"
-    qcelemental.util.auto_gen_docs_on_demand(doc_fixture, allow_failure=False, ignore_reapply=False)
+    qcel.util.auto_gen_docs_on_demand(doc_fixture, allow_failure=False, ignore_reapply=False)
     assert "this is complicated" not in doc_fixture.__doc__
 
 
 def test_auto_gen_doc_reapply_failure(doc_fixture):
-    qcelemental.util.auto_gen_docs_on_demand(doc_fixture, allow_failure=False, ignore_reapply=False)
+    qcel.util.auto_gen_docs_on_demand(doc_fixture, allow_failure=False, ignore_reapply=False)
     with pytest.raises(ValueError):
         # Allow true here because we are testing application, not errors in the doc generation itself
-        qcelemental.util.auto_gen_docs_on_demand(doc_fixture, allow_failure=True, ignore_reapply=False)
+        qcel.util.auto_gen_docs_on_demand(doc_fixture, allow_failure=True, ignore_reapply=False)
 
 
 def test_auto_gen_doc_delete(doc_fixture):
-    qcelemental.util.auto_gen_docs_on_demand(doc_fixture, allow_failure=False, ignore_reapply=False)
+    qcel.util.auto_gen_docs_on_demand(doc_fixture, allow_failure=False, ignore_reapply=False)
     assert "this is complicated" in doc_fixture.__doc__
     assert "A Pydantic model" in doc_fixture.__doc__
     del doc_fixture.__doc__

--- a/qcelemental/tests/test_utils.py
+++ b/qcelemental/tests/test_utils.py
@@ -6,7 +6,8 @@ from typing import Optional, Union, List, Tuple, Dict, Any
 import qcelemental as qcel
 from qcelemental.testing import compare_recursive, compare_values
 
-from .addons import using_msgpack
+from .addons import serialize_extensions, using_msgpack
+
 
 @pytest.fixture(scope="function")
 def doc_fixture():
@@ -202,9 +203,16 @@ def test_dihedral2():
     p7 = [22.557, 9.096, 30.459]
 
     _test_dihedral(p0, p1, p2, p3, -71.21515114671394)
+    _test_dihedral(p3, p2, p1, p0, -71.21515114671394)
+
     _test_dihedral(p0, p1, p4, p5, -171.94319947953642)
+    _test_dihedral(p5, p4, p1, p0, -171.94319947953642)
+
     _test_dihedral(p1, p4, p5, p6, 60.82226735264638)
+    _test_dihedral(p6, p5, p4, p1, 60.82226735264638)
+
     _test_dihedral(p1, p4, p5, p7, -177.63641151521261)
+    _test_dihedral(p7, p5, p4, p1, -177.63641151521261)
 
 
 def test_auto_gen_doc(doc_fixture):
@@ -240,25 +248,22 @@ def test_auto_gen_doc_delete(doc_fixture):
 
 @pytest.mark.parametrize("obj", [
     5,
-    1.11111111111111,
+    1.11111,
     "hello",
     "\u0394",
     np.random.rand(4),
     {"a": 5},
     {"a": 1.111111111111},
     {"a": "hello"},
-    {"a": np.random.rand(4), "b": np.array(5), "c": np.array("hello")},
+    {"a": np.random.rand(4), "b": np.array(5.1111111), "c": np.array("hello")},
+    ["12345"],
     ["hello", "world"],
     [5, 123.234, "abcdé", "\u0394", "\U00000394"],
     [5, "B63", np.random.rand(4)],
     ["abcdé", {"a": np.random.rand(2), "b": np.random.rand(5)}],
-    [np.array(3), np.arange(3, dtype=np.uint16), np.array(["a", "b"])],
-])
-@pytest.mark.parametrize("encoding", [
-    "json",
-    "json-ext",
-    pytest.param("msgpack-ext", marks=using_msgpack),
-])
+    [np.array(3), np.arange(3, dtype=np.uint16), {"b": np.array(["a", "b"])}],
+]) # yapf: disable
+@pytest.mark.parametrize("encoding", serialize_extensions)
 def test_serialization(obj, encoding):
     new_obj = qcel.util.deserialize(qcel.util.serialize(obj, encoding=encoding), encoding=encoding)
     assert compare_recursive(obj, new_obj)

--- a/qcelemental/tests/test_utils.py
+++ b/qcelemental/tests/test_utils.py
@@ -6,7 +6,7 @@ from typing import Optional, Union, List, Tuple, Dict, Any
 import qcelemental as qcel
 from qcelemental.testing import compare_recursive, compare_values
 
-from .addons import serialize_extensions, using_msgpack
+from .addons import serialize_extensions
 
 
 @pytest.fixture(scope="function")

--- a/qcelemental/tests/test_utils.py
+++ b/qcelemental/tests/test_utils.py
@@ -3,9 +3,10 @@ import pytest
 from pydantic import BaseModel, Schema
 from typing import Optional, Union, List, Tuple, Dict, Any
 
-import qcelemental
+import qcelemental as qcel
 from qcelemental.testing import compare_recursive, compare_values
 
+from .addons import using_msgpack
 
 @pytest.fixture(scope="function")
 def doc_fixture():
@@ -59,7 +60,7 @@ def doc_fixture():
     (['ABBCcAD', str.lower], 'ABCD'),
 ])
 def test_unique_everseen(inp, expected):
-    ue = qcelemental.util.unique_everseen(*inp)
+    ue = qcel.util.unique_everseen(*inp)
     assert list(ue) == list(expected)
 
 
@@ -69,7 +70,7 @@ def test_unique_everseen(inp, expected):
     (({1: [None, 1]}, {1: [2, 1],3:{"d":"D"}}), {1:[2, 1], 3:{"d":"D"}})
 ]) # yapf: disable
 def test_updatewitherror(inp, expected):
-    assert compare_recursive(expected, qcelemental.util.update_with_error(inp[0], inp[1]))
+    assert compare_recursive(expected, qcel.util.update_with_error(inp[0], inp[1]))
 
 
 @pytest.mark.parametrize("inp", [
@@ -79,7 +80,7 @@ def test_updatewitherror(inp, expected):
 ]) # yapf: disable
 def test_updatewitherror_error(inp):
     with pytest.raises(KeyError):
-        qcelemental.util.update_with_error(inp[0], inp[1])
+        qcel.util.update_with_error(inp[0], inp[1])
 
 
 @pytest.mark.parametrize("inp,expected", [
@@ -97,12 +98,12 @@ def test_updatewitherror_error(inp):
     ({'dicary': {"a": np.arange(2), "e": ["mouse", [np.arange(4).reshape(2, 2), {"f": np.arange(6).reshape(2, 3), "g": [[11], [12]]}]]}, 'flat': True}, {"a": [0, 1], "e": ["mouse", [[0, 1, 2, 3], {"f": [0, 1, 2, 3, 4, 5], "g": [[11], [12]]}]]}),
 ]) # yapf: disable
 def test_unnp(inp, expected):
-    assert compare_recursive(expected, qcelemental.util.unnp(**inp), atol=1.e-4)
+    assert compare_recursive(expected, qcel.util.unnp(**inp), atol=1.e-4)
 
 
 def test_distance():
     def _test_distance(p1, p2, value):
-        tmp = qcelemental.util.compute_distance(p1, p2)
+        tmp = qcel.util.compute_distance(p1, p2)
         assert compare_values(value, float(tmp))
 
     _test_distance([0, 0, 0], [0, 0, 1], 1.0)
@@ -111,13 +112,13 @@ def test_distance():
     tmp1 = np.random.rand(20, 3) * 4
     tmp2 = np.random.rand(20, 3) * 4
     np_dist = np.linalg.norm(tmp1 - tmp2, axis=1)
-    ee_dist = qcelemental.util.compute_distance(tmp1, tmp2)
+    ee_dist = qcel.util.compute_distance(tmp1, tmp2)
     assert np.allclose(np_dist, ee_dist)
 
 
 def test_angle():
     def _test_angle(p1, p2, p3, value, degrees=True):
-        tmp = qcelemental.util.compute_angle(p1, p2, p3, degrees=degrees)
+        tmp = qcel.util.compute_angle(p1, p2, p3, degrees=degrees)
         assert compare_values(value, float(tmp))
 
     # Check all 90 degree domains
@@ -151,7 +152,7 @@ def test_angle():
 
 def test_dihedral1():
     def _test_dihedral(p1, p2, p3, p4, value, degrees=True):
-        tmp = qcelemental.util.compute_dihedral(p1, p2, p3, p4, degrees=degrees)
+        tmp = qcel.util.compute_dihedral(p1, p2, p3, p4, degrees=degrees)
         assert compare_values(value, float(tmp), label="test_dihedral1")
 
     p1 = [0, 0, 0]
@@ -188,7 +189,7 @@ def test_dihedral2():
     # FROM: https://stackoverflow.com/questions/20305272/
 
     def _test_dihedral(p1, p2, p3, p4, value, degrees=True):
-        tmp = qcelemental.util.compute_dihedral(p1, p2, p3, p4, degrees=degrees)
+        tmp = qcel.util.compute_dihedral(p1, p2, p3, p4, degrees=degrees)
         assert compare_values(value, float(tmp), label="test_dihedral1")
 
     p0 = [24.969, 13.428, 30.692]
@@ -235,3 +236,29 @@ def test_auto_gen_doc_delete(doc_fixture):
     del doc_fixture.__doc__
     assert "this is complicated" not in doc_fixture.__doc__
     assert "A Pydantic model" in doc_fixture.__doc__
+
+
+@pytest.mark.parametrize("obj", [
+    5,
+    1.11111111111111,
+    "hello",
+    "\u0394",
+    np.random.rand(4),
+    {"a": 5},
+    {"a": 1.111111111111},
+    {"a": "hello"},
+    {"a": np.random.rand(4), "b": np.array(5), "c": np.array("hello")},
+    ["hello", "world"],
+    [5, 123.234, "abcdé", "\u0394", "\U00000394"],
+    [5, "B63", np.random.rand(4)],
+    ["abcdé", {"a": np.random.rand(2), "b": np.random.rand(5)}],
+    [np.array(3), np.arange(3, dtype=np.uint16), np.array(["a", "b"])],
+])
+@pytest.mark.parametrize("encoding", [
+    "json",
+    "json-ext",
+    pytest.param("msgpack-ext", marks=using_msgpack),
+])
+def test_serialization(obj, encoding):
+    new_obj = qcel.util.deserialize(qcel.util.serialize(obj, encoding=encoding), encoding=encoding)
+    assert compare_recursive(obj, new_obj)

--- a/qcelemental/util/__init__.py
+++ b/qcelemental/util/__init__.py
@@ -1,13 +1,13 @@
-from .np_blockwise import blockwise_expand, blockwise_contract
-from .np_rand3drot import random_rotation_matrix
-from .scipy_hungarian import linear_sum_assignment
+from .autodocs import auto_gen_docs_on_demand, get_base_docs
 from .gph_uno_bipartite import uno
-#from .mpl import plot_coord
-from .misc import (distance_matrix, update_with_error, standardize_efp_angles_units, filter_comments, unnp,
-                   compute_distance, compute_angle, compute_dihedral, measure_coordinates)
+from .importing import parse_version, safe_version, which, which_import
 from .internal import provenance_stamp
 from .itertools import unique_everseen
-from .importing import parse_version, safe_version, which, which_import
-
-from .autodocs import auto_gen_docs_on_demand, get_base_docs
-from .serialization import msgpackext_dumps, msgpackext_loads, jsonext_dumps, jsonext_loads, json_dumps, json_loads, serialize, deserialize
+#from .mpl import plot_coord
+from .misc import (compute_angle, compute_dihedral, compute_distance, distance_matrix, filter_comments,
+                   measure_coordinates, standardize_efp_angles_units, unnp, update_with_error)
+from .np_blockwise import blockwise_contract, blockwise_expand
+from .np_rand3drot import random_rotation_matrix
+from .scipy_hungarian import linear_sum_assignment
+from .serialization import (deserialize, json_dumps, json_loads, jsonext_dumps, jsonext_loads, msgpackext_dumps,
+                            msgpackext_loads, serialize)

--- a/qcelemental/util/__init__.py
+++ b/qcelemental/util/__init__.py
@@ -9,5 +9,5 @@ from .internal import provenance_stamp
 from .itertools import unique_everseen
 from .importing import parse_version, safe_version, which, which_import
 
-from .serialization import msgpack_dumps, msgpack_loads
 from .autodocs import auto_gen_docs_on_demand, get_base_docs
+from .serialization import msgpackext_dumps, msgpackext_loads, jsonext_dumps, jsonext_loads, json_dumps, json_loads, serialize, deserialize

--- a/qcelemental/util/gph_uno_bipartite.py
+++ b/qcelemental/util/gph_uno_bipartite.py
@@ -15,7 +15,6 @@ Updated Dec 2017 LAB for pep8, py3, more tests, starter_match, and simpler inter
 """
 import numpy as np
 
-
 # commented as untested [Apr 2019]
 #def _plotGraph(graph):
 #    """Plot graph using nodes as position number."""

--- a/qcelemental/util/serialization.py
+++ b/qcelemental/util/serialization.py
@@ -1,7 +1,8 @@
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import numpy as np
 from pydantic.json import pydantic_encoder
+import json
 
 from .importing import which_import
 
@@ -12,8 +13,10 @@ except ModuleNotFoundError:
 
 _msgpack_which_msg = "Please install via `conda install msgpack-python`."
 
+## MSGPackExt
 
-def msgpack_encode(obj: Any) -> Any:
+
+def msgpackext_encode(obj: Any) -> Any:
     """
     Encodes an object using pydantic and NumPy array serialization techniques suitable for msgpack.
 
@@ -48,7 +51,7 @@ def msgpack_encode(obj: Any) -> Any:
     return obj
 
 
-def msgpack_decode(obj: Any) -> Any:
+def msgpackext_decode(obj: Any) -> Any:
     """
     Decodes a msgpack objects from a dictionary representation.
 
@@ -73,13 +76,14 @@ def msgpack_decode(obj: Any) -> Any:
     return obj
 
 
-def msgpack_dumps(data: Dict[str, Any]) -> bytes:
-    """Safe serialization of a Python dictionary to msgpack binary representation using all known encoders.
+def msgpackext_dumps(data: Any) -> bytes:
+    """Safe serialization of a Python object to msgpack binary representation using all known encoders.
+    For NumPy, encodes a specialized object format to encode all shape and type data.
 
     Parameters
     ----------
-    data : Dict[str, Any]
-        A encodable dictionary.
+    data : Any
+        A encodable python object.
 
     Returns
     -------
@@ -88,10 +92,10 @@ def msgpack_dumps(data: Dict[str, Any]) -> bytes:
     """
     which_import("msgpack", raise_error=True, raise_msg=_msgpack_which_msg)
 
-    return msgpack.dumps(data, default=msgpack_encode, use_bin_type=True)
+    return msgpack.dumps(data, default=msgpackext_encode, use_bin_type=True)
 
 
-def msgpack_loads(data: bytes) -> Dict[str, Any]:
+def msgpackext_loads(data: bytes) -> Any:
     """Deserializes a msgpack byte representation of known objects into those objects.
 
     Parameters
@@ -101,9 +105,187 @@ def msgpack_loads(data: bytes) -> Dict[str, Any]:
 
     Returns
     -------
-    Dict[str, Any]
-        A dictionary of objects.
+    Any
+        The deserialized Python objects.
     """
     which_import("msgpack", raise_error=True, raise_msg=_msgpack_which_msg)
 
-    return msgpack.loads(data, object_hook=msgpack_decode, raw=False)
+    return msgpack.loads(data, object_hook=msgpackext_decode, raw=False)
+
+
+## JSON Ext
+
+
+class JSONExtArrayEncoder(json.JSONEncoder):
+    def default(self, obj: Any) -> Any:
+        try:
+            return pydantic_encoder(obj)
+        except TypeError:
+            pass
+
+        if isinstance(obj, np.ndarray):
+            if obj.shape:
+                data = {"_nd_": True, "dtype": obj.dtype.str, "data": np.ascontiguousarray(obj).tobytes().hex()}
+                if len(obj.shape) > 1:
+                    data[b'shape'] = obj.shape
+                return data
+
+            else:
+                # Converts np.array(5) -> 5
+                return obj.tolist()
+
+        return json.JSONEncoder.default(self, obj)
+
+
+def jsonext_decode(obj: Any) -> Any:
+
+    if "_nd_" in obj:
+        arr = np.frombuffer(bytes.fromhex(obj["data"]), dtype=obj["dtype"])
+        if "shape" in obj:
+            arr.shape = obj["shape"]
+
+        return arr
+
+    return obj
+
+
+def jsonext_dumps(data: Any) -> str:
+    """Safe serialization of Python objects to JSON string representation using all known encoders.
+    The JSON serializer uses a custom array syntax rather than flat JSON lists.
+
+    Parameters
+    ----------
+    data : Dict[str, Any]
+        A encodable python object.
+
+    Returns
+    -------
+    bytes
+        A JSON representation of the data.
+    """
+
+    return json.dumps(data, cls=JSONExtArrayEncoder)
+
+
+def jsonext_loads(data: str) -> Any:
+    """Deserializes a json representation of known objects into those objects.
+
+    Parameters
+    ----------
+    data : str
+        The serialized JSON blob.
+
+    Returns
+    -------
+    Any
+        The deserialized Python objects.
+    """
+
+    return json.loads(data, object_hook=jsonext_decode)
+
+
+## JSON
+
+
+class JSONArrayEncoder(json.JSONEncoder):
+    def default(self, obj: Any) -> Any:
+        try:
+            return pydantic_encoder(obj)
+        except TypeError:
+            pass
+
+        if isinstance(obj, np.ndarray):
+            if obj.shape:
+                return obj.ravel().tolist()
+            else:
+                return obj.tolist()
+
+        return json.JSONEncoder.default(self, obj)
+
+
+def json_dumps(data: Any) -> str:
+    """Safe serialization of a Python dictionary to JSON string representation using all known encoders.
+
+    Parameters
+    ----------
+    data : Any
+        A encodable python object.
+
+    Returns
+    -------
+    str
+        A JSON representation of the data.
+    """
+
+    return json.dumps(data, cls=JSONArrayEncoder)
+
+
+def json_loads(data: str) -> Any:
+    """Deserializes a json representation of known objects into those objects.
+
+    Parameters
+    ----------
+    data : str
+        The serialized JSON blob.
+
+    Returns
+    -------
+    Any
+        The deserialized Python objects.
+    """
+
+    return json.loads(data)
+
+
+## Helper functions
+
+
+def serialize(data: Any, encoding: str) -> Union[str, bytes]:
+    """Encoding Python objects using the provided encoder.
+
+    Parameters
+    ----------
+    data : Any
+        A encodable python object.
+    encoding : str
+        The type of encoding to perform: {'json', 'json-ext', 'msgpack'}
+
+    Returns
+    -------
+    Union[str, bytes]
+        A serialized representation of the data.
+
+    """
+    if encoding.lower() == "json":
+        return json_dumps(data)
+    elif encoding.lower() == "json-ext":
+        return jsonext_dumps(data)
+    elif encoding.lower() == "msgpack-ext":
+        return msgpackext_dumps(data)
+    else:
+        raise KeyError(f"Encoding '{encoding}' not understood, valid options: 'json', 'json-ext', 'msgpack-ext'")
+
+
+def deserialize(blob: Union[str, bytes], encoding: str) -> Any:
+    """Encoding Python objects using .
+
+    Parameters
+    ----------
+    blob : Union[str, bytes]
+        The serialized data.
+    encoding : str
+        The type of encoding of the blob: {'json', 'json-ext', 'msgpack'}
+
+    Returns
+    -------
+    Any
+        The deserialized Python objects.
+    """
+    if encoding.lower() == "json":
+        return json_loads(blob)
+    elif encoding.lower() == "json-ext":
+        return jsonext_loads(blob)
+    elif encoding.lower() == "msgpack-ext":
+        return msgpackext_loads(blob)
+    else:
+        raise KeyError(f"Encoding '{encoding}' not understood, valid options: 'json', 'json-ext', 'msgpack-ext'")

--- a/qcelemental/util/serialization.py
+++ b/qcelemental/util/serialization.py
@@ -1,8 +1,8 @@
+import json
 from typing import Any, Dict, Union
 
 import numpy as np
 from pydantic.json import pydantic_encoder
-import json
 
 from .importing import which_import
 
@@ -127,7 +127,7 @@ class JSONExtArrayEncoder(json.JSONEncoder):
             if obj.shape:
                 data = {"_nd_": True, "dtype": obj.dtype.str, "data": np.ascontiguousarray(obj).tobytes().hex()}
                 if len(obj.shape) > 1:
-                    data[b'shape'] = obj.shape
+                    data['shape'] = obj.shape
                 return data
 
             else:
@@ -155,12 +155,12 @@ def jsonext_dumps(data: Any) -> str:
 
     Parameters
     ----------
-    data : Dict[str, Any]
+    data : Any
         A encodable python object.
 
     Returns
     -------
-    bytes
+    str
         A JSON representation of the data.
     """
 

--- a/qcelemental/util/serialization.py
+++ b/qcelemental/util/serialization.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Union
+from typing import Any, Union
 
 import numpy as np
 from pydantic.json import pydantic_encoder
@@ -234,7 +234,8 @@ def json_loads(data: str) -> Any:
         The deserialized Python objects.
     """
 
-    return json.loads(data)
+    # Doesn't hurt anything to try to load JSONext as well
+    return json.loads(data, object_hook=jsonext_decode)
 
 
 ## Helper functions
@@ -285,7 +286,7 @@ def deserialize(blob: Union[str, bytes], encoding: str) -> Any:
         return json_loads(blob)
     elif encoding.lower() == "json-ext":
         return jsonext_loads(blob)
-    elif encoding.lower() == "msgpack-ext":
+    elif encoding.lower() in ["msgpack", "msgpack-ext"]:
         return msgpackext_loads(blob)
     else:
         raise KeyError(f"Encoding '{encoding}' not understood, valid options: 'json', 'json-ext', 'msgpack-ext'")

--- a/qcelemental/util/test_gph_uno_bipartite.py
+++ b/qcelemental/util/test_gph_uno_bipartite.py
@@ -3,9 +3,10 @@
 # * AmbiguousSolution errors seem to have cropped up, though not in the alignment usage.
 
 import pytest
-from ..tests.addons import using_networkx, using_scipy
 
-from qcelemental.util.gph_uno_bipartite import uno, _enumMaximumMatching, _enumMaximumMatching2
+from qcelemental.util.gph_uno_bipartite import _enumMaximumMatching, _enumMaximumMatching2, uno
+
+from ..tests.addons import using_networkx, using_scipy
 
 
 @using_networkx

--- a/qcelemental/util/test_scipy_hungarian.py
+++ b/qcelemental/util/test_scipy_hungarian.py
@@ -7,10 +7,9 @@
 # Author: Brian M. Clapper, G. Varoquaux, Lars Buitinck
 # License: BSD
 
+import numpy as np
 from numpy.testing import assert_array_equal
 from pytest import raises as assert_raises
-
-import numpy as np
 
 from qcelemental.util.scipy_hungarian import linear_sum_assignment
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
         package_data={'': [os.path.join('qcelemental', 'data', '*.json')]},
         setup_requires=[] + pytest_runner,
         python_requires='>=3.6',
-        install_requires=['numpy', 'pint', 'pydantic >= 0.30.1'],
+        install_requires=['numpy', 'pint', 'pydantic >= 0.32'],
         extras_require={
             'docs': [
                 'numpydoc',


### PR DESCRIPTION
This bumps pydantic to v0.32 as the latest release and also ensure that molecules built from Schema go through validators. The validator issue is subtle, but important where the Molecule rounding definitions must be applied even though that is formally not in the schema. I figure from a file can be slow(er) than from memory and keeps this simple.