### PR TITLE
dipole as array

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,7 +13,8 @@ Changelog
 .. Bug Fixes
 .. +++++++++
 
-X.Y.0 / 2020-MM-DD
+
+0.14.0 / 2020-03-DD
 -------------------
 
 New Features
@@ -23,10 +24,13 @@ Enhancements
 ++++++++++++
 - (:pr:`211`) Improve testing reliability by excusing PubChem when internet flaky.
 - (:pr:`216`) "CODATA2018" constants now tested.
+- (:pr:`207`) Multipoles exist in ``AtomicResultProperties`` as ndarray with order-dimensional shape.
+  Property ``scf_quadrupole_moment`` defined.
 
 Bug Fixes
 +++++++++
 - (:pr:`216`) Fixes a bug where "CODATA2018" constants could not be used with ``conversion_factor``.
+- (:pr:`217`) Can now run ``.schema()`` on pydantic classes containing ``Array`` fields (allowing ndarray in place of List).
 
 
 0.13.1 / 2020-02-05

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -50,7 +50,8 @@ class AtomicResultProperties(ProtoModel):
         None,
         description="The dispersion correction appended to an underlying functional when a DFT-D method is requested.",
     )
-    scf_dipole_moment: Optional[List[float]] = Field(None, description="The X, Y, and Z dipole components.")
+    scf_dipole_moment: Optional[Array[float]] = Field(None, description="The X, Y, and Z dipole components.")
+    scf_quadrupole_moment: Optional[Array[float]] = Field(None, description="The (3, 3) quadrupole components (redundant; 6 unique).")
     scf_total_energy: Optional[float] = Field(
         None, description="The total electronic energy of the SCF stage of the calculation."
     )
@@ -78,7 +79,7 @@ class AtomicResultProperties(ProtoModel):
     mp2_total_energy: Optional[float] = Field(
         None, description="The total MP2 energy (MP2 correlation energy + HF energy)."
     )
-    mp2_dipole_moment: Optional[List[float]] = Field(None, description="The MP2 X, Y, and Z dipole components.")
+    mp2_dipole_moment: Optional[Array[float]] = Field(None, description="The MP2 X, Y, and Z dipole components.")
 
     # CCSD Keywords
     ccsd_same_spin_correlation_energy: Optional[float] = Field(
@@ -99,7 +100,7 @@ class AtomicResultProperties(ProtoModel):
     ccsd_total_energy: Optional[float] = Field(
         None, description="The total CCSD energy (CCSD correlation energy + HF energy)."
     )
-    ccsd_dipole_moment: Optional[List[float]] = Field(None, description="The CCSD X, Y, and Z dipole components.")
+    ccsd_dipole_moment: Optional[Array[float]] = Field(None, description="The CCSD X, Y, and Z dipole components.")
     ccsd_iterations: Optional[int] = Field(None, description="The number of CCSD iterations taken before convergence.")
 
     # CCSD(T) keywords
@@ -107,7 +108,7 @@ class AtomicResultProperties(ProtoModel):
     ccsd_prt_pr_total_energy: Optional[float] = Field(
         None, description="The total CCSD(T) energy (CCSD(T) correlation energy + HF energy)."
     )
-    ccsd_prt_pr_dipole_moment: Optional[List[float]] = Field(
+    ccsd_prt_pr_dipole_moment: Optional[Array[float]] = Field(
         None, description="The CCSD(T) X, Y, and Z dipole components."
     )
 

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -120,6 +120,16 @@ class AtomicResultProperties(ProtoModel):
     def __repr_args__(self) -> "ReprArgs":
         return [(k, v) for k, v in self.dict().items()]
 
+    @validator("scf_dipole_moment", "mp2_dipole_moment", "ccsd_dipole_moment", "ccsd_prt_pr_dipole_moment")
+    def _validate_dipoles(cls, v, values):
+        shape = tuple([3] * 1)
+        return np.asarray(v).reshape(shape)
+
+    @validator("scf_quadrupole_moment")
+    def _validate_quadrupoles(cls, v, values):
+        shape = tuple([3] * 2)
+        return np.asarray(v).reshape(shape)
+
 
 class WavefunctionProperties(ProtoModel):
 

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -140,6 +140,7 @@ class AtomicResultProperties(ProtoModel):
         return np.asarray(v).reshape(shape)
 
     def dict(self, *args, **kwargs):
+        # pure-json dict repr for QCFractal compliance, see https://github.com/MolSSI/QCFractal/issues/579
         kwargs["encoding"] = "json"
         return super().dict(*args, **kwargs)
 

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -51,7 +51,9 @@ class AtomicResultProperties(ProtoModel):
         description="The dispersion correction appended to an underlying functional when a DFT-D method is requested.",
     )
     scf_dipole_moment: Optional[Array[float]] = Field(None, description="The X, Y, and Z dipole components.")
-    scf_quadrupole_moment: Optional[Array[float]] = Field(None, description="The (3, 3) quadrupole components (redundant; 6 unique).")
+    scf_quadrupole_moment: Optional[Array[float]] = Field(
+        None, description="The (3, 3) quadrupole components (redundant; 6 unique)."
+    )
     scf_total_energy: Optional[float] = Field(
         None, description="The total electronic energy of the SCF stage of the calculation."
     )

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -120,15 +120,25 @@ class AtomicResultProperties(ProtoModel):
     def __repr_args__(self) -> "ReprArgs":
         return [(k, v) for k, v in self.dict().items()]
 
-    @validator("scf_dipole_moment", "mp2_dipole_moment", "ccsd_dipole_moment", "ccsd_prt_pr_dipole_moment")
-    def _validate_dipoles(cls, v, values):
-        shape = tuple([3] * 1)
+    @validator(
+        "scf_dipole_moment",
+        "mp2_dipole_moment",
+        "ccsd_dipole_moment",
+        "ccsd_prt_pr_dipole_moment",
+        "scf_quadrupole_moment",
+    )
+    def _validate_poles(cls, v, values, field):
+        if field.name.endswith("_dipole_moment"):
+            order = 1
+        elif field.name.endswith("_quadrupole_moment"):
+            order = 2
+
+        shape = tuple([3] * order)
         return np.asarray(v).reshape(shape)
 
-    @validator("scf_quadrupole_moment")
-    def _validate_quadrupoles(cls, v, values):
-        shape = tuple([3] * 2)
-        return np.asarray(v).reshape(shape)
+    def dict(self, *args, **kwargs):
+        kwargs["encoding"] = "json"
+        return super().dict(*args, **kwargs)
 
 
 class WavefunctionProperties(ProtoModel):

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -128,6 +128,9 @@ class AtomicResultProperties(ProtoModel):
         "scf_quadrupole_moment",
     )
     def _validate_poles(cls, v, values, field):
+        if v is None:
+            return v
+
         if field.name.endswith("_dipole_moment"):
             order = 1
         elif field.name.endswith("_quadrupole_moment"):

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Union
 
 import numpy as np
 from pydantic import Field, constr, validator

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -371,7 +371,7 @@ def test_model_dictable(result_data_fixture, optimization_data_fixture, smodel):
 
     elif smodel == "atomicresultproperties":
         model = qcel.models.AtomicResultProperties
-        data = {"scf_one_electron_energy": "-5.0", "scf_dipole_moment": [1, 2, 3]}
+        data = {"scf_one_electron_energy": "-5.0", "scf_dipole_moment": [1, 2, 3], "ccsd_dipole_moment": None}
 
     elif smodel == "atomicinput":
         model = qcel.models.AtomicInput

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -344,6 +344,19 @@ def test_failed_operation(result_data_fixture):
     assert "its all good" in failed_json
 
 
+def test_result_properties_array():
+
+    obj = qcel.models.AtomicResultProperties(
+        scf_one_electron_energy="-5.0", scf_dipole_moment=[1, 2, 3], scf_quadrupole_moment=[1, 2, 3, 2, 4, 5, 3, 5, 6]
+    )
+
+    assert pytest.approx(obj.scf_one_electron_energy) == -5.0
+    assert obj.scf_dipole_moment.shape == (3,)
+    assert obj.scf_quadrupole_moment.shape == (3, 3)
+
+    assert obj.dict().keys() == {"scf_one_electron_energy", "scf_dipole_moment", "scf_quadrupole_moment"}
+
+
 @pytest.mark.parametrize(
     "smodel", ["molecule", "atomicresultproperties", "atomicinput", "atomicresult", "optimizationresult"]
 )
@@ -355,7 +368,7 @@ def test_model_dictable(result_data_fixture, optimization_data_fixture, smodel):
 
     elif smodel == "atomicresultproperties":
         model = qcel.models.AtomicResultProperties
-        data = {"scf_one_electron_energy": "-5.0"}
+        data = {"scf_one_electron_energy": "-5.0", "scf_dipole_moment": [1, 2, 3]}
 
     elif smodel == "atomicinput":
         model = qcel.models.AtomicInput

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -345,9 +345,10 @@ def test_failed_operation(result_data_fixture):
 
 
 def test_result_properties_array():
+    lquad = [1, 2, 3, 2, 4, 5, 3, 5, 6]
 
     obj = qcel.models.AtomicResultProperties(
-        scf_one_electron_energy="-5.0", scf_dipole_moment=[1, 2, 3], scf_quadrupole_moment=[1, 2, 3, 2, 4, 5, 3, 5, 6]
+        scf_one_electron_energy="-5.0", scf_dipole_moment=[1, 2, 3], scf_quadrupole_moment=lquad
     )
 
     assert pytest.approx(obj.scf_one_electron_energy) == -5.0
@@ -355,6 +356,8 @@ def test_result_properties_array():
     assert obj.scf_quadrupole_moment.shape == (3, 3)
 
     assert obj.dict().keys() == {"scf_one_electron_energy", "scf_dipole_moment", "scf_quadrupole_moment"}
+    assert np.array_equal(obj.scf_quadrupole_moment, np.array(lquad).reshape(3, 3))
+    assert obj.dict()["scf_quadrupole_moment"] == lquad
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Allow array serialization of dipoles. Venture a quadrupole.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
