### PR TITLE
Cherry-pick for 0.6.1: NumPy: Calls top level functions and not core C functions

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,15 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
+0.6.1 / 2019-08-19
+------------------
+
+Bug Fixes
++++++++++
+
+- (:pr:`114`) The Numpy einsum calls reference the top level functions and not core C functions. This fixes an issue
+  which can result in NumPy version dependencies.
+
 0.6.0 / 2019-08-14
 ------------------
 

--- a/qcelemental/molparse/from_arrays.py
+++ b/qcelemental/molparse/from_arrays.py
@@ -586,7 +586,7 @@ def validate_and_fill_geometry(geom=None, tooclose=0.1, copy=True):
     tooclose_inds = []
     for x in range(npgeom.shape[0]):
         diffs = npgeom[x] - npgeom[x+1:]
-        dists = np.core._multiarray_umath.c_einsum('ij,ij->i', diffs, diffs)
+        dists = np.einsum('ij,ij->i', diffs, diffs)
 
         # Record issues
         if np.any(dists < metric):


### PR DESCRIPTION
Candidate for 0.6.1 based on cherry-pick of #114 from the 0.6.0 tag