### PR TITLE
Molecule: add pubchem identifiers

### DIFF
--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -73,6 +73,9 @@ class Identifiers(ProtoModel):
     canonical_isomeric_explicit_hydrogen_smiles: Optional[str] = None
     canonical_isomeric_smiles: Optional[str] = None
     canonical_smiles: Optional[str] = None
+    pubchem_cid: Optional[str] = Field(None, description="PubChem Compound ID")
+    pubchem_sid: Optional[str] = Field(None, description="PubChem Substance ID")
+    pubchem_conformerid: Optional[str] = Field(None, description="PubChem Conformer ID")
 
     class Config(ProtoModel.Config):
         serialize_skip_defaults = True


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR adds optional pubchem identifiers to molecules, namely compound, substance, and conformer ID. I think nothing needs to change in Fractal for this to work.

## Changelog description
Optional PubChem identifiers were added to molecules.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
