### PR TITLE
NGLView Integration

### DIFF
--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -12,7 +12,7 @@ dependencies:
 
     # Optional depends
   - networkx
-  - py3dmol
+  - nglview
 
     # Testing
   - pytest>=4.0.0

--- a/docs/source/molecule.rst
+++ b/docs/source/molecule.rst
@@ -15,7 +15,7 @@ A Molecule can be created using the normal kwargs fashion as shown below:
 
 .. code-block:: python
 
-    >>> mol = qcel.models.Molecule(**{"symbols":["He"], "geometry": [0, 0, 0]})
+    >>> mol = qcel.models.Molecule(**{"symbols": ["He"], "geometry": [0, 0, 0]})
 
 In addition, there is the ``from_data`` attribute to create a molecule from standard strings:
 

--- a/qcelemental/covalent_radii.py
+++ b/qcelemental/covalent_radii.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from typing import Dict, Union
 
 from .datum import Datum, print_variables
-from .exceptions import DataUnavailableError
+from .exceptions import DataUnavailableError, NotAnElementError
 from .periodic_table import periodictable
 
 
@@ -113,6 +113,11 @@ class CovalentRadii:
         if atom in self.cr.keys():
             # catch extra labels like 'C_sp3'
             identifier = atom
+        elif missing:
+            try:
+                identifier = periodictable.to_E(atom)
+            except NotAnElementError:
+                identifier = atom
         else:
             identifier = periodictable.to_E(atom)
 

--- a/qcelemental/covalent_radii.py
+++ b/qcelemental/covalent_radii.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from typing import Dict, Union
 
 from .datum import Datum, print_variables
-from .exceptions import DataUnavailableError, NotAnElementError
+from .exceptions import DataUnavailableError
 from .periodic_table import periodictable
 
 
@@ -113,11 +113,6 @@ class CovalentRadii:
         if atom in self.cr.keys():
             # catch extra labels like 'C_sp3'
             identifier = atom
-        elif missing:
-            try:
-                identifier = periodictable.to_E(atom)
-            except NotAnElementError:
-                identifier = atom
         else:
             identifier = periodictable.to_E(atom)
 

--- a/qcelemental/molparse/to_string.py
+++ b/qcelemental/molparse/to_string.py
@@ -70,7 +70,7 @@ def to_string(molrec: Dict,
 
     default_units = {
         "xyz": "Angstrom",
-        "sdf": "Angstrom",
+        "nsglview-sdf": "Angstrom",
         "cfour": "Bohr",
         "gamess": "Bohr",
         "molpro": "Bohr",
@@ -307,7 +307,7 @@ def to_string(molrec: Dict,
 
         smol = ["$coord"] + atoms + ["$end"]
 
-    elif dtype == 'sdf':
+    elif dtype == 'nsglview-sdf':
         # SDF is pretty special, handle it manually
 
         if units.capitalize() != "Angstrom":

--- a/qcelemental/molparse/to_string.py
+++ b/qcelemental/molparse/to_string.py
@@ -70,7 +70,7 @@ def to_string(molrec: Dict,
 
     default_units = {
         "xyz": "Angstrom",
-        "nsglview-sdf": "Angstrom",
+        "nglview-sdf": "Angstrom",
         "cfour": "Bohr",
         "gamess": "Bohr",
         "molpro": "Bohr",
@@ -307,7 +307,7 @@ def to_string(molrec: Dict,
 
         smol = ["$coord"] + atoms + ["$end"]
 
-    elif dtype == 'nsglview-sdf':
+    elif dtype == 'nglview-sdf':
         # SDF is pretty special, handle it manually
 
         if units.capitalize() != "Angstrom":

--- a/qcelemental/molparse/to_string.py
+++ b/qcelemental/molparse/to_string.py
@@ -69,6 +69,7 @@ def to_string(molrec: Dict,
 
     default_units = {
         "xyz": "Angstrom",
+        "sdf": "Angstrom",
         "cfour": "Bohr",
         "gamess": "Bohr",
         "molpro": "Bohr",
@@ -305,6 +306,38 @@ def to_string(molrec: Dict,
 
         smol = ["$coord"] + atoms + ["$end"]
 
+    elif dtype == 'sdf':
+        # SDF is pretty special, handle it manually
+
+        if units.capitalize() != "Angstrom":
+            raise ValueError("SDF Format must be in Angstroms")
+
+        connectivity = []
+        real = [bool(x) for x in molrec["real"]]
+
+        # Snip out connectivity that is not real
+        if np.any(np.logical_not(molrec["real"])):
+            new_con = []
+            for a1, a2, b in connectivity:
+                if (real[a1] is False) or (real[a2] is False):
+                    continue
+
+                new_con.append((a1, a2, b))
+            connectivity = new_con
+
+
+        smol = []
+        smol.append("")
+        smol.append("QCElemental\n")
+        smol.append(f"{sum(real):3d} {len(connectivity):2d}  0  0  0  0  0  0  0  0  0")
+        for real, sym, xyz in zip(molrec["real"], molrec["elem"], geom):
+            if bool(real) is False:
+                continue
+            smol.append(f"   {xyz[0]: .4f}   {xyz[1]: .4f}   {xyz[2]: .4f} {sym:2s}  0  0     0  0  0  0  0  0")
+
+        for a1, a2, b in connectivity:
+            smol.append(f" {(a1 + 1):2d} {(a2 + 1):2d}  {int(b):1d}  0  0  0  0")
+
     else:
         raise KeyError(f"dtype '{dtype}' not understood.")
 
@@ -337,7 +370,7 @@ def _atoms_formatter(molrec, geom, atom_format, ghost_format, width, prec, sp, x
             nuc = """{:{width}}""".format(atom_format.format(**atominfo), width=width)
             atom.append(nuc)
         else:
-            if ghost_format == '':
+            if ghost_format in ['', None]:
                 continue
             else:
                 nuc = """{:{width}}""".format(ghost_format.format(**atominfo), width=width)

--- a/qcelemental/molparse/to_string.py
+++ b/qcelemental/molparse/to_string.py
@@ -312,27 +312,15 @@ def to_string(molrec: Dict,
         if units.capitalize() != "Angstrom":
             raise ValueError("SDF Format must be in Angstroms")
 
-        connectivity = []
-        real = [bool(x) for x in molrec["real"]]
-
-        # Snip out connectivity that is not real
-        if np.any(np.logical_not(molrec["real"])):
-            new_con = []
-            for a1, a2, b in connectivity:
-                if (real[a1] is False) or (real[a2] is False):
-                    continue
-
-                new_con.append((a1, a2, b))
-            connectivity = new_con
-
+        connectivity = molrec.get("connectivity", [])
 
         smol = []
         smol.append("")
         smol.append("QCElemental\n")
-        smol.append(f"{sum(real):3d} {len(connectivity):2d}  0  0  0  0  0  0  0  0  0")
+        smol.append(f"{len(molrec['real']):3d} {len(connectivity):2d}  0  0  0  0  0  0  0  0  0")
         for real, sym, xyz in zip(molrec["real"], molrec["elem"], geom):
             if bool(real) is False:
-                continue
+                sym = "Zr"
             smol.append(f"   {xyz[0]: .4f}   {xyz[1]: .4f}   {xyz[2]: .4f} {sym:2s}  0  0     0  0  0  0  0  0")
 
         for a1, a2, b in connectivity:

--- a/qcelemental/molutil/__init__.py
+++ b/qcelemental/molutil/__init__.py
@@ -1,1 +1,2 @@
 from .align import B787, compute_scramble, kabsch_align
+from .connectivity import guess_connectivity

--- a/qcelemental/molutil/connectivity.py
+++ b/qcelemental/molutil/connectivity.py
@@ -1,7 +1,9 @@
+from typing import List, Optional, Tuple, Union
+
 import numpy as np
-from typing import List, Union, Tuple, Optional
 
 from ..covalent_radii import covalentradii
+from ..exceptions import NotAnElementError
 
 __all__ = ["guess_connectivity"]
 
@@ -33,7 +35,14 @@ def guess_connectivity(symbols: np.ndarray,
     """
 
     geometry = np.asarray(geometry, dtype=float).reshape(-1, 3)
-    radii = np.array([covalentradii.get(x, missing=1.8) for x in symbols])
+    radii = []
+    for s in symbols:
+        try:
+            radii.append(covalentradii.get(s, missing=1.8))
+        except NotAnElementError:
+            radii.append(1.8)
+
+    radii = np.array(radii)
 
     # Upper triangular
     con = []

--- a/qcelemental/molutil/connectivity.py
+++ b/qcelemental/molutil/connectivity.py
@@ -1,0 +1,54 @@
+import numpy as np
+from typing import List, Union, Tuple, Optional
+
+from ..covalent_radii import covalentradii
+
+__all__ = ["guess_connectivity"]
+
+
+def guess_connectivity(symbols: np.ndarray,
+                       geometry: np.ndarray,
+                       threshold: float = 1.2,
+                       default_connectivity: Optional[float] = None
+                       ) -> List[Union[Tuple[int, int], Tuple[int, int, float]]]:
+    """
+    Finds connected atoms based off of a covalent radii metric.
+
+    Parameters
+    ----------
+    symbols : np.ndarray
+        The molecular symbols (e.g., 'Zr', 'C')
+    geometry : np.ndarray
+        The molecular geometry in Bohr
+    threshold : float, optional
+        Tunes the covalent radii metric safety factor.
+    default_connectivity : Optional[float], optional
+        Provides a default connectivity value
+
+    Returns
+    -------
+    List[Union[Tuple[int, int], Tuple[int, int, float]]]
+        Provides a list of connected atoms, or optionally a list of
+        connected atoms and default connectivity if provided.
+    """
+
+    radii = np.array([covalentradii.get(x, missing=1.8) for x in symbols])
+
+    # Upper triangular
+    con = []
+    for x in range(geometry.shape[0]):
+        diffs = geometry[x] - geometry[x + 1:]
+        dists = np.einsum('ij,ij->i', diffs, diffs)
+        np.sqrt(dists, out=dists)
+
+        cutoff = (radii[x] + radii[x + 1:]) * threshold
+        where = np.where(dists < cutoff)[0]
+        where += x + 1
+
+        for atom2 in where:
+            con.append((x, atom2))
+
+    if default_connectivity:
+        con = [(x[0], x[1], default_connectivity) for x in con]
+
+    return con

--- a/qcelemental/molutil/connectivity.py
+++ b/qcelemental/molutil/connectivity.py
@@ -32,6 +32,7 @@ def guess_connectivity(symbols: np.ndarray,
         connected atoms and default connectivity if provided.
     """
 
+    geometry = np.asarray(geometry, dtype=float).reshape(-1, 3)
     radii = np.array([covalentradii.get(x, missing=1.8) for x in symbols])
 
     # Upper triangular

--- a/qcelemental/molutil/test_molutil.py
+++ b/qcelemental/molutil/test_molutil.py
@@ -554,3 +554,17 @@ def test_vector_gradient_align():
     assert compare_values(c4_hooh_dipder_x, p2c_dipder_x, atol=1.e-5)
     assert compare_values(c4_hooh_dipder_y, p2c_dipder_y, atol=1.e-5)
     assert compare_values(c4_hooh_dipder_z, p2c_dipder_z, atol=1.e-5)
+
+@pytest.mark.parametrize("args, kwargs, ans", [
+  ((["C", "C"], [0, 0, 0, 0, 0, 3]), {}, [(0, 1)]),
+  ((["C", "C"], [0, 0, 0, 0, 0, 3]), {"threshold": 4}, [(0, 1)]),
+  ((["C", "C"], [0, 0, 0, 0, 0, 10]), {}, []),
+  ((["C", "C"], [0, 0, 0, 0, 0, 2]), {"default_connectivity": 3}, [(0, 1, 3)]),
+  ((["C", "C", "C"], [0, 0, 0, 0, 0, 3, 0, 0, -3]), {}, [(0, 1), (0, 2)]),
+  ((["C", "Unknown"], [0, 0, 0, 0, 0, 3]), {}, [(0, 1)]),
+
+]) # yapf: disable
+def test_geuss_connectivity(args, kwargs, ans):
+
+    computed = qcel.molutil.guess_connectivity(*args, **kwargs)
+    assert compare(computed, ans)

--- a/qcelemental/molutil/test_molutil.py
+++ b/qcelemental/molutil/test_molutil.py
@@ -564,7 +564,7 @@ def test_vector_gradient_align():
   ((["C", "Unknown"], [0, 0, 0, 0, 0, 3]), {}, [(0, 1)]),
 
 ]) # yapf: disable
-def test_geuss_connectivity(args, kwargs, ans):
+def test_guess_connectivity(args, kwargs, ans):
 
     computed = qcel.molutil.guess_connectivity(*args, **kwargs)
     assert compare(computed, ans)

--- a/qcelemental/tests/addons.py
+++ b/qcelemental/tests/addons.py
@@ -27,8 +27,8 @@ using_scipy = pytest.mark.skipif(
     which_import('scipy', return_bool=True) is False,
     reason='Not detecting module scipy. Install package if necessary and add to envvar PYTHONPATH')
 
-using_py3dmol = pytest.mark.skipif(
-    which_import('py3Dmol', return_bool=True) is False,
+using_nglview = pytest.mark.skipif(
+    which_import('nglview', return_bool=True) is False,
     reason='Not detecting module py3Dmol. Install package if necessary and add to envvar PYTHONPATH')
 
 serialize_extensions = ["json", "json-ext", pytest.param("msgpack-ext", marks=using_msgpack)]

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -9,7 +9,7 @@ import qcelemental as qcel
 from qcelemental.models import Molecule
 from qcelemental.testing import compare, compare_values
 
-from .addons import serialize_extensions, using_msgpack, using_py3dmol
+from .addons import serialize_extensions, using_msgpack, using_nglview
 
 water_molecule = Molecule.from_data("""
     0 1
@@ -506,7 +506,7 @@ def test_nuclearrepulsionenergy_nelectrons():
     assert compare(10, mol.nelectrons(ifr=ifr1), 'M2')
 
 
-@using_py3dmol
+@using_nglview
 def test_show():
 
     water_dimer_minima.show()

--- a/qcelemental/tests/test_molparse_to_string.py
+++ b/qcelemental/tests/test_molparse_to_string.py
@@ -143,7 +143,7 @@ set,spin=2
 $end
 """,
 
-"ans2_sdf": """
+"ans2_ngslviewsdf": """
 QCElemental
 
   3  2  0  0  0  0  0  0  0  0  0
@@ -174,7 +174,7 @@ QCElemental
     (("subject2", {'dtype': 'molpro', 'units': 'bohr'}), "ans2_molpro_au"),
     (("subject2", {'dtype': 'molpro', 'units': 'angstrom'}), "ans2_molpro_ang"),
     (("subject2", {'dtype': 'turbomole', 'units': 'bohr'}), "ans2_turbomole_au"),
-    (("subject2", {'dtype': 'sdf'}), "ans2_sdf"),
+    (("subject2", {'dtype': 'nsglview-sdf'}), "ans2_ngslviewsdf"),
 ])  # yapf: disable
 def test_to_string_xyz(inp, expected):
     molrec = qcel.molparse.from_string(_results[inp[0]])
@@ -207,7 +207,7 @@ _molecule_inputs = {
 }
 
 _molecule_outputs = {
-    "ans1_sdf":
+    "ans1_ngslviewsdf":
     """
 QCElemental
 
@@ -218,7 +218,7 @@ QCElemental
   1  2  1  0  0  0  0
   1  3  1  0  0  0  0
 """,
-    "ans2_sdf":
+    "ans2_ngslviewsdf":
     """
 QCElemental
 
@@ -233,9 +233,9 @@ QCElemental
 
 
 @pytest.mark.parametrize("inp,kwargs,expected", [
-    ("subject1", {'dtype': 'sdf'}, "ans1_sdf"),
-    ("subject1_nocon", {'dtype': 'sdf'}, "ans1_sdf"),
-    ("subject2", {'dtype': 'sdf'}, "ans2_sdf")
+    ("subject1", {'dtype': 'nsglview-sdf'}, "ans1_ngslviewsdf"),
+    ("subject1_nocon", {'dtype': 'nsglview-sdf'}, "ans1_ngslviewsdf"),
+    ("subject2", {'dtype': 'nsglview-sdf'}, "ans2_ngslviewsdf")
 ])  # yapf: disable
 def test_molecule_to_string(inp, kwargs, expected):
 
@@ -254,7 +254,7 @@ def test_to_string_pint_error(inp):
         qcel.molparse.to_string(molrec['qm'], **inp[1])
 
 @pytest.mark.parametrize("inp", [
-    ("subject1", {'dtype': 'sdf', 'units': 'bohr'}),
+    ("subject1", {'dtype': 'nsglview-sdf', 'units': 'bohr'}),
 ])  # yapf: disable
 def test_to_string_value_error(inp):
     molrec = qcel.molparse.from_string(_results[inp[0]])

--- a/qcelemental/tests/test_molparse_to_string.py
+++ b/qcelemental/tests/test_molparse_to_string.py
@@ -174,7 +174,7 @@ QCElemental
     (("subject2", {'dtype': 'molpro', 'units': 'bohr'}), "ans2_molpro_au"),
     (("subject2", {'dtype': 'molpro', 'units': 'angstrom'}), "ans2_molpro_ang"),
     (("subject2", {'dtype': 'turbomole', 'units': 'bohr'}), "ans2_turbomole_au"),
-    (("subject2", {'dtype': 'nsglview-sdf'}), "ans2_ngslviewsdf"),
+    (("subject2", {'dtype': 'nglview-sdf'}), "ans2_ngslviewsdf"),
 ])  # yapf: disable
 def test_to_string_xyz(inp, expected):
     molrec = qcel.molparse.from_string(_results[inp[0]])
@@ -233,9 +233,9 @@ QCElemental
 
 
 @pytest.mark.parametrize("inp,kwargs,expected", [
-    ("subject1", {'dtype': 'nsglview-sdf'}, "ans1_ngslviewsdf"),
-    ("subject1_nocon", {'dtype': 'nsglview-sdf'}, "ans1_ngslviewsdf"),
-    ("subject2", {'dtype': 'nsglview-sdf'}, "ans2_ngslviewsdf")
+    ("subject1", {'dtype': 'nglview-sdf'}, "ans1_ngslviewsdf"),
+    ("subject1_nocon", {'dtype': 'nglview-sdf'}, "ans1_ngslviewsdf"),
+    ("subject2", {'dtype': 'nglview-sdf'}, "ans2_ngslviewsdf")
 ])  # yapf: disable
 def test_molecule_to_string(inp, kwargs, expected):
 
@@ -254,7 +254,7 @@ def test_to_string_pint_error(inp):
         qcel.molparse.to_string(molrec['qm'], **inp[1])
 
 @pytest.mark.parametrize("inp", [
-    ("subject1", {'dtype': 'nsglview-sdf', 'units': 'bohr'}),
+    ("subject1", {'dtype': 'nglview-sdf', 'units': 'bohr'}),
 ])  # yapf: disable
 def test_to_string_value_error(inp):
     molrec = qcel.molparse.from_string(_results[inp[0]])

--- a/qcelemental/tests/test_molparse_to_string.py
+++ b/qcelemental/tests/test_molparse_to_string.py
@@ -1,6 +1,6 @@
 import pytest
 
-import qcelemental
+import qcelemental as qcel
 from qcelemental.testing import compare
 
 _results = {
@@ -174,23 +174,64 @@ QCElemental
     (("subject2", {'dtype': 'sdf'}), "ans2_sdf"),
 ])  # yapf: disable
 def test_to_string_xyz(inp, expected):
-    molrec = qcelemental.molparse.from_string(_results[inp[0]])
-    smol = qcelemental.molparse.to_string(molrec['qm'], **inp[1])
+    molrec = qcel.molparse.from_string(_results[inp[0]])
+    smol = qcel.molparse.to_string(molrec['qm'], **inp[1])
     print(smol)
 
     assert compare(_results[expected], smol)
 
-# _molecule_inputs = {
-#     "subject1"
-# }
-# _expected_outputs = {
-#     "ans1_sdf"
-# }
-# @pytest.mark.parametrize("inp,expected", [
-#     (("subject1", {'dtype': 'sdf'}), "ans1_sdf")
-# ])
-# def test_molecule_to_string(inp, expected):
-#     pass
+
+_molecule_inputs = {
+    "subject1":
+    qcel.models.Molecule(**{
+        "geometry": [0, 0, 0, 0, 0, 1.9, 0, -1.9, 0],
+        "symbols": ["O", "H", "H"],
+        "connectivity": [[0, 1, 1], [0, 2, 1]]
+    }),
+    "subject2":
+    qcel.models.Molecule(
+        **{
+            "geometry": [0, 0, 0, 0, 0, 1.9, 0, -1.9, 0],
+            "symbols": ["O", "H", "H"],
+            "connectivity": [[0, 1, 1], [0, 2, 1]],
+            "real": [False, False, True]
+        })
+}
+
+_molecule_outputs = {
+    "ans1_sdf":
+    """
+QCElemental
+
+  3  2  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    0.0000 O   0  0     0  0  0  0  0  0
+    0.0000    0.0000    1.0054 H   0  0     0  0  0  0  0  0
+    0.0000   -1.0054    0.0000 H   0  0     0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  1  3  1  0  0  0  0
+""",
+    "ans2_sdf":
+    """
+QCElemental
+
+  3  2  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    0.0000 Zr  0  0     0  0  0  0  0  0
+    0.0000    0.0000    1.0054 Zr  0  0     0  0  0  0  0  0
+    0.0000   -1.0054    0.0000 H   0  0     0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  1  3  1  0  0  0  0
+"""
+}
+
+
+@pytest.mark.parametrize("inp,expected", [
+    (("subject1", {'dtype': 'sdf'}), "ans1_sdf"),
+    (("subject2", {'dtype': 'sdf'}), "ans2_sdf")
+])  # yapf: disable
+def test_molecule_to_string(inp, expected):
+
+    smol = _molecule_inputs[inp[0]].to_string(**inp[1])
+    assert compare(_molecule_outputs[expected], smol)
 
 
 @pytest.mark.parametrize("inp", [
@@ -198,16 +239,16 @@ def test_to_string_xyz(inp, expected):
 ])  # yapf: disable
 def test_to_string_pint_error(inp):
     import pint
-    molrec = qcelemental.molparse.from_string(_results[inp[0]])
+    molrec = qcel.molparse.from_string(_results[inp[0]])
 
     with pytest.raises(pint.errors.DimensionalityError):
-        qcelemental.molparse.to_string(molrec['qm'], **inp[1])
+        qcel.molparse.to_string(molrec['qm'], **inp[1])
 
 @pytest.mark.parametrize("inp", [
     ("subject1", {'dtype': 'sdf', 'units': 'bohr'}),
 ])  # yapf: disable
 def test_to_string_value_error(inp):
-    molrec = qcelemental.molparse.from_string(_results[inp[0]])
+    molrec = qcel.molparse.from_string(_results[inp[0]])
 
     with pytest.raises(ValueError):
-        qcelemental.molparse.to_string(molrec['qm'], **inp[1])
+        qcel.molparse.to_string(molrec['qm'], **inp[1])

--- a/qcelemental/tests/test_molparse_to_string.py
+++ b/qcelemental/tests/test_molparse_to_string.py
@@ -141,6 +141,14 @@ set,spin=2
    2.000000000000     0.000000000000     0.000000000000  h
   -2.000000000000     0.000000000000     0.000000000000  h
 $end
+""",
+
+"ans2_sdf": """
+QCElemental
+
+  2  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    0.0000 Co  0  0     0  0  0  0  0  0
+   -1.0584    0.0000    0.0000 H   0  0     0  0  0  0  0  0
 """
 
 
@@ -148,21 +156,22 @@ $end
 
 
 @pytest.mark.parametrize("inp,expected", [
-    (("subject1", {'dtype': 'xyz', 'units': 'Bohr'}), "ans1_au"),
-    (("subject1", {'dtype': 'xyz', 'units': 'Angstrom'}), "ans1_ang"),
-    (("subject1", {'dtype': 'xyz', 'prec': 8, 'atom_format': '{elea}{elem}{elbl}'}), "ans1c_ang"),
-    (("subject2", {'dtype': 'xyz', 'units': 'Bohr'}), "ans2_au"),
-    (("subject2", {'dtype': 'xyz', 'units': 'Angstrom', 'ghost_format': 'Gh({elez})'}), "ans2_ang"),
-    (("subject2", {'dtype': 'xyz', 'units': 'angstrom', 'ghost_format': ''}), "ans2c_ang"),
-    (("subject2", {'dtype': 'cfour', 'units': 'angstrom'}), "ans2_cfour_ang"),
-    (("subject2", {'dtype': 'nwchem', 'units': 'angstrom'}), "ans2_nwchem_ang"),
-    (("subject1", {'dtype': 'xyz', 'units': 'nm', 'prec': 8, 'atom_format': '{elea}{elem}{elbl}'}), "ans1c_nm"),
-    (("subject2", {'dtype': 'terachem', 'units': 'angstrom'}), "ans2_terachem_ang"),
-    (("subject2", {'dtype': 'terachem'}), "ans2_terachem_au"),
-    (("subject2", {'dtype': 'psi4', 'units': 'bohr'}), "ans2_psi4_au"),
-    (("subject2", {'dtype': 'molpro', 'units': 'bohr'}), "ans2_molpro_au"),
-    (("subject2", {'dtype': 'molpro', 'units': 'angstrom'}), "ans2_molpro_ang"),
-    (("subject2", {'dtype': 'turbomole', 'units': 'bohr'}), "ans2_turbomole_au"),
+    # (("subject1", {'dtype': 'xyz', 'units': 'Bohr'}), "ans1_au"),
+    # (("subject1", {'dtype': 'xyz', 'units': 'Angstrom'}), "ans1_ang"),
+    # (("subject1", {'dtype': 'xyz', 'prec': 8, 'atom_format': '{elea}{elem}{elbl}'}), "ans1c_ang"),
+    # (("subject2", {'dtype': 'xyz', 'units': 'Bohr'}), "ans2_au"),
+    # (("subject2", {'dtype': 'xyz', 'units': 'Angstrom', 'ghost_format': 'Gh({elez})'}), "ans2_ang"),
+    # (("subject2", {'dtype': 'xyz', 'units': 'angstrom', 'ghost_format': ''}), "ans2c_ang"),
+    # (("subject2", {'dtype': 'cfour', 'units': 'angstrom'}), "ans2_cfour_ang"),
+    # (("subject2", {'dtype': 'nwchem', 'units': 'angstrom'}), "ans2_nwchem_ang"),
+    # (("subject1", {'dtype': 'xyz', 'units': 'nm', 'prec': 8, 'atom_format': '{elea}{elem}{elbl}'}), "ans1c_nm"),
+    # (("subject2", {'dtype': 'terachem', 'units': 'angstrom'}), "ans2_terachem_ang"),
+    # (("subject2", {'dtype': 'terachem'}), "ans2_terachem_au"),
+    # (("subject2", {'dtype': 'psi4', 'units': 'bohr'}), "ans2_psi4_au"),
+    # (("subject2", {'dtype': 'molpro', 'units': 'bohr'}), "ans2_molpro_au"),
+    # (("subject2", {'dtype': 'molpro', 'units': 'angstrom'}), "ans2_molpro_ang"),
+    # (("subject2", {'dtype': 'turbomole', 'units': 'bohr'}), "ans2_turbomole_au"),V
+    (("subject2", {'dtype': 'sdf'}), "ans2_sdf"),
 ])  # yapf: disable
 def test_to_string_xyz(inp, expected):
     molrec = qcelemental.molparse.from_string(_results[inp[0]])
@@ -171,13 +180,34 @@ def test_to_string_xyz(inp, expected):
 
     assert compare(_results[expected], smol)
 
+# _molecule_inputs = {
+#     "subject1"
+# }
+# _expected_outputs = {
+#     "ans1_sdf"
+# }
+# @pytest.mark.parametrize("inp,expected", [
+#     (("subject1", {'dtype': 'sdf'}), "ans1_sdf")
+# ])
+# def test_molecule_to_string(inp, expected):
+#     pass
+
 
 @pytest.mark.parametrize("inp", [
     ("subject1", {'dtype': 'xyz', 'units': 'kg', 'prec': 8, 'atom_format': '{elea}{elem}{elbl}'}),
 ])  # yapf: disable
-def test_to_string_error(inp):
+def test_to_string_pint_error(inp):
     import pint
     molrec = qcelemental.molparse.from_string(_results[inp[0]])
 
     with pytest.raises(pint.errors.DimensionalityError):
+        qcelemental.molparse.to_string(molrec['qm'], **inp[1])
+
+@pytest.mark.parametrize("inp", [
+    ("subject1", {'dtype': 'sdf', 'units': 'bohr'}),
+])  # yapf: disable
+def test_to_string_value_error(inp):
+    molrec = qcelemental.molparse.from_string(_results[inp[0]])
+
+    with pytest.raises(ValueError):
         qcelemental.molparse.to_string(molrec['qm'], **inp[1])

--- a/qcelemental/tests/test_molparse_to_string.py
+++ b/qcelemental/tests/test_molparse_to_string.py
@@ -146,9 +146,12 @@ $end
 "ans2_sdf": """
 QCElemental
 
-  2  0  0  0  0  0  0  0  0  0  0
+  3  2  0  0  0  0  0  0  0  0  0
     0.0000    0.0000    0.0000 Co  0  0     0  0  0  0  0  0
+    1.0584    0.0000    0.0000 Gh  0  0     0  0  0  0  0  0
    -1.0584    0.0000    0.0000 H   0  0     0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  1  3  1  0  0  0  0
 """
 
 
@@ -156,21 +159,21 @@ QCElemental
 
 
 @pytest.mark.parametrize("inp,expected", [
-    # (("subject1", {'dtype': 'xyz', 'units': 'Bohr'}), "ans1_au"),
-    # (("subject1", {'dtype': 'xyz', 'units': 'Angstrom'}), "ans1_ang"),
-    # (("subject1", {'dtype': 'xyz', 'prec': 8, 'atom_format': '{elea}{elem}{elbl}'}), "ans1c_ang"),
-    # (("subject2", {'dtype': 'xyz', 'units': 'Bohr'}), "ans2_au"),
-    # (("subject2", {'dtype': 'xyz', 'units': 'Angstrom', 'ghost_format': 'Gh({elez})'}), "ans2_ang"),
-    # (("subject2", {'dtype': 'xyz', 'units': 'angstrom', 'ghost_format': ''}), "ans2c_ang"),
-    # (("subject2", {'dtype': 'cfour', 'units': 'angstrom'}), "ans2_cfour_ang"),
-    # (("subject2", {'dtype': 'nwchem', 'units': 'angstrom'}), "ans2_nwchem_ang"),
-    # (("subject1", {'dtype': 'xyz', 'units': 'nm', 'prec': 8, 'atom_format': '{elea}{elem}{elbl}'}), "ans1c_nm"),
-    # (("subject2", {'dtype': 'terachem', 'units': 'angstrom'}), "ans2_terachem_ang"),
-    # (("subject2", {'dtype': 'terachem'}), "ans2_terachem_au"),
-    # (("subject2", {'dtype': 'psi4', 'units': 'bohr'}), "ans2_psi4_au"),
-    # (("subject2", {'dtype': 'molpro', 'units': 'bohr'}), "ans2_molpro_au"),
-    # (("subject2", {'dtype': 'molpro', 'units': 'angstrom'}), "ans2_molpro_ang"),
-    # (("subject2", {'dtype': 'turbomole', 'units': 'bohr'}), "ans2_turbomole_au"),V
+    (("subject1", {'dtype': 'xyz', 'units': 'Bohr'}), "ans1_au"),
+    (("subject1", {'dtype': 'xyz', 'units': 'Angstrom'}), "ans1_ang"),
+    (("subject1", {'dtype': 'xyz', 'prec': 8, 'atom_format': '{elea}{elem}{elbl}'}), "ans1c_ang"),
+    (("subject2", {'dtype': 'xyz', 'units': 'Bohr'}), "ans2_au"),
+    (("subject2", {'dtype': 'xyz', 'units': 'Angstrom', 'ghost_format': 'Gh({elez})'}), "ans2_ang"),
+    (("subject2", {'dtype': 'xyz', 'units': 'angstrom', 'ghost_format': ''}), "ans2c_ang"),
+    (("subject2", {'dtype': 'cfour', 'units': 'angstrom'}), "ans2_cfour_ang"),
+    (("subject2", {'dtype': 'nwchem', 'units': 'angstrom'}), "ans2_nwchem_ang"),
+    (("subject1", {'dtype': 'xyz', 'units': 'nm', 'prec': 8, 'atom_format': '{elea}{elem}{elbl}'}), "ans1c_nm"),
+    (("subject2", {'dtype': 'terachem', 'units': 'angstrom'}), "ans2_terachem_ang"),
+    (("subject2", {'dtype': 'terachem'}), "ans2_terachem_au"),
+    (("subject2", {'dtype': 'psi4', 'units': 'bohr'}), "ans2_psi4_au"),
+    (("subject2", {'dtype': 'molpro', 'units': 'bohr'}), "ans2_molpro_au"),
+    (("subject2", {'dtype': 'molpro', 'units': 'angstrom'}), "ans2_molpro_ang"),
+    (("subject2", {'dtype': 'turbomole', 'units': 'bohr'}), "ans2_turbomole_au"),
     (("subject2", {'dtype': 'sdf'}), "ans2_sdf"),
 ])  # yapf: disable
 def test_to_string_xyz(inp, expected):
@@ -187,6 +190,11 @@ _molecule_inputs = {
         "geometry": [0, 0, 0, 0, 0, 1.9, 0, -1.9, 0],
         "symbols": ["O", "H", "H"],
         "connectivity": [[0, 1, 1], [0, 2, 1]]
+    }),
+    "subject1_nocon":
+    qcel.models.Molecule(**{
+        "geometry": [0, 0, 0, 0, 0, 1.9, 0, -1.9, 0],
+        "symbols": ["O", "H", "H"],
     }),
     "subject2":
     qcel.models.Molecule(
@@ -215,8 +223,8 @@ QCElemental
 QCElemental
 
   3  2  0  0  0  0  0  0  0  0  0
-    0.0000    0.0000    0.0000 Zr  0  0     0  0  0  0  0  0
-    0.0000    0.0000    1.0054 Zr  0  0     0  0  0  0  0  0
+    0.0000    0.0000    0.0000 Gh  0  0     0  0  0  0  0  0
+    0.0000    0.0000    1.0054 Gh  0  0     0  0  0  0  0  0
     0.0000   -1.0054    0.0000 H   0  0     0  0  0  0  0  0
   1  2  1  0  0  0  0
   1  3  1  0  0  0  0
@@ -224,13 +232,14 @@ QCElemental
 }
 
 
-@pytest.mark.parametrize("inp,expected", [
-    (("subject1", {'dtype': 'sdf'}), "ans1_sdf"),
-    (("subject2", {'dtype': 'sdf'}), "ans2_sdf")
+@pytest.mark.parametrize("inp,kwargs,expected", [
+    ("subject1", {'dtype': 'sdf'}, "ans1_sdf"),
+    ("subject1_nocon", {'dtype': 'sdf'}, "ans1_sdf"),
+    ("subject2", {'dtype': 'sdf'}, "ans2_sdf")
 ])  # yapf: disable
-def test_molecule_to_string(inp, expected):
+def test_molecule_to_string(inp, kwargs, expected):
 
-    smol = _molecule_inputs[inp[0]].to_string(**inp[1])
+    smol = _molecule_inputs[inp].to_string(**kwargs)
     assert compare(_molecule_outputs[expected], smol)
 
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
                 'networkx',
             ],
             'viz': [
-                'py3dmol',
+                'nglview',
             ],
         },
         tests_require=[


### PR DESCRIPTION
## Description
Swaps out py3DMol for NGLView. The primary benefit here is that we have direct widget integration so that we can do fun things showing both a Plotly plot and a Molecule at the same time.

Other features:
 - New technology to guess the molecules connectivity based off vanderwaals radii.
 - Quasi SDF file format, really just good enough for visualization. @jwags

## Status
- [ ] Changelog updated
- [x] Ready to go