### PR TITLE
reduced mol storage 2

### DIFF
--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -124,7 +124,7 @@ class ProtoModel(BaseModel):
         *,
         include: Optional[Set[str]] = None,
         exclude: Optional[Set[str]] = None,
-        exclude_unset: bool = False,
+        exclude_unset: Optional[bool] = None,
     ) -> Union[bytes, str]:
         """Generates a serialized representation of the model
 
@@ -136,7 +136,7 @@ class ProtoModel(BaseModel):
             Fields to be included in the serialization.
         exclude : Optional[Set[str]], optional
             Fields to be excluded in the serialization.
-        exclude_unset : bool, optional
+        exclude_unset : Optional[bool], optional
             If True, skips fields that have default values provided.
 
         Returns
@@ -144,9 +144,22 @@ class ProtoModel(BaseModel):
         Union[bytes, str]
             The serialized model.
         """
-        data = self.dict(include=include, exclude=exclude, exclude_unset=exclude_unset)
+
+        kwargs = {}
+        if include:
+            kwargs["include"] = include
+        if exclude:
+            kwargs["exclude"] = exclude
+        if exclude_unset:
+            kwargs["exclude_unset"] = exclude_unset
+
+        data = self.dict(**kwargs)
 
         return serialize(data, encoding=encoding)
+
+    def json(self, **kwargs):
+        # Alias JSON here from BaseModel to reflect dict changes
+        return self.serialize("json", **kwargs)
 
     def compare(self, other: Union["ProtoModel", BaseModel], **kwargs) -> bool:
         """Compares the current object to the provided object recursively.

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -145,7 +145,7 @@ class Molecule(ProtoModel):
     molecular_multiplicity: int = Field(1, description="The total multiplicity of this Molecule.")  # type: ignore
 
     # Atom data
-    masses: Optional[Array[float]] = Field(  # type: ignore
+    masses_: Optional[Array[float]] = Field(  # type: ignore
         None,
         description="An ordered 1-D array-like object of atomic masses [u] of shape (nat,). Index order "
         "matches the 0-indexed indices of all other per-atom settings like ``symbols`` and ``real``. If "
@@ -153,7 +153,7 @@ class Molecule(ProtoModel):
         "is provided, it must be the same length as ``symbols`` but can accept ``None`` entries for "
         "standard masses to infer from the same index in the ``symbols`` field.",
     )
-    real: Optional[Array[bool]] = Field(  # type: ignore
+    real_: Optional[Array[bool]] = Field(  # type: ignore
         None,
         description="An ordered 1-D array-like object of shape (nat,) indicating if each atom is real (``True``) or "
         "ghost/virtual (``False``). Index "
@@ -181,13 +181,13 @@ class Molecule(ProtoModel):
     )
 
     # Fragment and connection data
-    connectivity: Optional[List[Tuple[int, int, float]]] = Field(  # type: ignore
+    connectivity_: Optional[List[Tuple[int, int, float]]] = Field(  # type: ignore
         None,
         description="The connectivity information between each atom in the ``symbols`` array. Each entry in this "
         "list is a Tuple of ``(atom_index_A, atom_index_B, bond_order)`` where the ``atom_index`` "
         "matches the 0-indexed indices of all other per-atom settings like ``symbols`` and ``real``.",
     )
-    fragments: Optional[List[Array[np.int32]]] = Field(  # type: ignore
+    fragments_: Optional[List[Array[np.int32]]] = Field(  # type: ignore
         None,
         description="An indication of which sets of atoms are fragments within the Molecule. This is a list of shape "
         "(nfr) of 1-D array-like objects of arbitrary length. Each entry in the list indicates a new "
@@ -197,13 +197,13 @@ class Molecule(ProtoModel):
         "atoms which compose the fragment. The atom indices match the 0-indexed indices of all other "
         "per-atom settings like ``symbols`` and ``real``.",
     )
-    fragment_charges: Optional[List[float]] = Field(  # type: ignore
+    fragment_charges_: Optional[List[float]] = Field(  # type: ignore
         None,
         description="The total charge of each fragment in the ``fragments`` list of shape (nfr,). The index of this "
         "list matches the 0-index indices of ``fragment`` list. Will be filled in based on a set of rules "
         "if not provided (and ``fragments`` are specified).",
     )
-    fragment_multiplicities: Optional[List[int]] = Field(  # type: ignore
+    fragment_multiplicities_: Optional[List[int]] = Field(  # type: ignore
         None,
         description="The multiplicity of each fragment in the ``fragments`` list of shape (nfr,). The index of this "
         "list matches the 0-index indices of ``fragment`` list. Will be filled in based on a set of "
@@ -249,9 +249,15 @@ class Molecule(ProtoModel):
             ("hash", self.get_hash()[:7]),
         ]
         fields = {
+            "masses_": "masses",
+            "real_": "real",
             "atom_labels_": "atom_labels",
             "atomic_numbers_": "atomic_numbers",
             "mass_numbers_": "mass_numbers",
+            "connectivity_": "connectivity",
+            "fragments_": "fragments",
+            "fragment_charges_": "fragment_charges",
+            "fragment_multiplicities_": "fragment_multiplicities",
         }
 
     def __init__(self, orient: bool = False, validate: Optional[bool] = None, **kwargs: Any) -> None:
@@ -284,41 +290,64 @@ class Molecule(ProtoModel):
         super().__init__(**kwargs)
 
         # We are pulling out the values *explicitly* so that the pydantic skip_defaults works as expected
-        # All attributes set bellow are equivalent to the default set.
+        # All attributes set below are equivalent to the default set.
         values = self.__dict__
 
         natoms = values["geometry"].shape[0]
         if validate:
             values["symbols"] = np.core.defchararray.title(self.symbols)  # Title case for consistency
 
-        if values["masses"] is None:  # Setup masses before fixing the orientation
-            values["masses"] = np.array([periodictable.to_mass(x) for x in values["symbols"]])
-
-        if values["real"] is None:
-            values["real"] = np.ones(natoms, dtype=bool)
-
         if orient:
+            if "masses" not in values:  # Setup masses before fixing the orientation
+                values["masses"] = np.array([periodictable.to_mass(x) for x in values["symbols"]])
             values["geometry"] = float_prep(self._orient_molecule_internal(), GEOMETRY_NOISE)
         elif validate:
             values["geometry"] = float_prep(values["geometry"], GEOMETRY_NOISE)
 
-        # Cleanup un-initialized variables  (more complex than Pydantic Validators allow)
-        if values["fragments"] is None:
-            values["fragments"] = [np.arange(natoms, dtype=np.int32)]
-            values["fragment_charges"] = [values["molecular_charge"]]
-            values["fragment_multiplicities"] = [values["molecular_multiplicity"]]
-        else:
-            if values["fragment_charges"] is None:
-                if np.isclose(values["molecular_charge"], 0.0):
-                    values["fragment_charges"] = [0 for _ in values["fragments"]]
-                else:
-                    raise KeyError("Fragments passed in, but not fragment charges for a charged molecule.")
+#        # Cleanup un-initialized variables  (more complex than Pydantic Validators allow)
+#        if values["fragments"] is None:
+#            values["fragments"] = [np.arange(natoms, dtype=np.int32)]
+#            values["fragment_charges"] = [values["molecular_charge"]]
+#            values["fragment_multiplicities"] = [values["molecular_multiplicity"]]
+#        else:
+#            if values["fragment_charges"] is None:
+#                if np.isclose(values["molecular_charge"], 0.0):
+#                    values["fragment_charges"] = [0 for _ in values["fragments"]]
+#                else:
+#                    raise KeyError("Fragments passed in, but not fragment charges for a charged molecule.")
+#
+#            if values["fragment_multiplicities"] is None:
+#                if values["molecular_multiplicity"] == 1:
+#                    values["fragment_multiplicities"] = [1 for _ in values["fragments"]]
+#                else:
+#                    raise KeyError("Fragments passed in, but not fragment multiplicities for a non-singlet molecule.")
 
-            if values["fragment_multiplicities"] is None:
-                if values["molecular_multiplicity"] == 1:
-                    values["fragment_multiplicities"] = [1 for _ in values["fragments"]]
-                else:
-                    raise KeyError("Fragments passed in, but not fragment multiplicities for a non-singlet molecule.")
+        if "masses" in values:
+            values["masses_"] = values["masses"]
+
+        if "real" in values:
+            values["real_"] = values["real"]
+
+        if "atom_labels" in values:
+            values["atom_labels_"] = values["atom_labels"]
+
+        if "atomic_numbers" in values:
+            values["atomic_numbers_"] = values["atomic_numbers"]
+
+        if "mass_numbers" in values:
+            values["mass_numbers_"] = values["mass_numbers"]
+
+        if "connectivity" in values:
+            values["connectivity_"] = values["connectivity"]
+
+        if "fragments" in values:
+            values["fragments_"] = values["fragments"]
+
+        if "fragment_charges" in values:
+            values["fragment_charges_"] = values["fragment_charges"]
+
+        if "fragment_multiplicities" in values:
+            values["fragment_multiplicities_"] = values["fragment_multiplicities"]
 
     @validator("geometry")
     def _must_be_3n(cls, v, values, **kwargs):
@@ -329,14 +358,14 @@ class Molecule(ProtoModel):
             raise ValueError("Geometry must be castable to shape (N,3)!")
         return v
 
-    @validator("masses", "real")
+    @validator("masses_", "real_")
     def _must_be_n(cls, v, values, **kwargs):
         n = len(values["symbols"])
         if len(v) != n:
             raise ValueError("Masses and Real must be same number of entries as Symbols")
         return v
 
-    @validator("real")
+    @validator("real_")
     def _populate_real(cls, v, values, **kwargs):
         # Can't use geometry here since its already been validated and not in values
         n = len(values["symbols"])
@@ -344,19 +373,19 @@ class Molecule(ProtoModel):
             v = np.array([True for _ in range(n)])
         return v
 
-    @validator("fragment_charges", "fragment_multiplicities")
+    @validator("fragment_charges_", "fragment_multiplicities_")
     def _must_be_n_frag(cls, v, values, **kwargs):
-        if "fragments" in values:
-            n = len(values["fragments"])
+        if "fragments_" in values:
+            n = len(values["fragments_"])
             if len(v) != n:
                 raise ValueError(
-                    "Fragment Charges and Fragment Multiplicities" " must be same number of entries as Fragments"
+                    "Fragment Charges and Fragment Multiplicities must be same number of entries as Fragments"
                 )
         else:
-            raise ValueError("Cannot have Fragment Charges or Fragment Multiplicities " "without Fragments")
+            raise ValueError("Cannot have Fragment Charges or Fragment Multiplicities without Fragments")
         return v
 
-    @validator("connectivity", each_item=True)
+    @validator("connectivity_", each_item=True)
     def _min_zero(cls, v):
         if v < 0:
             raise ValueError("Connectivity entries must be greater than 0")
@@ -378,6 +407,20 @@ class Molecule(ProtoModel):
         ]
 
     @property
+    def masses(self) -> Array[float]:
+        masses = self.__dict__.get("masses_")
+        if masses is None:
+            masses = np.array([periodictable.to_mass(x) for x in self.symbols])
+        return masses
+
+    @property
+    def real(self) -> Array[bool]:
+        real = self.__dict__.get("real_")
+        if real is None:
+            real = np.array([True for x in self.symbols])
+        return real
+
+    @property
     def atom_labels(self) -> Array[str]:
         atom_labels = self.__dict__.get("atom_labels_")
         if atom_labels is None:
@@ -397,6 +440,34 @@ class Molecule(ProtoModel):
         if mass_numbers is None:
             mass_numbers = np.array([periodictable.to_A(x) for x in self.symbols])
         return mass_numbers
+
+    @property
+    def connectivity(self) -> List[Tuple[int, int, float]]:
+        connectivity = self.__dict__.get("connectivity_")
+        if connectivity is None:
+            connectivity = []
+        return connectivity
+
+    @property
+    def fragments(self) -> List[Array[np.int32]]:
+        fragments = self.__dict__.get("fragments_")
+        if fragments is None:
+            fragments = [np.arange(len(self.symbols), dtype=np.int32)]
+        return fragments
+
+    @property
+    def fragment_charges(self) -> List[float]:
+        fragment_charges = self.__dict__.get("fragment_charges_")
+        if fragment_charges is None:
+            fragment_charges = [0.0 for _ in self.fragments]
+        return fragment_charges
+
+    @property
+    def fragment_multiplicities(self) -> List[int]:
+        fragment_multiplicities = self.__dict__.get("fragment_multiplicities_")
+        if fragment_multiplicities is None:
+            fragment_multiplicities = [1 for _ in self.fragments]
+        return fragment_multiplicities
 
     ### Non-Pydantic API functions
 
@@ -480,10 +551,12 @@ class Molecule(ProtoModel):
         return self.get_hash() == other.get_hash()
 
     def dict(self, *args, **kwargs):
+        kwargs.setdefault("exclude_unset", True)
         kwargs.setdefault("by_alias", True)
         return super().dict(*args, **kwargs)
 
     def json(self, *args, **kwargs):
+        kwargs.setdefault("exclude_unset", True)
         kwargs.setdefault("by_alias", True)
         return super().json(*args, **kwargs)
 
@@ -693,11 +766,16 @@ class Molecule(ProtoModel):
         m = hashlib.sha1()
         concat = ""
 
-        tmp_dict = super().dict(exclude_unset=False)
+        print(self.masses)
+        tmp_dict = super().dict(exclude_unset=False, by_alias=True)
+        print("superdict")
+        for k, v in tmp_dict.items():
+            print(k, v)
 
         np.set_printoptions(precision=16)
         for field in self.hash_fields:
             data = tmp_dict[field]
+            print(field, data)
             if field == "geometry":
                 data = float_prep(data, GEOMETRY_NOISE)
             elif field == "fragment_charges":
@@ -1328,6 +1406,8 @@ class Molecule(ProtoModel):
 
 
 def _filter_defaults(dicary):
+    nat = len(dicary["symbols"])
+
     default_mass = np.array([periodictable.to_mass(z) for z in dicary["atomic_numbers"]])
     if np.allclose(default_mass, dicary["masses"]):
         dicary.pop("mass_numbers")
@@ -1337,8 +1417,18 @@ def _filter_defaults(dicary):
     if all(dicary["real"]):
         dicary.pop("real")
 
-    if dicary["atom_labels"].tolist() == len(dicary["symbols"]) * [""]:
+    if dicary["atom_labels"].tolist() == nat * [""]:
         dicary.pop("atom_labels")
+
+    if "connectivity" in dicary and dicary["connectivity"] == []:
+        dicary.pop("connectivity")
+
+    if ((dicary["fragments"] == [list(np.arange(nat))]) and
+         all([fr == 0.0  for fr in dicary["fragment_charges"]]) and
+         all([fr == 1  for fr in dicary["fragment_multiplicities"]])):
+        dicary.pop("fragments")
+        dicary.pop("fragment_charges")
+        dicary.pop("fragment_multiplicities")
 
     return dicary
 

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -259,7 +259,6 @@ class Molecule(ProtoModel):
             "fragment_charges_": "fragment_charges",
             "fragment_multiplicities_": "fragment_multiplicities",
         }
-        force_skip_defaults: bool = True
 
     def __init__(self, orient: bool = False, validate: Optional[bool] = None, **kwargs: Any) -> None:
         """Initializes the molecule object from dictionary-like values.
@@ -501,14 +500,8 @@ class Molecule(ProtoModel):
         return self.get_hash() == other.get_hash()
 
     def dict(self, *args, **kwargs):
-        kwargs.setdefault("exclude_unset", True)
         kwargs.setdefault("by_alias", True)
         return super().dict(*args, **kwargs)
-
-    def json(self, *args, **kwargs):
-        kwargs.setdefault("exclude_unset", True)
-        kwargs.setdefault("by_alias", True)
-        return super().json(*args, **kwargs)
 
     def pretty_print(self):
         """Print the molecule in Angstroms. Same as :py:func:`print_out` only always in Angstroms.
@@ -1352,7 +1345,6 @@ class Molecule(ProtoModel):
 
 
 def _filter_defaults(dicary):
-    #    print("\nfilter pree:", sorted(dicary))
     nat = len(dicary["symbols"])
     default_mass = np.array([periodictable.to_mass(e) for e in dicary["symbols"]])
 

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -298,8 +298,6 @@ class Molecule(ProtoModel):
             values["symbols"] = np.core.defchararray.title(self.symbols)  # Title case for consistency
 
         if orient:
-            if "masses" not in values:  # Setup masses before fixing the orientation
-                values["masses"] = np.array([periodictable.to_mass(x) for x in values["symbols"]])
             values["geometry"] = float_prep(self._orient_molecule_internal(), GEOMETRY_NOISE)
         elif validate:
             values["geometry"] = float_prep(values["geometry"], GEOMETRY_NOISE)

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -1395,12 +1395,14 @@ class Molecule(ProtoModel):
 
 
 def _filter_defaults(dicary):
+    #    print("\nfilter pree:", sorted(dicary))
     nat = len(dicary["symbols"])
+    default_mass = np.array([periodictable.to_mass(e) for e in dicary["symbols"]])
 
-    default_mass = np.array([periodictable.to_mass(z) for z in dicary["atomic_numbers"]])
+    dicary.pop("atomic_numbers")
+
     if np.allclose(default_mass, dicary["masses"]):
         dicary.pop("mass_numbers")
-        dicary.pop("atomic_numbers")
         dicary.pop("masses")
 
     if all(dicary["real"]):

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -302,47 +302,6 @@ class Molecule(ProtoModel):
         elif validate:
             values["geometry"] = float_prep(values["geometry"], GEOMETRY_NOISE)
 
-        #        # Cleanup un-initialized variables  (more complex than Pydantic Validators allow)
-        #        if values["fragments"] is not None:
-        #            if values["fragment_charges"] is None:
-        #                if np.isclose(values["molecular_charge"], 0.0):
-        #                    values["fragment_charges"] = [0 for _ in values["fragments"]]
-        #                else:
-        #                    raise KeyError("Fragments passed in, but not fragment charges for a charged molecule.")
-        #
-        #            if values["fragment_multiplicities"] is None:
-        #                if values["molecular_multiplicity"] == 1:
-        #                    values["fragment_multiplicities"] = [1 for _ in values["fragments"]]
-        #                else:
-        #                    raise KeyError("Fragments passed in, but not fragment multiplicities for a non-singlet molecule.")
-
-        if "masses" in values:
-            values["masses_"] = values["masses"]
-
-        if "real" in values:
-            values["real_"] = values["real"]
-
-        if "atom_labels" in values:
-            values["atom_labels_"] = values["atom_labels"]
-
-        if "atomic_numbers" in values:
-            values["atomic_numbers_"] = values["atomic_numbers"]
-
-        if "mass_numbers" in values:
-            values["mass_numbers_"] = values["mass_numbers"]
-
-        if "connectivity" in values:
-            values["connectivity_"] = values["connectivity"]
-
-        if "fragments" in values:
-            values["fragments_"] = values["fragments"]
-
-        if "fragment_charges" in values:
-            values["fragment_charges_"] = values["fragment_charges"]
-
-        if "fragment_multiplicities" in values:
-            values["fragment_multiplicities_"] = values["fragment_multiplicities"]
-
     @validator("geometry")
     def _must_be_3n(cls, v, values, **kwargs):
         n = len(values["symbols"])
@@ -1409,7 +1368,7 @@ def _filter_defaults(dicary):
     if dicary["atom_labels"].tolist() == nat * [""]:
         dicary.pop("atom_labels")
 
-    if "connectivity" in dicary and dicary["connectivity"] == []:
+    if dicary.get("connectivity", "N/A") is None:
         dicary.pop("connectivity")
 
     if dicary["fragments"] == [list(np.arange(nat))]:

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -264,6 +264,19 @@ def test_from_data_kwargs():
     assert mol.fragment_charges[0] == 1
     assert mol.fragment_multiplicities[0] == 2
 
+    with pytest.raises(qcel.ValidationError) as e:
+        mol = Molecule.from_data(
+            """
+            O 0 0 0
+            H 0 1.5 0
+            H 0 0 1.5
+            """,
+            molecular_charge=1,
+            molecular_multiplicity=2,
+            fragment_charges=[2],
+        )
+    assert "Inconsistent or unspecified chg/mult" in str(e.value)
+
 
 def test_water_orient():
     # These are identical molecules, should find the correct results

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -630,3 +630,14 @@ def test_molecule_connectivity():
     connectivity[0][0] = -1
     with pytest.raises(ValueError):
         mol = Molecule(**data, connectivity=connectivity)
+
+
+def test_orient_nomasses():
+    """
+    Masses must be auto generated on the fly
+    """
+
+    mol = Molecule(symbols=["He", "He"], geometry=[0, 0, -2, 0, 0, 2], orient=True, validated=True)
+
+    assert mol.__dict__["masses_"] is None
+    assert compare_values([[2, 0, 0], [-2, 0, 0]], mol.geometry)

--- a/qcelemental/tests/test_molparse_from_string.py
+++ b/qcelemental/tests/test_molparse_from_string.py
@@ -347,7 +347,7 @@ def test_psi4_qm_2a():
 
     kmol = Molecule.from_data(subject)
     _check_eq_molrec_minimal_model(
-        ["fragments", "fragment_charges", "fragment_multiplicities", "mass_numbers", "masses", "atom_labels", "real",],
+        ["fragments", "fragment_charges", "fragment_multiplicities", "mass_numbers", "masses", "atom_labels", "real"],
         kmol.dict(),
         fullans,
     )

--- a/qcelemental/tests/test_molparse_from_string.py
+++ b/qcelemental/tests/test_molparse_from_string.py
@@ -347,18 +347,7 @@ def test_psi4_qm_2a():
 
     kmol = Molecule.from_data(subject)
     _check_eq_molrec_minimal_model(
-        [
-            "fix_com",
-            "fix_orientation",
-            "fragments",
-            "fragment_charges",
-            "fragment_multiplicities",
-            "mass_numbers",
-            "masses",
-            "atom_labels",
-            "real",
-            "atomic_numbers",
-        ],
+        ["fragments", "fragment_charges", "fragment_multiplicities", "mass_numbers", "masses", "atom_labels", "real",],
         kmol.dict(),
         fullans,
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Continuation of #190 with all fields targeted. This is strictly test driven dev on existing test suite. All pass but 3 and those are ok if turn off default filtering. The 3 that don't pass I don't understand b/c masses are perfectly accessible (https://github.com/MolSSI/QCElemental/compare/master...loriab:smollmol2?expand=1#diff-c1df0b88317a0c0331bea59a1793059cR769) but not getting stashed for hashing.

```
[ 1.00782503223 15.99491461957 15.99491461957  1.00782503223]
superdict
schema_name qcschema_molecule
schema_version 2
validated True
symbols ['H' 'O' 'O' 'H']
geometry [[ 1.7317  1.2909  1.0371]
 [ 1.3156 -0.0074 -0.2807]
 [-1.3143  0.0084 -0.2741]
 [-1.7241 -1.3079  1.0277]]
name H2O2
identifiers None
comment None
molecular_charge 0.0
molecular_multiplicity 1
masses None
real None
atom_labels None
atomic_numbers None
mass_numbers None
connectivity None
fragments None
fragment_charges None
fragment_multiplicities None
fix_com False
fix_orientation False
fix_symmetry None
provenance {'creator': 'QCElemental', 'version': 'v0.12.0+59.gce318ac', 'routine': 'qcelemental.molparse.from_schema'}
id None
extras None
symbols ['H' 'O' 'O' 'H']
masses None
```

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
