### PR TITLE
numpy 1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # QCElemental
 
 [![Build Status](https://github.com/MolSSI/QCElemental/workflows/CI/badge.svg?branch=master)](https://github.com/MolSSI/QCElemental/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/MolSSI/QCElemental/branch/master/graph/badge.svg)](https://codecov.io/gh/MolSSI/QCElemental)
+[![codecov](https://img.shields.io/codecov/c/github/MolSSI/QCElemental.svg?logo=Codecov&logoColor=white)](https://codecov.io/gh/MolSSI/QCElemental)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/MolSSI/QCElemental.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/MolSSI/QCElemental/context:python)
 [![Documentation Status](https://readthedocs.org/projects/qcelemental/badge/?version=latest)](https://qcelemental.readthedocs.io/en/latest/?badge=latest)
 [![Chat on Slack](https://img.shields.io/badge/chat-on_slack-green.svg?longCache=true&style=flat&logo=slack)](https://join.slack.com/t/qcarchive/shared_invite/enQtNDIzNTQ2OTExODk0LTE3MWI0YzBjNzVhNzczNDM0ZTA5MmQ1ODcxYTc0YTA1ZDQ2MTk1NDhlMjhjMmQ0YWYwOGMzYzJkZTM2NDlmOGM)

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
     # Base depends
-  - numpy
+  - numpy>=1.12.0
   - nomkl
   - python
   - pint>=0.10.0

--- a/devtools/conda-envs/minimal.yaml
+++ b/devtools/conda-envs/minimal.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
     # Base depends
-  - numpy
+  - numpy=1.14  # technically, pint has an optional >=1.12.0 numpy dep but c-f doesn't have py38 builds for it
   - nomkl
   - python
   - pint=0.10.0  # technically, qcel has no lower bound for pint version for py36,37 but needs 0.10 for 38

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,7 +19,8 @@ Changelog
 
 New Features
 ++++++++++++
-- (:pr:`179`) QCElemental works with Python 3.8 at the expense of needing a new 0.10 pint (rather than generic install).
+- (:pr:`179`, :pr:`181`) QCElemental works with Python 3.8 at the expense of needing a new 0.10 pint (rather than generic install).
+  Pint 0.10 has optional NumPy dependency of >=1.12.0, so QCElemental that requires both NumPy and pint needs this constraint.
 
 Enhancements
 ++++++++++++

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
         package_data={'': [os.path.join('qcelemental', 'data', '*.json')]},
         setup_requires=[] + pytest_runner,
         python_requires='>=3.6',
-        install_requires=['numpy', 'pint >= 0.10.0', 'pydantic >= 1.0.0'],
+        install_requires=['numpy >= 1.12.0', 'pint >= 0.10.0', 'pydantic >= 1.0.0'],
         extras_require={
             'docs': [
                 'numpydoc',


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
mention numpy>=1.12 constraint inherited from pint. distribution-wise, c-f is home free b/c it builds against a minimum 1.14. but default's minimum is 1.11, so worth having explicit constraint. 

## Changelog description
already edited

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go (if CI passes)
