### PR TITLE
CI: Non-matrix products builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,11 +8,16 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        conda-env: [base, minimal]
-        python-version: [3.6, 3.8]
+        cfg:
+          - conda-env: minimal
+            python-version: 3.6
+          - conda-env: base
+            python-version: 3.6
+          - conda-env: base
+            python-version: 3.8
     env:
-      PYVER: ${{ matrix.python-version }}
-      CONDA_ENV: ${{ matrix.conda-env }}
+      PYVER: ${{ matrix.cfg.python-version }}
+      CONDA_ENV: ${{ matrix.cfg.conda-env }}
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Format
 
 on: [push, pull_request]
 
@@ -21,7 +21,7 @@ jobs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e '.[lint]'
+        python -m pip install black
 
     - name: Lint
       shell: bash


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Attempts to use non-matrix product builds. Previously everything in the matrix would simply build the Cartesian product unless some trickery with excludes was used. This uses a `cfg` yaml config found by @jaimergp.

## Changelog description
N/A

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
