### PR TITLE
Models: Allows repr/str passthrough in new repr overloading

### DIFF
--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -26,8 +26,12 @@ class ProtoModel(BaseModel):
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
         cls.__doc__ = AutoPydanticDocGenerator(cls, always_apply=True)
-        cls.__repr__ = _repr
-        cls.__str__ = _repr
+
+        if "pydantic" in cls.__repr__.__module__:
+            cls.__repr__ = _repr
+
+        if "pydantic" in cls.__str__.__module__:
+            cls.__str__ = _repr
 
     @classmethod
     def parse_raw(cls, data: Union[bytes, str], *, encoding: str = None) -> "ProtoModel":  # type: ignore

--- a/qcelemental/tests/test_model_general.py
+++ b/qcelemental/tests/test_model_general.py
@@ -75,3 +75,27 @@ def test_repr_optimization():
 
     assert "molecule_hash" in str(opt)
     assert "molecule_hash" in repr(opt)
+
+def test_model_custom_repr():
+
+    class Model(ProtoModel):
+        a: int
+
+        def __repr__(self) -> str:
+            return "Hello world!"
+
+
+    m = Model(a=5)
+    assert repr(m) == "Hello world!"
+    assert "Model(" in str(m)
+
+
+    class Model2(ProtoModel):
+        a: int
+
+        def __str__(self) -> str:
+            return "Hello world!"
+
+    m = Model2(a=5)
+    assert "Model2(" in repr(m)
+    assert str(m) == "Hello world!"


### PR DESCRIPTION
## Description
Overloading `__str__` again in ProtoModel subclasses correctly works again.

## Status
- [ ] Changelog updated
- [x] Ready to go