### PR TITLE
Update master docs for 0.6.1

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,15 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
+0.6.1 / 2019-08-19
+------------------
+
+Bug Fixes
++++++++++
+
+- (:pr:`114`) The Numpy einsum calls reference the top level functions and not core C functions. This fixes an issue
+  which can result in NumPy version dependencies.
+
 0.6.0 / 2019-08-14
 ------------------
 


### PR DESCRIPTION
This keeps the change log in sync on 1 location. I can't just make a
PR from the cherry-pick maintenance branch since it tries to make the
cherry-pick change on top of it.

Still working out order-of-operations. I think it may be good to make the doc change in `master`, and cherry-pick the docs as well as the code.