### PR TITLE
Models Repr

### DIFF
--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -17,6 +17,7 @@ class ProtoModel(BaseModel):
         serialize_default_excludes = set()
         serialize_skip_defaults = False
         force_skip_defaults = False
+        canonical_repr = False
 
     @classmethod
     def parse_raw(cls, data: Union[bytes, str], *, encoding: str = None) -> 'Model':
@@ -146,5 +147,9 @@ class ProtoModel(BaseModel):
         """
         return compare_recursive(self, other, **kwargs)
 
-    def to_string(self):  # lgtm [py/inheritance/incorrect-overridden-signature]
-        return f"{self.__class__.__name__}(ProtoModel)"
+
+    def __str__(self) -> str:
+        if self.__config__.canonical_repr:
+            return super().to_string()
+        else:
+            return f"{self.__class__.__name__}(ProtoModel)"

--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -147,4 +147,4 @@ class ProtoModel(BaseModel):
         return compare_recursive(self, other, **kwargs)
 
     def to_string(self):  # lgtm [py/inheritance/incorrect-overridden-signature]
-        return f"{self.__class__.__name__}"
+        return f"{self.__class__.__name__}(ProtoModel)"

--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -16,6 +16,7 @@ class ProtoModel(BaseModel):
         json_encoders = {np.ndarray: lambda v: v.flatten().tolist()}
         serialize_default_excludes = set()
         serialize_skip_defaults = False
+        force_skip_defaults = False
 
     @classmethod
     def parse_raw(cls, data: Union[bytes, str], *, encoding: str = None) -> 'Model':
@@ -88,6 +89,9 @@ class ProtoModel(BaseModel):
 
         kwargs["exclude"] = (kwargs.get("exclude", None) or set()) | self.__config__.serialize_default_excludes
         kwargs.setdefault("skip_defaults", self.__config__.serialize_skip_defaults)
+        if self.__config__.force_skip_defaults:
+            kwargs["skip_defaults"] = True
+
         data = super().dict(*args, **kwargs)
 
         if encoding is None:

--- a/qcelemental/models/common_models.py
+++ b/qcelemental/models/common_models.py
@@ -16,6 +16,7 @@ class Provenance(ProtoModel):
     routine: Optional[str] = None
 
     class Config(ProtoModel.Config):
+        canonical_repr = True
         extra = "allow"
 
 
@@ -36,6 +37,7 @@ class Model(ProtoModel):
     # basis_spec: BasisSpec = None  # This should be exclusive with basis, but for now will be omitted
 
     class Config(ProtoModel.Config):
+        canonical_repr = True
         extra = "allow"
 
 
@@ -69,11 +71,15 @@ class ComputeError(ProtoModel):
         description="Additional data to ship with the ComputeError object."
     )
 
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}(error_type={self.error_type} error_message:\n{self.error_message}\n)"
+
+
 class FailedOperation(ProtoModel):
     """
     A record indicating that a given operation (compute, procedure, etc.) has failed and contains the reason and
     input data which generated the failure.
-    
+
     """
     id: str = Schema(
         None,
@@ -101,6 +107,9 @@ class FailedOperation(ProtoModel):
         description="Additional information to bundle with this Failed Operation. Details which pertain specifically "
                     "to a thrown error should be contained in the `error` field. See :class:`ComputeError` for details."
     )
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}(error={self.error})"
 
 
 qcschema_input_default = "qcschema_input"

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -845,7 +845,6 @@ class Molecule(ProtoModel):
         elif dtype in ["numpy"]:
             elements = np.array(self.atomic_numbers).reshape(-1, 1)
             npmol = np.hstack((elements, self.geometry * constants.conversion_factor("bohr", "angstroms")))
-
             np.save(filename, npmol)
             return
 
@@ -903,13 +902,13 @@ class Molecule(ProtoModel):
                 break
         return new_geometry
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.pretty_print()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self.__class__.__name__}(name='{self.name}' formula='{self.get_molecular_formula()}' hash='{self.get_hash()[:7]}')>"
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         try:
             return self.show()._repr_html_()
         except ModuleNotFoundError:

--- a/qcelemental/models/procedures.py
+++ b/qcelemental/models/procedures.py
@@ -36,6 +36,9 @@ class OptimizationInput(ProtoModel):
 
     provenance: Provenance = provenance_stamp(__name__)
 
+    def __str__(self):
+        return f"{self.__class__.__name__}(model='{self.input_specification.model.dict()}' molecule_hash='{self.initial_molecule.get_hash()[:7]}')"
+
 
 class Optimization(OptimizationInput):
     schema_name: constr(strip_whitespace=True,

--- a/qcelemental/models/procedures.py
+++ b/qcelemental/models/procedures.py
@@ -36,7 +36,7 @@ class OptimizationInput(ProtoModel):
 
     provenance: Provenance = provenance_stamp(__name__)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.__class__.__name__}(model='{self.input_specification.model.dict()}' molecule_hash='{self.initial_molecule.get_hash()[:7]}')"
 
 

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -80,6 +80,9 @@ class ResultInput(ProtoModel):
 
     provenance: Provenance = provenance_stamp(__name__)
 
+    def __str__(self):
+        return f"{self.__class__.__name__}(driver='{self.driver}' model='{self.model.dict()}' molecule_hash='{self.molecule.get_hash()[:7]}')"
+
 
 class Result(ResultInput):
     schema_name: constr(strip_whitespace=True, regex=qcschema_output_default) = qcschema_output_default

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -61,6 +61,10 @@ class ResultProperties(ProtoModel):
     class Config(ProtoModel.Config):
         force_skip_defaults = True
 
+    def __str__(self):
+        data_str = ', '.join(f'{k}={v}' for k, v in self.dict().items())
+        return f"{self.__class__.__name__}({data_str})"
+
 
 ### Primary models
 

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -59,7 +59,7 @@ class ResultProperties(ProtoModel):
     ccsd_prt_pr_dipole_moment: Optional[List[float]] = None
 
     class Config(ProtoModel.Config):
-        serialize_skip_defaults = True
+        force_skip_defaults = True
 
 
 ### Primary models

--- a/qcelemental/tests/test_model_serials.py
+++ b/qcelemental/tests/test_model_serials.py
@@ -210,7 +210,6 @@ def test_default_skip():
 
 def test_default_repr():
     obj = ResultProperties(scf_one_electron_energy="-5.0")
-    assert len(obj.to_string()) < 100
     assert len(str(obj)) < 100
     assert len(repr(obj)) < 100
 

--- a/qcelemental/tests/test_model_serials.py
+++ b/qcelemental/tests/test_model_serials.py
@@ -5,7 +5,7 @@ import pytest
 from pydantic import ValidationError
 
 from qcelemental.models import (ComputeError, FailedOperation, Molecule, Optimization, OptimizationInput, ProtoModel,
-                                Result, ResultInput, ResultProperties)
+                                Provenance, Result, ResultInput, ResultProperties)
 from qcelemental.models.types import Array
 from qcelemental.util import provenance_stamp
 
@@ -213,3 +213,61 @@ def test_default_repr():
     assert len(obj.to_string()) < 100
     assert len(str(obj)) < 100
     assert len(repr(obj)) < 100
+
+
+def test_repr_provenance():
+
+    prov = Provenance(creator="qcel", version="v0.3.2")
+
+    assert "qcel" in str(prov)
+    assert "qcel" in repr(prov)
+
+
+def test_repr_compute_error():
+    ce = ComputeError(error_type="random_error", error_message="this is bad")
+
+    assert "random_error" in str(ce)
+    assert "random_error" in repr(ce)
+
+
+def test_repr_failed_op():
+    fail_op = FailedOperation(error=ComputeError(error_type="random_error", error_message="this is bad"))
+
+    assert "random_error" in str(fail_op)
+    assert "random_error" in repr(fail_op)
+
+
+def test_repr_result():
+
+    result = ResultInput(**{
+        "driver": "gradient",
+        "model": {
+            "method": "UFF"
+        },
+        "molecule": {
+            "symbols": ["He"],
+            "geometry": [0, 0, 0]
+        }
+    })
+    assert "UFF" in str(result)
+    assert "UFF" in repr(result)
+
+
+def test_repr_optimization():
+
+    opt = OptimizationInput(
+        **{
+            "input_specification": {
+                "driver": "gradient",
+                "model": {
+                    "method": "UFF"
+                },
+            },
+            "initial_molecule": {
+                "symbols": ["He"],
+                "geometry": [0, 0, 0]
+            }
+        })
+
+    assert "UFF" in str(opt)
+    assert "UFF" in repr(opt)


### PR DESCRIPTION
This PR attempts to give reasonable string representation for all models and ensure that skip_defaults are called on certain models to prevent the alteration of defaulted fields in downstream Pydantic uses.