### PR TITLE
Fix doc builds for LRU Cache wrapped function

### DIFF
--- a/docs/source/physconst.rst
+++ b/docs/source/physconst.rst
@@ -144,7 +144,10 @@ Top level user functions:
 Function Definitions
 --------------------
 
-.. autofunction:: conversion_factor
+.. note:: ``conversion_factor`` is a function, not a class, but cannot be documented in Sphinx as such
+           due to the way the LRU Cache wraps it. Please disregard the marking of it being a "class."
+
+.. autoclass:: conversion_factor
 
 .. autofunction:: get
 


### PR DESCRIPTION
This imperfect fix lets the docs continue building once again, they have not been building since #86 due to the LRU cache.

Near as I can tell, if you try to call Sphinx `autofunction` on a `functools.lru_cache` wrapped function, Sphinx cannot properly detect that it is a function since its now technically a class?

Either way, you get this error which blocks the build:

```
AttributeError: 'functools._lru_cache_wrapper' object has no attribute '__code__'
```

If you try to `autoclass` it however, it works fine, but the rendered automatic documentation is a bit off. So for now I added a note about the discrepancy, made the imperfect fix, and moved on.

This also appears to be [a known problem](https://groups.google.com/forum/#!topic/dev-python/IpweOZNwRg0), however, this is also beyond the scope of things for us to fix as this is 100% a Sphinx-related issue, not a bug in our code