### PR TITLE
Molecule Hash Canary Tests

### DIFF
--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -275,6 +275,8 @@ class Molecule(ProtoModel):
         if validate is None:
             validate = not kwargs.get("validated", False)
 
+        geometry_prep = kwargs.pop("_geometry_prep", False)
+
         if validate:
             kwargs["schema_name"] = kwargs.pop("schema_name", "qcschema_molecule")
             kwargs["schema_version"] = kwargs.pop("schema_version", 2)
@@ -298,7 +300,7 @@ class Molecule(ProtoModel):
 
         if orient:
             values["geometry"] = float_prep(self._orient_molecule_internal(), GEOMETRY_NOISE)
-        elif validate:
+        elif validate or geometry_prep:
             values["geometry"] = float_prep(values["geometry"], GEOMETRY_NOISE)
 
     @validator("geometry")
@@ -816,6 +818,7 @@ class Molecule(ProtoModel):
             input_dict = to_schema(mol_dict["qm"], dtype=2, np_out=True)
             input_dict = _filter_defaults(input_dict)
             input_dict["validated"] = True
+            input_dict["_geometry_prep"] = True
         elif dtype == "numpy":
             data = np.asarray(data)
             data = {
@@ -827,6 +830,7 @@ class Molecule(ProtoModel):
             input_dict = to_schema(from_arrays(**data), dtype=2, np_out=True)
             input_dict = _filter_defaults(input_dict)
             input_dict["validated"] = True
+            input_dict["_geometry_prep"] = True
         elif dtype == "msgpack":
             assert isinstance(data, bytes)
             input_dict = msgpackext_loads(data)

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -73,6 +73,32 @@ def test_molecule_data_constructor_error():
         Molecule.from_data({}, dtype="bad")
 
 
+def test_hash_canary():
+    water_dimer_minima = Molecule.from_data(
+        """
+    0 1
+    O  -1.551007  -0.114520   0.000000
+    H  -1.934259   0.762503   0.000000
+    H  -0.599677   0.040712   0.000000
+    --
+    O   1.350625   0.111469   0.000000
+    H   1.680398  -0.373741  -0.758561
+    H   1.680398  -0.373741   0.758561
+    """,
+        dtype="psi4",
+    )
+    assert water_dimer_minima.get_hash() == "42f3ac52af52cf2105c252031334a2ad92aa911c"
+
+    # Check orientation
+    mol = water_dimer_minima.orient_molecule()
+    assert mol.get_hash() == "632490a0601500bfc677e9277275f82fbc45affe"
+
+    frag_0 = mol.get_fragment(0, orient=True)
+    frag_1 = mol.get_fragment(1, orient=True)
+    assert frag_0.get_hash() == "d0b499739f763e8d3a5556b4ddaeded6a148e4d5"
+    assert frag_1.get_hash() == "bdc1f75bd1b7b999ff24783d7c1673452b91beb9"
+
+
 def test_molecule_np_constructors():
     """
     Neon tetramer fun


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## Description
Adds all Fractal molecule hash canaries to QCElemental and reverts the order of operations change for hashing molecule in the `from_data` procedure. Hashing molecules is fairly sensitive to the order of operations and this was disrupted slightly when the `from_data` procedure stopped passing the `validate` flag through to the `__init__`. This was primarily done to prevent a duplicate to/from schema, but had the worrying effect that the geometry was not correctly rounded. A new flag has been introduced to fix this particular issue.

## Changelog description
Fixes a Molecule hashing issue due to order of operations changes in `Molecule.from_data`.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
