### PR TITLE
better "extras" passing in Molecule for EFP

### DIFF
--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -235,7 +235,10 @@ class Molecule(ProtoModel):
             kwargs["schema_version"] = kwargs.pop("schema_version", 2)
             # original_keys = set(kwargs.keys())  # revive when ready to revisit sparsity
 
-            schema = to_schema(from_schema(kwargs), dtype=kwargs["schema_version"], copy=False, np_out=True)
+            schema = to_schema(from_schema(kwargs, missing_enabled_return='minimal'),
+                               dtype=kwargs["schema_version"],
+                               copy=False,
+                               np_out=True)
 
             kwargs["validated"] = True
             kwargs = {**kwargs, **schema}  # Allow any extra fields

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -724,9 +724,9 @@ class Molecule(ProtoModel):
                 raise TypeError("Input type not understood, please supply the 'dtype' kwarg.")
 
         if dtype in ["string", "psi4", "psi4+", "xyz", "xyz+"]:
-            mol_dict = from_string(data)
-            assert isinstance(mol_dict, dict)
-            input_dict = to_schema(mol_dict["qm"], dtype=2)
+            molrec = from_string(data, enable_qm=True, missing_enabled_return_qm='minimal')
+            assert isinstance(molrec, dict)
+            input_dict = to_schema(molrec["qm"], dtype=2)
             validate = True
         elif dtype == "numpy":
             data = np.asarray(data)

--- a/qcelemental/molparse/from_schema.py
+++ b/qcelemental/molparse/from_schema.py
@@ -7,7 +7,7 @@ from ..util import provenance_stamp
 from .from_arrays import from_arrays
 
 
-def from_schema(molschema, *, verbose: int = 1) -> Dict:
+def from_schema(molschema, *, missing_enabled_return: str = 'error', verbose: int = 1) -> Dict:
     """Construct molecule dictionary representation from non-Psi4 schema.
 
     Parameters
@@ -71,7 +71,7 @@ def from_schema(molschema, *, verbose: int = 1) -> Dict:
         provenance=ms.get('provenance', None),
         connectivity=ms.get('connectivity', None),
         domain='qm',
-        #missing_enabled_return=missing_enabled_return,
+        missing_enabled_return=missing_enabled_return,
         speclabel=False,
         #tooclose=tooclose,
         #zero_ghost_fragments=zero_ghost_fragments,

--- a/qcelemental/molparse/to_schema.py
+++ b/qcelemental/molparse/to_schema.py
@@ -94,6 +94,14 @@ def to_schema(molrec: Dict[str, Any],
         if 'connectivity' in molrec:
             molecule['connectivity'] = deepcopy(molrec['connectivity'])
 
+        # EFP extras
+        if 'fragment_files' in molrec:
+            molecule['extras'] = {
+                'fragment_files': molrec['fragment_files'],
+                'hint_types': molrec['hint_types'],
+                'geom_hints': molrec['geom_hints'],
+            }
+
         if dtype == 1:
             qcschema = {'schema_name': 'qcschema_input', 'schema_version': 1, 'molecule': molecule}
         elif dtype == 2:

--- a/qcelemental/tests/test_utils.py
+++ b/qcelemental/tests/test_utils.py
@@ -55,7 +55,8 @@ def test_unique_everseen(inp, expected):
 @pytest.mark.parametrize("inp,expected", [
     (({1:{"a":"A"},2:{"b":"B"}}, {2:{"c":"C"},3:{"d":"D"}}), {1:{"a":"A"},2:{"b":"B","c":"C"},3:{"d":"D"}}),
     (({1:{"a":"A"},2:{"b":"B","c":None}}, {2:{"c":"C"},3:{"d":"D"}}), {1:{"a":"A"},2:{"b":"B","c":"C"},3:{"d":"D"}}),
-    (({1: [None, 1]}, {1: [2, 1],3:{"d":"D"}}), {1:[2, 1], 3:{"d":"D"}})
+    (({1: [None, 1]}, {1: [2, 1],3:{"d":"D"}}), {1:[2, 1], 3:{"d":"D"}}),
+    (({1: True, 'extras':{'aa': [True]}}, {2: None, 'extras':{'bb': 5}}), {1: True, 2: None, 'extras':{'aa': [True], 'bb':5}}),
 ]) # yapf: disable
 def test_updatewitherror(inp, expected):
     assert compare_recursive(expected, qcel.util.update_with_error(inp[0], inp[1]))


### PR DESCRIPTION
- [x] the `enable_qm=True` isn't changing anything -- molparse parses QM aspects of the molecule string (`enable_efp=False` by default)
- [x] the `missing_enabled_return_qm='minimal'` bit is changing from the default (error) to (minimal). this can't do much at present as other things prevent an empty QM `models.Molecule` for the case of efp-only.
```missing_enabled_return : {'minimal', 'none', 'error'}
        What to do when an enabled domain is of zero-length? Respectively, return
        a fully valid but empty molrec, return empty dictionary, or throw error.
```
- [ ] Q: can we have a blank QM mol without throwing all QCA into consternation? The structure I'm working with for pure-efp is:
```
{
    'symbols': [],
    'geometry': [],
    'extras': {
        'efp_molecule': {
            'symbols': [...],  # filled in by pylibefp
            'geometry': [...],  # filled in by pylibefp
            'extras': {
                 'fragment_files': [...],  # filled in by user
                 'hint_types': [...],  # "
                 'geom_hints': [...],  # "
            }
        }
    }
}
```
- [ ] Q: the "# EFP extras" bit helps transmit data and works fine for now. But it brings up an issue with https://github.com/MolSSI/QCElemental/blob/master/qcelemental/models/molecule.py#L241 in that if both kwargs and schema contain non-conflicting leaves in `'extras'`, then one set is going to get dropped, probably to someone's surprise. may want to consider replacing with a recursive update, like [`update_with_error`](https://github.com/MolSSI/QCElemental/blob/master/qcelemental/util/misc.py#L22) without the error.
