### PR TITLE
trigger slim mol in AtomicResult.dict() in test suite

### DIFF
--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -501,7 +501,7 @@ class Molecule(ProtoModel):
 
     def dict(self, *args, **kwargs):
         kwargs["by_alias"] = True
-        kwargs["skip_defaults"] = True
+        kwargs["exclude_unset"] = True
         return super().dict(*args, **kwargs)
 
     def pretty_print(self):

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -500,7 +500,8 @@ class Molecule(ProtoModel):
         return self.get_hash() == other.get_hash()
 
     def dict(self, *args, **kwargs):
-        kwargs.setdefault("by_alias", True)
+        kwargs["by_alias"] = True
+        kwargs["skip_defaults"] = True
         return super().dict(*args, **kwargs)
 
     def pretty_print(self):

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -297,11 +297,6 @@ class AtomicInput(ProtoModel):
 
     provenance: Provenance = Field(Provenance(**provenance_stamp(__name__)), description=str(Provenance.__base_doc__))
 
-    #def dict(self, *args, **kwargs):
-    #    kwargs.setdefault("by_alias", True)
-    #    kwargs.setdefault("skip_defaults", True)
-    #    return super().dict(*args, **kwargs)
-
     def __repr_args__(self) -> "ReprArgs":
         return [
             ("driver", self.driver.value),

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -297,6 +297,11 @@ class AtomicInput(ProtoModel):
 
     provenance: Provenance = Field(Provenance(**provenance_stamp(__name__)), description=str(Provenance.__base_doc__))
 
+    #def dict(self, *args, **kwargs):
+    #    kwargs.setdefault("by_alias", True)
+    #    kwargs.setdefault("skip_defaults", True)
+    #    return super().dict(*args, **kwargs)
+
     def __repr_args__(self) -> "ReprArgs":
         return [
             ("driver", self.driver.value),

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -323,22 +323,6 @@ def test_result_build_stdout(result_data_fixture):
     assert ret.stdout == "I ran."
 
 
-def test_moldict(result_data_fixture):
-    # mret = qcel.models.Molecule(**result_data_fixture['molecule'])
-    mret = result_data_fixture["molecule"]
-    print(mret.dict())
-
-    # Molecule model builds back from dict
-    mret = qcel.models.Molecule(**result_data_fixture["molecule"].dict())
-    print(mret.dict())
-
-    # AtomicResult model with Molecule inside does not
-    ares = qcel.models.AtomicResult(**result_data_fixture)
-    print(ares.dict())
-    model = qcel.models.AtomicResult(**ares.dict())
-    print(model.dict())
-
-
 def test_failed_operation(result_data_fixture):
     water = qcel.models.Molecule.from_data(
         """
@@ -358,6 +342,35 @@ def test_failed_operation(result_data_fixture):
     failed_json = failed.json()
     assert isinstance(failed_json, str)
     assert "its all good" in failed_json
+
+
+@pytest.mark.parametrize(
+    "smodel", ["molecule", "atomicresultproperties", "atomicinput", "atomicresult", "optimizationresult"]
+)
+def test_model_dictable(result_data_fixture, optimization_data_fixture, smodel):
+
+    if smodel == "molecule":
+        model = qcel.models.Molecule
+        data = result_data_fixture["molecule"].dict()
+
+    elif smodel == "atomicresultproperties":
+        model = qcel.models.AtomicResultProperties
+        data = {"scf_one_electron_energy": "-5.0"}
+
+    elif smodel == "atomicinput":
+        model = qcel.models.AtomicInput
+        data = {k: result_data_fixture[k] for k in ["molecule", "model", "driver"]}
+
+    elif smodel == "atomicresult":
+        model = qcel.models.AtomicResult
+        data = result_data_fixture
+
+    elif smodel == "optimizationresult":
+        model = qcel.models.OptimizationResult
+        data = optimization_data_fixture
+
+    instance = model(**data)
+    assert model(**instance.dict())
 
 
 def test_result_model_deprecations(result_data_fixture, optimization_data_fixture):

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -324,12 +324,12 @@ def test_result_build_stdout(result_data_fixture):
 
 
 def test_moldict(result_data_fixture):
-    #mret = qcel.models.Molecule(**result_data_fixture['molecule'])
-    mret = result_data_fixture['molecule']
+    # mret = qcel.models.Molecule(**result_data_fixture['molecule'])
+    mret = result_data_fixture["molecule"]
     print(mret.dict())
 
     # Molecule model builds back from dict
-    mret = qcel.models.Molecule(**result_data_fixture['molecule'].dict())
+    mret = qcel.models.Molecule(**result_data_fixture["molecule"].dict())
     print(mret.dict())
 
     # AtomicResult model with Molecule inside does not

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -323,6 +323,22 @@ def test_result_build_stdout(result_data_fixture):
     assert ret.stdout == "I ran."
 
 
+def test_moldict(result_data_fixture):
+    #mret = qcel.models.Molecule(**result_data_fixture['molecule'])
+    mret = result_data_fixture['molecule']
+    print(mret.dict())
+
+    # Molecule model builds back from dict
+    mret = qcel.models.Molecule(**result_data_fixture['molecule'].dict())
+    print(mret.dict())
+
+    # AtomicResult model with Molecule inside does not
+    ares = qcel.models.AtomicResult(**result_data_fixture)
+    print(ares.dict())
+    model = qcel.models.AtomicResult(**ares.dict())
+    print(model.dict())
+
+
 def test_failed_operation(result_data_fixture):
     water = qcel.models.Molecule.from_data(
         """


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
trigger slim mol in AtomicResult.dict() in test suite

should trigger the error:
```
E   pydantic.error_wrappers.ValidationError: 9 validation errors for AtomicResult
E   molecule -> atom_labels_
E     extra fields not permitted (type=value_error.extra)
E   molecule -> atomic_numbers_
E     extra fields not permitted (type=value_error.extra)
E   molecule -> connectivity_
E     extra fields not permitted (type=value_error.extra)
E   molecule -> fragment_charges_
E     extra fields not permitted (type=value_error.extra)
E   molecule -> fragment_multiplicities_
E     extra fields not permitted (type=value_error.extra)
E   molecule -> fragments_
E     extra fields not permitted (type=value_error.extra)
E   molecule -> mass_numbers_
E     extra fields not permitted (type=value_error.extra)
E   molecule -> masses_
E     extra fields not permitted (type=value_error.extra)
E   molecule -> real_
E     extra fields not permitted (type=value_error.extra)
```

uncommenting the `def dict` with `by_alias` yields a new error:
```
E   pydantic.error_wrappers.ValidationError: 2 validation errors for AtomicResult
E   molecule -> masses
E     object of type 'NoneType' has no len() (type=type_error)
E   molecule -> real
E     object of type 'NoneType' has no len() (type=type_error)
```
the skip_defaults fixes that. but this probably isn't the right way (indeed, the skip_defaults line breaks psi4 again)

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
