### PR TITLE
Native Molecule Hashing

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,23 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
+X.Y.0 / 2019-MM-DD
+------------------
+
+New Features
+++++++++++++
+
+Enhancements
+++++++++++++
+- (:pr:`156`) ``Molecules`` can now be correctly compared with ``==``.
+
+Deprecations
+++++++++++++
+- (:pr:`156`) ``Molecule.compare`` is deprecated and will be removed in v0.13.0.
+
+Bug Fixes
++++++++++
+
 0.11.1 / 2019-10-28
 -------------------
 

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -5,6 +5,7 @@ Molecule Object Model
 import collections
 import hashlib
 import json
+import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -388,6 +389,11 @@ class Molecule(ProtoModel):
         return Molecule(orient=True, **self.dict())
 
     def compare(self, other):
+        warnings.warn("Molecule.compare is deprecated and will be removed in v0.13.0. Use == instead.",
+                      DeprecationWarning)
+        return self == other
+
+    def __eq__(self, other):
         """
         Checks if two molecules are identical. This is a molecular identity defined
         by scientific terms, and not programing terms, so it's less rigorous than
@@ -401,18 +407,7 @@ class Molecule(ProtoModel):
         else:
             raise TypeError("Comparison molecule not understood of type '{}'.".format(type(other)))
 
-        match = True
-        match &= np.array_equal(self.symbols, other.symbols)
-        match &= np.allclose(self.masses, other.masses, atol=(10**-MASS_NOISE))
-        match &= np.array_equal(self.real, other.real)
-        match &= np.array_equal(self.fragments, other.fragments)
-        match &= np.allclose(self.fragment_charges, other.fragment_charges, atol=(10**-CHARGE_NOISE))
-        match &= np.array_equal(self.fragment_multiplicities, other.fragment_multiplicities)
-
-        match &= np.allclose(self.molecular_charge, other.molecular_charge, atol=(10**-CHARGE_NOISE))
-        match &= np.array_equal(self.molecular_multiplicity, other.molecular_multiplicity)
-        match &= np.allclose(self.geometry, other.geometry, atol=(10**-GEOMETRY_NOISE))
-        return match
+        return self.get_hash() == other.get_hash()
 
     def pretty_print(self):
         """Print the molecule in Angstroms. Same as :py:func:`print_out` only always in Angstroms.

--- a/qcelemental/tests/test_model_serials.py
+++ b/qcelemental/tests/test_model_serials.py
@@ -136,7 +136,7 @@ def test_protomodel_to_from_file(tmp_path, dtype, filext):
 
     mol = Molecule.parse_file(p)
 
-    assert mol.compare(benchmol)
+    assert mol == benchmol
 
 
 def test_molecule_skip_defaults(water):

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -39,10 +39,10 @@ def test_molecule_data_constructor_numpy():
     npwater = np.hstack((ele, water_psi.geometry * qcel.constants.conversion_factor("Bohr", "angstrom")))
 
     water_from_np = Molecule.from_data(npwater, name="water dimer", dtype="numpy", frags=[3])
-    assert water_psi.compare(water_from_np)
+    assert water_psi == water_from_np
 
     water_from_np = Molecule.from_data(npwater, name="water dimer", frags=[3])
-    assert water_psi.compare(water_from_np)
+    assert water_psi == water_from_np
     assert water_psi.get_molecular_formula() == "H4O2"
 
 
@@ -51,11 +51,11 @@ def test_molecule_data_constructor_dict():
 
     # Check the JSON construct/deconstruct
     water_from_json = Molecule.from_data(water_psi.dict())
-    assert water_psi.compare(water_from_json)
+    assert water_psi == water_from_json
 
     water_from_json = Molecule.from_data(water_psi.json(), "json")
-    assert water_psi.compare(water_from_json)
-    assert water_psi.compare(Molecule.from_data(water_psi.to_string("psi4"), dtype="psi4"))
+    assert water_psi == water_from_json
+    assert water_psi == Molecule.from_data(water_psi.to_string("psi4"), dtype="psi4")
 
     assert water_psi.get_hash() == '3c4b98f515d64d1adc1648fe1fe1d6789e978d34'  # copied from schema_version=1
     assert water_psi.schema_version == 2
@@ -89,20 +89,20 @@ def test_molecule_np_constructors():
     npneon = np.hstack((ele, neon_from_psi.geometry))
     neon_from_np = Molecule.from_data(npneon, name="neon tetramer", dtype="numpy", frags=[1, 2, 3], units="bohr")
 
-    assert neon_from_psi.compare(neon_from_np)
+    assert neon_from_psi == neon_from_np
 
     # Check the JSON construct/deconstruct
     neon_from_json = Molecule.from_data(neon_from_psi.json(), dtype="json")
-    assert neon_from_psi.compare(neon_from_json)
+    assert neon_from_psi == neon_from_json
     assert neon_from_json.get_molecular_formula() == "Ne4"
 
 
 def test_molecule_compare():
     water_molecule2 = water_molecule.copy()
-    assert water_molecule2.compare(water_molecule)
+    assert water_molecule2 == water_molecule
 
     water_molecule3 = water_molecule.copy(update={"geometry": (water_molecule.geometry + np.array([0.1, 0, 0]))})
-    assert water_molecule.compare(water_molecule3) is False
+    assert water_molecule != water_molecule3
 
 
 def test_water_minima_data():
@@ -182,7 +182,7 @@ def test_to_from_file_simple(tmp_path, dtype, filext):
 
     mol = Molecule.from_file(p)
 
-    assert mol.compare(benchmol)
+    assert mol == benchmol
 
 
 @pytest.mark.parametrize("dtype", ["json", "psi4"])
@@ -192,7 +192,7 @@ def test_to_from_file_complex(tmp_path, dtype):
     water_dimer_minima.to_file(p)
 
     mol = Molecule.from_file(p)
-    assert mol.compare(water_dimer_minima)
+    assert mol == water_dimer_minima
 
 
 @pytest.mark.parametrize("dtype, filext", [
@@ -218,7 +218,7 @@ def test_to_from_file_charge_spin(tmp_path, dtype, filext):
     assert mol.molecular_multiplicity == 2
     assert mol.fragment_charges[0] == 1
     assert mol.fragment_multiplicities[0] == 2
-    assert mol.compare(benchmol)
+    assert mol == benchmol
 
 
 def test_from_data_kwargs():
@@ -332,13 +332,13 @@ def test_molecule_json_serialization():
 
     assert isinstance(water_dimer_minima.dict(encoding="json")["geometry"], list)
 
-    assert water_dimer_minima.compare(Molecule.from_data(water_dimer_minima.json(), dtype="json"))
+    assert water_dimer_minima == Molecule.from_data(water_dimer_minima.json(), dtype="json")
 
 
 @pytest.mark.parametrize("encoding", serialize_extensions)
 def test_molecule_serialization(encoding):
     blob = water_dimer_minima.serialize(encoding)
-    assert water_dimer_minima.compare(Molecule.parse_raw(blob, encoding=encoding))
+    assert water_dimer_minima == Molecule.parse_raw(blob, encoding=encoding)
 
 
 def test_charged_fragment():


### PR DESCRIPTION
## Description
This PR implements `__eq__` for Molecule by comparing hashes from `get_hash`. `get_hash` was chosen over `__hash__` because our Molecule hashes do not satisfy Python's requirements. `Molecule.compare` is deprecated. Resolves #154.

## Status
- [x] Changelog updated
- [x] Ready to go