### PR TITLE
`which_import` now handles submodules correctly

### DIFF
--- a/qcelemental/util/importing.py
+++ b/qcelemental/util/importing.py
@@ -5,7 +5,7 @@ from typing import Union
 
 
 def which_import(module: str, *, return_bool: bool = False, raise_error: bool = False,
-                 raise_msg: str = None) -> Union[bool, None, str]:
+                 raise_msg: str = None, package: str = None) -> Union[bool, None, str]:
     """Tests to see if a Python module is available.
 
     Returns
@@ -23,10 +23,7 @@ def which_import(module: str, *, return_bool: bool = False, raise_error: bool = 
     """
     import importlib
 
-    try:
-        module_spec = importlib.util.find_spec(module)
-    except ModuleNotFoundError:
-        module_spec = None
+    module_spec = importlib.util.find_spec(module, package=package)
 
     if module_spec is None:
         if raise_error:

--- a/qcelemental/util/importing.py
+++ b/qcelemental/util/importing.py
@@ -22,7 +22,11 @@ def which_import(module: str, *, return_bool: bool = False, raise_error: bool = 
 
     """
     import importlib
-    module_spec = importlib.util.find_spec(module)
+
+    try:
+        module_spec = importlib.util.find_spec(module)
+    except ModuleNotFoundError:
+        module_spec = None
 
     if module_spec is None:
         if raise_error:


### PR DESCRIPTION
## Description

<strike>For checking if OpenMM exists in the environment, we need to feed
"simtk.openmm" to `importlib.util.find_spec`. This will work by actually
importing `simtk`, which in the case of OpenMM not being present raises
a `ModuleNotFoundError`.

This PR handles the case in which this `ModuleNotFoundError` is raised.</strike>

For checking if OpenMM exists in the environment, we need to feed "openmm" with `package="simtk"` to `importlib.util.find_spec`. This PR adds a new keyword arg `package` to `which_import` in order to pass this through to `find_spec`.

## Status
- [ ] Changelog updated
- [ ] Ready to go