### PR TITLE
Molecule: add optional Hill order

### DIFF
--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -811,7 +811,6 @@ class Molecule(ProtoModel):
         str
             The molecular formula
         """
-        """Converts a chemical formula to alphabetical order, matching behavior in qcel"""
 
         matches = re.findall("[A-Z][^A-Z]*", formula)
         count = collections.defaultdict(int)

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -735,7 +735,12 @@ class Molecule(ProtoModel):
         Pararmeters
         -----------
         order: str, optional
-            sorting order of the formula. Valid choices are "alphabetical" and "hill".
+            Sorting order of the formula. Valid choices are "alphabetical" and "hill".
+
+        Returns
+        -------
+        str
+            The molecular formula.
 
         Examples
         --------
@@ -758,7 +763,7 @@ class Molecule(ProtoModel):
         ClH
 
         """
-        return self._formula_from_symbols(self.symbols, order)
+        return self._formula_from_symbols(symbols=self.symbols, order=order)
 
     @staticmethod
     def _formula_from_symbols(symbols: List[str], order: str = "alphabetical") -> str:
@@ -770,21 +775,22 @@ class Molecule(ProtoModel):
         symbols: List[str]
             List of chemical symbols
         order: str, optional
-            sorting order of the formula. Valid choices are "alphabetical" and "hill".
+            Sorting order of the formula. Valid choices are "alphabetical" and "hill".
 
         Returns
         -------
         str
-            The molecular formula
+            The molecular formula.
         """
 
         supported_orders = ["alphabetical", "hill"]
-        if order.lower() not in supported_orders:
+        order = order.lower()
+        if order not in supported_orders:
             raise ValueError(f"Unsupported molecular formula order: {order}. Supported orders are f{supported_orders}.")
         count = collections.Counter(x.title() for x in symbols)
         element_order = sorted(count.keys())
 
-        if order.lower() == "hill" and "C" in element_order:
+        if order == "hill" and "C" in element_order:
             if "H" in element_order:
                 element_order.insert(0, element_order.pop(element_order.index("H")))
             element_order.insert(0, element_order.pop(element_order.index("C")))
@@ -808,18 +814,20 @@ class Molecule(ProtoModel):
         formula: str
             A molecular formula
         order: str, optional
-            sorting order of the formula. Valid choices are "alphabetical" and "hill".
+            Sorting order of the formula. Valid choices are "alphabetical" and "hill".
 
         Returns
         -------
         str
-            The molecular formula
+            The molecular formula.
         """
 
-        matches = re.findall("[A-Z][^A-Z]*", formula)
+        matches = re.findall(r"[A-Z][^A-Z]*", formula)
+        if not "".join(matches) == formula:
+            raise ValueError(f"{formula} is not a valid molecular formula.")
         count = collections.defaultdict(int)
         for match in matches:
-            match_n = re.match("(\D+)(\d*)", match)
+            match_n = re.match(r"(\D+)(\d*)", match)
             assert match_n
             if match_n.group(2) == "":
                 n = 1

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -777,6 +777,10 @@ class Molecule(ProtoModel):
         str
             The molecular formula
         """
+
+        supported_orders = ["alphabetical", "hill"]
+        if order.lower() not in supported_orders:
+            raise ValueError(f"Unsupported molecular formula order: {order}. Supported orders are f{supported_orders}.")
         count = collections.Counter(x.title() for x in symbols)
         element_order = sorted(count.keys())
 

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -763,79 +763,10 @@ class Molecule(ProtoModel):
         ClH
 
         """
-        return self._formula_from_symbols(symbols=self.symbols, order=order)
 
-    @staticmethod
-    def _formula_from_symbols(symbols: List[str], order: str = "alphabetical") -> str:
-        """
-        Returns the molecular formula for a list of symbols.
+        from ..molutil import molecular_formula_from_symbols
 
-        Pararmeters
-        -----------
-        symbols: List[str]
-            List of chemical symbols
-        order: str, optional
-            Sorting order of the formula. Valid choices are "alphabetical" and "hill".
-
-        Returns
-        -------
-        str
-            The molecular formula.
-        """
-
-        supported_orders = ["alphabetical", "hill"]
-        order = order.lower()
-        if order not in supported_orders:
-            raise ValueError(f"Unsupported molecular formula order: {order}. Supported orders are f{supported_orders}.")
-        count = collections.Counter(x.title() for x in symbols)
-        element_order = sorted(count.keys())
-
-        if order == "hill" and "C" in element_order:
-            if "H" in element_order:
-                element_order.insert(0, element_order.pop(element_order.index("H")))
-            element_order.insert(0, element_order.pop(element_order.index("C")))
-
-        ret = []
-        for k in element_order:
-            c = count[k]
-            ret.append(k)
-            if c > 1:
-                ret.append(str(c))
-
-        return "".join(ret)
-
-    @staticmethod
-    def order_molecular_formula(formula: str, order: str = "alphabetical") -> str:
-        """
-        Reorders a molecular formula.
-
-        Pararmeters
-        -----------
-        formula: str
-            A molecular formula
-        order: str, optional
-            Sorting order of the formula. Valid choices are "alphabetical" and "hill".
-
-        Returns
-        -------
-        str
-            The molecular formula.
-        """
-
-        matches = re.findall(r"[A-Z][^A-Z]*", formula)
-        if not "".join(matches) == formula:
-            raise ValueError(f"{formula} is not a valid molecular formula.")
-        count = collections.defaultdict(int)
-        for match in matches:
-            match_n = re.match(r"(\D+)(\d*)", match)
-            assert match_n
-            if match_n.group(2) == "":
-                n = 1
-            else:
-                n = int(match_n.group(2))
-            count[match_n.group(1)] += n
-        symbols = [k for k, v in count.items() for i in range(v)]
-        return Molecule._formula_from_symbols(symbols=symbols, order=order)
+        return molecular_formula_from_symbols(symbols=self.symbols, order=order)
 
     ### Constructors
 

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -2,10 +2,8 @@
 Molecule Object Model
 """
 
-import collections
 import hashlib
 import json
-import re
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union

--- a/qcelemental/molutil/__init__.py
+++ b/qcelemental/molutil/__init__.py
@@ -1,2 +1,3 @@
 from .align import B787, compute_scramble, kabsch_align
 from .connectivity import guess_connectivity
+from .molecular_formula import order_molecular_formula, molecular_formula_from_symbols

--- a/qcelemental/molutil/molecular_formula.py
+++ b/qcelemental/molutil/molecular_formula.py
@@ -1,0 +1,75 @@
+import collections
+import re
+from typing import List
+
+
+def order_molecular_formula(formula: str, order: str = "alphabetical") -> str:
+    """
+    Reorders a molecular formula.
+
+    Pararmeters
+    -----------
+    formula: str
+        A molecular formula
+    order: str, optional
+        Sorting order of the formula. Valid choices are "alphabetical" and "hill".
+
+    Returns
+    -------
+    str
+        The molecular formula.
+    """
+
+    matches = re.findall(r"[A-Z][^A-Z]*", formula)
+    if not "".join(matches) == formula:
+        raise ValueError(f"{formula} is not a valid molecular formula.")
+    count = collections.defaultdict(int)
+    for match in matches:
+        match_n = re.match(r"(\D+)(\d*)", match)
+        assert match_n
+        if match_n.group(2) == "":
+            n = 1
+        else:
+            n = int(match_n.group(2))
+        count[match_n.group(1)] += n
+    symbols = [k for k, v in count.items() for i in range(v)]
+    return molecular_formula_from_symbols(symbols=symbols, order=order)
+
+
+def molecular_formula_from_symbols(symbols: List[str], order: str = "alphabetical") -> str:
+    """
+    Returns the molecular formula for a list of symbols.
+
+    Pararmeters
+    -----------
+    symbols: List[str]
+        List of chemical symbols
+    order: str, optional
+        Sorting order of the formula. Valid choices are "alphabetical" and "hill".
+
+    Returns
+    -------
+    str
+        The molecular formula.
+    """
+
+    supported_orders = ["alphabetical", "hill"]
+    order = order.lower()
+    if order not in supported_orders:
+        raise ValueError(f"Unsupported molecular formula order: {order}. Supported orders are f{supported_orders}.")
+    count = collections.Counter(x.title() for x in symbols)
+    element_order = sorted(count.keys())
+
+    if order == "hill" and "C" in element_order:
+        if "H" in element_order:
+            element_order.insert(0, element_order.pop(element_order.index("H")))
+        element_order.insert(0, element_order.pop(element_order.index("C")))
+
+    ret = []
+    for k in element_order:
+        c = count[k]
+        ret.append(k)
+        if c > 1:
+            ret.append(str(c))
+
+    return "".join(ret)

--- a/qcelemental/molutil/test_molutil.py
+++ b/qcelemental/molutil/test_molutil.py
@@ -572,3 +572,31 @@ def test_guess_connectivity(args, kwargs, ans):
 
     computed = qcel.molutil.guess_connectivity(*args, **kwargs)
     assert compare(computed, ans)
+
+
+@pytest.mark.parametrize(
+    "input,order,expected",
+    [
+        ("NH3", "alphabetical", "H3N"),
+        ("NH3", "hill", "H3N"),
+        ("CH4", "alphabetical", "CH4"),
+        ("CH4", "hill", "CH4"),
+        ("IBr", "alphabetical", "BrI"),
+        ("IBr", "hill", "BrI"),
+        ("CCl4", "alphabetical", "CCl4"),
+        ("CCl4", "hill", "CCl4"),
+        ("CBr4", "alphabetical", "Br4C"),
+        ("CBr4", "hill", "CBr4"),
+        ("CBrH3", "alphabetical", "BrCH3"),
+        ("CBrH3", "hill", "CH3Br"),
+    ],
+)
+def test_order_molecular_formula(input, order, expected):
+    assert qcel.molutil.order_molecular_formula(input, order=order) == expected
+
+
+def test_bad_formula_order():
+    with pytest.raises(ValueError):
+        qcel.molutil.order_molecular_formula("CH4", order="disorder")
+    with pytest.raises(ValueError):
+        qcel.molutil.order_molecular_formula("ch4")

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -72,6 +72,11 @@ def test_order_molecular_formula(input, order, expected):
     assert Molecule.order_molecular_formula(input, order) == expected
 
 
+def test_bad_formula_order():
+    with pytest.raises(ValueError):
+        Molecule.order_molecular_formula("CH4", "disorder")
+
+
 def test_molecule_data_constructor_dict():
     water_psi = water_dimer_minima.copy()
 

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -47,6 +47,29 @@ def test_molecule_data_constructor_numpy():
     water_from_np = Molecule.from_data(npwater, name="water dimer", frags=[3])
     assert water_psi == water_from_np
     assert water_psi.get_molecular_formula() == "H4O2"
+    assert water_psi.get_molecular_formula(order="alphabetical") == "H4O2"
+    assert water_psi.get_molecular_formula(order="hill") == "H4O2"
+
+
+@pytest.mark.parametrize(
+    "input,order,expected",
+    [
+        ("NH3", "alphabetical", "H3N"),
+        ("NH3", "hill", "H3N"),
+        ("CH4", "alphabetical", "CH4"),
+        ("CH4", "hill", "CH4"),
+        ("IBr", "alphabetical", "BrI"),
+        ("IBr", "hill", "BrI"),
+        ("CCl4", "alphabetical", "CCl4"),
+        ("CCl4", "hill", "CCl4"),
+        ("CBr4", "alphabetical", "Br4C"),
+        ("CBr4", "hill", "CBr4"),
+        ("CBrH3", "alphabetical", "BrCH3"),
+        ("CBrH3", "hill", "CH3Br"),
+    ],
+)
+def test_order_molecular_formula(input, order, expected):
+    assert Molecule.order_molecular_formula(input, order) == expected
 
 
 def test_molecule_data_constructor_dict():

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -51,34 +51,6 @@ def test_molecule_data_constructor_numpy():
     assert water_psi.get_molecular_formula(order="hill") == "H4O2"
 
 
-@pytest.mark.parametrize(
-    "input,order,expected",
-    [
-        ("NH3", "alphabetical", "H3N"),
-        ("NH3", "hill", "H3N"),
-        ("CH4", "alphabetical", "CH4"),
-        ("CH4", "hill", "CH4"),
-        ("IBr", "alphabetical", "BrI"),
-        ("IBr", "hill", "BrI"),
-        ("CCl4", "alphabetical", "CCl4"),
-        ("CCl4", "hill", "CCl4"),
-        ("CBr4", "alphabetical", "Br4C"),
-        ("CBr4", "hill", "CBr4"),
-        ("CBrH3", "alphabetical", "BrCH3"),
-        ("CBrH3", "hill", "CH3Br"),
-    ],
-)
-def test_order_molecular_formula(input, order, expected):
-    assert Molecule.order_molecular_formula(input, order=order) == expected
-
-
-def test_bad_formula_order():
-    with pytest.raises(ValueError):
-        Molecule.order_molecular_formula("CH4", order="disorder")
-    with pytest.raises(ValueError):
-        Molecule.order_molecular_formula("ch4")
-
-
 def test_molecule_data_constructor_dict():
     water_psi = water_dimer_minima.copy()
 

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -69,12 +69,14 @@ def test_molecule_data_constructor_numpy():
     ],
 )
 def test_order_molecular_formula(input, order, expected):
-    assert Molecule.order_molecular_formula(input, order) == expected
+    assert Molecule.order_molecular_formula(input, order=order) == expected
 
 
 def test_bad_formula_order():
     with pytest.raises(ValueError):
-        Molecule.order_molecular_formula("CH4", "disorder")
+        Molecule.order_molecular_formula("CH4", order="disorder")
+    with pytest.raises(ValueError):
+        Molecule.order_molecular_formula("ch4")
 
 
 def test_molecule_data_constructor_dict():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
This PR adds the option to Hill-order molecular formulas. It also adds `Molecule.order_molecular_formula` to re-order existing formulas (needed by Fractal). 

Closes #206.

## Changelog description
Added the option to Hill-order molecular formulas. 

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
