### PR TITLE
Units: add atomic unit of time

### DIFF
--- a/qcelemental/info/cpu_info.py
+++ b/qcelemental/info/cpu_info.py
@@ -5,8 +5,8 @@ Contains metadata about Processors
 import difflib
 import re
 from enum import Enum
-from typing import List, Optional
 from functools import lru_cache
+from typing import List, Optional
 
 from pydantic import Field
 

--- a/qcelemental/physical_constants/ureg.py
+++ b/qcelemental/physical_constants/ureg.py
@@ -43,6 +43,9 @@ def build_units_registry(context):
     ureg.define("wavenumber = 1 / centimeter")
     ureg.define("Angstrom = angstrom")
 
+    # Time
+    ureg.define(f"au_time = {phys_const['atomic unit of time']['value']} * {phys_const['atomic unit of time']['unit']}")
+
     # Masses
     ureg.define(
         "atomic_mass_unit = {} * kilogram = u = amu = dalton = Da".format(phys_const["atomic mass constant"]["value"])

--- a/qcelemental/tests/test_units.py
+++ b/qcelemental/tests/test_units.py
@@ -78,3 +78,14 @@ def test_quantities_smoke():
     Smoke test to ensure Quantities are correctly returned
     """
     assert 5 == qcelemental.constants.Quantity("5 kcal").magnitude
+
+
+def test_speed_of_light():
+    assert (
+        pytest.approx(
+            qcelemental.constants.speed_of_light_in_vacuum
+            * qcelemental.constants.conversion_factor("m/s", "bohr/au_time"),
+            1e-8,
+        )
+        == qcelemental.constants.c_au
+    )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR adds the atomic unit of time to the units registry as `au_time`. 

## Changelog description
The atomic unit of time has been added to the units registry (named `"au_time"`).

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
