### PR TITLE
add ResultProtocols.logfile

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -22,7 +22,9 @@ New Features
 Enhancements
 ++++++++++++
 - (:pr:`156`) ``Molecules`` can now be correctly compared with ``==``.
-- (:pr:``) ``molparse.to_string`` Q-Chem dtype developed. Psi4 dtype now includes label and doesn't have extraneous info for single fragment systems.
+- (:pr:`157`) ``molparse.to_string`` Q-Chem dtype developed. Psi4 dtype now includes label and doesn't have extraneous info for single fragment systems.
+- (:pr:``) New protocol ``logfile`` controlling whether ``stdout`` (which generally contains the primary logfile, whether a
+  program writes it to file or stdout) is returned added to ``ResultProtocols``.
 
 Deprecations
 ++++++++++++

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,8 +23,8 @@ Enhancements
 ++++++++++++
 - (:pr:`156`) ``Molecules`` can now be correctly compared with ``==``.
 - (:pr:`157`) ``molparse.to_string`` Q-Chem dtype developed. Psi4 dtype now includes label and doesn't have extraneous info for single fragment systems.
-- (:pr:``) New protocol ``logfile`` controlling whether ``stdout`` (which generally contains the primary logfile, whether a
-  program writes it to file or stdout) is returned added to ``ResultProtocols``.
+- (:pr:`162`) New protocol ``stdout`` added to ``ResultProtocols`` controlling whether ``stdout`` field (which generally
+  contains the primary logfile, whether a program writes it to file or stdout) is returned.
 
 Deprecations
 ++++++++++++

--- a/qcelemental/models/__init__.py
+++ b/qcelemental/models/__init__.py
@@ -8,7 +8,7 @@ from . import types
 from .align import AlignmentMill
 from .basemodels import AutodocBaseSettings, ProtoModel
 from .basis import BasisSet
-from .common_models import ComputeError, FailedOperation, Provenance
+from .common_models import ComputeError, DriverEnum, FailedOperation, Provenance
 from .molecule import Molecule
 from .procedures import Optimization, OptimizationInput
 from .results import Result, ResultInput, ResultProperties

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -220,6 +220,7 @@ class ResultProtocols(ProtoModel):
 
     wavefunction: WavefunctionProtocolEnum = Field(WavefunctionProtocolEnum.none,
                                                    description=str(WavefunctionProtocolEnum.__doc__))
+    logfile: bool = Field(True, description="Primary output file to keep from a Result computation")
 
     class Config:
         force_skip_defaults = True
@@ -347,3 +348,18 @@ class Result(ResultInput):
             return ret_wfn
         else:
             return wfn
+
+    @validator('stdout', pre=True)
+    def _logfile_protocol(cls, value, values):
+
+        # Do not propogate validation errors
+        if 'protocols' not in values:
+            raise ValueError("Protocols was not properly formed.")
+
+        logp = values['protocols'].logfile
+        if logp is True:
+            return value
+        elif logp is False:
+            return None
+        else:
+            raise ValueError(f"Protocol `logfile:{logp}` is not understood")

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -220,7 +220,7 @@ class ResultProtocols(ProtoModel):
 
     wavefunction: WavefunctionProtocolEnum = Field(WavefunctionProtocolEnum.none,
                                                    description=str(WavefunctionProtocolEnum.__doc__))
-    logfile: bool = Field(True, description="Primary output file to keep from a Result computation")
+    stdout: bool = Field(True, description="Primary output file to keep from a Result computation")
 
     class Config:
         force_skip_defaults = True
@@ -301,7 +301,7 @@ class Result(ResultInput):
         else:
             raise ValueError('wavefunction must be None, a dict, or a WavefunctionProperties object.')
 
-        # Do not propogate validation errors
+        # Do not propagate validation errors
         if 'protocols' not in values:
             raise ValueError("Protocols was not properly formed.")
 
@@ -349,17 +349,17 @@ class Result(ResultInput):
         else:
             return wfn
 
-    @validator('stdout', pre=True)
-    def _logfile_protocol(cls, value, values):
+    @validator('stdout')
+    def _stdout_protocol(cls, value, values):
 
-        # Do not propogate validation errors
+        # Do not propagate validation errors
         if 'protocols' not in values:
             raise ValueError("Protocols was not properly formed.")
 
-        logp = values['protocols'].logfile
-        if logp is True:
+        outp = values['protocols'].stdout
+        if outp is True:
             return value
-        elif logp is False:
+        elif outp is False:
             return None
         else:
-            raise ValueError(f"Protocol `logfile:{logp}` is not understood")
+            raise ValueError(f"Protocol `stdout:{outp}` is not understood")

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -296,7 +296,7 @@ def test_optimization_trajectory_protocol(keep, indices, optimization_data_fixtu
 
 
 def test_result_build_stdout_delete(result_data_fixture):
-    result_data_fixture["protocols"] = {"logfile": False}
+    result_data_fixture["protocols"] = {"stdout": False}
     ret = qcel.models.Result(**result_data_fixture)
     assert ret.stdout is None
 

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -90,7 +90,8 @@ def result_data_fixture():
         "properties": {},
         "provenance": {
             "creator": "qcel"
-        }
+        },
+        "stdout": "I ran.",
     }
 
 
@@ -292,3 +293,14 @@ def test_optimization_trajectory_protocol(keep, indices, optimization_data_fixtu
     assert len(opt.trajectory) == len(indices)
     for result, index in zip(opt.trajectory, indices):
         assert result.return_result == index
+
+
+def test_result_build_stdout_delete(result_data_fixture):
+    result_data_fixture["protocols"] = {"logfile": False}
+    ret = qcel.models.Result(**result_data_fixture)
+    assert ret.stdout is None
+
+
+def test_result_build_stdout(result_data_fixture):
+    ret = qcel.models.Result(**result_data_fixture)
+    assert ret.stdout == "I ran."


### PR DESCRIPTION
## Todos
  - [x] following slack discussion, use a protocol to control stdout return rather than `return_output` field (which doesn't validate with no extras)
  - [x] move `DriverEnum` up to `models`. I import it a lot, and most else is common_models was accessible

## Questions
- [ ] This could be made an enum and control stdout/stderr/other returned files. But keeping it simple for now.

## Status
- [x] Changelog updated
- [x] Ready to go