### PR TITLE
try minimal storage mol for atomic_number

### DIFF
--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -461,6 +461,10 @@ class Molecule(ProtoModel):
 
         return self.get_hash() == other.get_hash()
 
+    def dict(self, *args, **kwargs):
+        kwargs.setdefault("by_alias", True)
+        return super().dict(*args, **kwargs)
+
     def pretty_print(self):
         """Print the molecule in Angstroms. Same as :py:func:`print_out` only always in Angstroms.
         (method name in libmints is print_in_angstrom)

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -465,6 +465,10 @@ class Molecule(ProtoModel):
         kwargs.setdefault("by_alias", True)
         return super().dict(*args, **kwargs)
 
+    def json(self, *args, **kwargs):
+        kwargs.setdefault("by_alias", True)
+        return super().json(*args, **kwargs)
+
     def pretty_print(self):
         """Print the molecule in Angstroms. Same as :py:func:`print_out` only always in Angstroms.
         (method name in libmints is print_in_angstrom)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Start of minimal storage for mol. Minimal validation is definitely a target, but I understand minimal storage is first. I started passing up the defaulted fields up but then figured why bother passing when it can be computed as needed. This is a first stab at #169 dealing only with atomic_number. Autogeneration does work or the nuclear_repulsion_energy fn test would fail. Currently 12 tests fail, mostly with extra_fields/serialization trouble. Looking for first comments.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
