### PR TITLE
Molpro: Writing the multiplicity

### DIFF
--- a/qcelemental/molparse/to_string.py
+++ b/qcelemental/molparse/to_string.py
@@ -187,7 +187,8 @@ def to_string(molrec: Dict,
             smol.append(ghost_line)
 
         smol.append(f"set,charge={molrec['molecular_charge']}")
-        smol.append(f"set,multiplicity={molrec['molecular_multiplicity']}")
+        # The Molpro "spin" is the multiplicity minus one
+        smol.append(f"set,spin={molrec['molecular_multiplicity']-1}")
 
     elif dtype == 'nwchem':
 

--- a/qcelemental/tests/test_molparse_to_string.py
+++ b/qcelemental/tests/test_molparse_to_string.py
@@ -119,7 +119,7 @@ H                    -2.000000000000     0.000000000000     0.000000000000
 }
 dummy,2
 set,charge=0.0
-set,multiplicity=3
+set,spin=2
 """,
 
 "ans2_molpro_ang": """{orient,noorient}
@@ -133,7 +133,7 @@ H                    -1.058354421340     0.000000000000     0.000000000000
 }
 dummy,2
 set,charge=0.0
-set,multiplicity=3
+set,spin=2
 """,
 
 }  # yapf: disable


### PR DESCRIPTION
- Changed how multiplicity is set in the Molpro input file so it is actually used by the program. 
- The previous way of setting was never used by the program (a default guess was used instead)