### PR TITLE
GitHub Action btwn QCEl and QCSk

### DIFF
--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -87,7 +87,7 @@ jobs:
       with:
         directory: ./qcsk
         repository: loriab/QCSchema
-        branch: ${branch}
+        branch: ${{ env.branch }}
         #branch: "qcel-204"
         github_token: ${{ secrets.QCSK_TOKEN }}
 

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -1,6 +1,6 @@
 name: QCSchema
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -27,9 +27,9 @@ jobs:
         path: qcsk
         ref: py2json
         #ref: master
-        #persist-credentials: false
+        persist-credentials: false
         fetch-depth: 0
-        token: ${{ secrets.QCSK_TOKEN }}
+        #token: ${{ secrets.QCSK_TOKEN }}
 
     - name: Python Setup
       uses: actions/setup-python@v1
@@ -67,7 +67,7 @@ jobs:
         # Note: `qcschema_json` is a folder in the py2json branch containing plain JSON files of the schema,
         #       rather than the python module of the current repo
 
-    - name: ASDF
+    - name: Generated vs. Stable
       shell: bash
       working-directory: ./qcsk
       run: |

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -45,6 +45,7 @@ jobs:
       run: |
         eval "$(conda shell.bash hook)" && conda activate test
         make qcschema
+        ls -l qcschema
         cd ..
         git clone https://github.com/loriab/QCSchema.git
         cd QCSchema
@@ -52,7 +53,7 @@ jobs:
         cd qcschema_json
         ls -l
         pwd
-        cp -p ../../qcschema/* .
+        cp -p ../../QCElemental/qcschema/* .
         git diff
 
 #    - name: CodeCov  

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -1,6 +1,6 @@
 name: QCSchema
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
@@ -29,7 +29,6 @@ jobs:
         #ref: master
         persist-credentials: false
         fetch-depth: 0
-        #token: ${{ secrets.QCSK_TOKEN }}
 
     - name: Python Setup
       uses: actions/setup-python@v1
@@ -76,8 +75,8 @@ jobs:
         branch=qcel-${pull_number}
         git checkout -b ${branch}
         git remote -v
-        git config --global user.email "lori.burns@gmail.com"
-        git config --global user.name "Lori A. Burns"
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
         git add -A
         git commit -m "auto-generated from QCElemental"
         echo "::set-env name=branch::${branch}"
@@ -88,36 +87,9 @@ jobs:
         directory: ./qcsk
         repository: loriab/QCSchema
         branch: ${{ env.branch }}
-        #branch: "qcel-204"
         github_token: ${{ secrets.QCSK_TOKEN }}
 
 
-#echo "::set-env name=action_state::yellow"
-
-
-
-#        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
-#git pull github ${GITHUB_REF} --ff-only
-#
-#git add ...
-#
-#git commit -m "Update native model"
-#git push github HEAD:${GITHUB_REF}
-
-#remote_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
-
-#git push "${remote_repo}" HEAD:${INPUT_BRANCH} --follow-tags $_FORCE_OPTION $_TAGS;
-
-#Push to branch ${branch}
-#remote: Not Found
-#fatal: repository 'https://github.com/https://github.com/loriab/QCSchema.git.git/' not found
-
-#github_token    string      Token for the repo. Can be passed in using ${{ secrets.GITHUB_TOKEN }}.
-#branch  string  'master'    Destination branch to push changes.
-#force   boolean false   Determines if force push is used.
-#tags    boolean false   Determines if --tags is used.
-#directory   string  '.' Directory to change to before pushing.
-#repository  string  ''  Repository name. Default or empty repository name represents current github repository. If you want to push to other repository, you should make a personal access token and use it as the github_token input.
 
 
 #jobs:

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -58,13 +58,9 @@ jobs:
       working-directory: ./qcel
       run: |
         eval "$(conda shell.bash hook)" && conda activate test
-        #cd qcel
         make qcschema
         ls -l qcschema
         cp -p qcschema/* ../qcsk/qcschema_json/
-        #cd ../qcsk/qcschema_json
-        #cp -p ../../qcel/qcschema/* .
-        #git diff
         # Note: `qcschema_json` is a folder in the py2json branch containing plain JSON files of the schema,
         #       rather than the python module of the current repo
 
@@ -72,10 +68,15 @@ jobs:
       shell: bash
       working-directory: ./qcsk
       run: |
-        git diff
-        echo ${GITHUB_REF}
+        git diff --color-words
         pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         echo ${pull_number}
+        branch=qcel-${pull_number}
+        echo ${branch}
+        git checkout -b ${branch}
+        git add -A
+        git commit -m "auto-generated from QCElemental"
+        git push origin ${branch}
 
 #    - name: CodeCov  
 #      uses: codecov/codecov-action@v1

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -25,7 +25,8 @@ jobs:
         repository: loriab/QCSchema
         #repository: MolSSI/QCSchema
         path: qcsk
-        ref: py2json
+        #ref: py2json
+        ref: json_files
         #ref: master
         persist-credentials: false
         fetch-depth: 0
@@ -62,7 +63,8 @@ jobs:
         eval "$(conda shell.bash hook)" && conda activate test
         make qcschema
         ls -l qcschema
-        cp -p qcschema/* ../qcsk/qcschema_json/
+        #cp -p qcschema/* ../qcsk/qcschema_json/
+        cp -p qcschema/* ../qcsk/qcschema/
         # Note: `qcschema_json` is a folder in the py2json branch containing plain JSON files of the schema,
         #       rather than the python module of the current repo
 
@@ -89,3 +91,4 @@ jobs:
         #repository: MolSSI/QCSchema
         branch: ${{ env.prbranch }}
         github_token: ${{ secrets.QCSK_TOKEN }}
+        force: true

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -15,8 +15,7 @@ jobs:
 
     steps:
     - name: Checkout
-      #uses: actions/checkout@v2
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: qcel
 

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -20,16 +20,16 @@ jobs:
         path: qcel
 
     - name: Checkout schema repo
-      #uses: actions/checkout@v2
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         repository: loriab/QCSchema
         #repository: MolSSI/QCSchema
         path: qcsk
         ref: py2json
         #ref: master
-        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
-        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+        #persist-credentials: false
+        fetch-depth: 0
+        token: ${{ secrets.QCSK_TOKEN }}
 
     - name: Python Setup
       uses: actions/setup-python@v1

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -66,7 +66,7 @@ jobs:
         # Note: `qcschema_json` is a folder in the py2json branch containing plain JSON files of the schema,
         #       rather than the python module of the current repo
 
-    - name: Generated vs. Stable
+    - name: Compare Schemas (generated vs. community)
       shell: bash
       working-directory: ./qcsk
       run: |
@@ -79,33 +79,13 @@ jobs:
         git config --local user.name "GitHub Action"
         git add -A
         git commit -m "auto-generated from QCElemental"
-        echo "::set-env name=branch::${branch}"
+        echo "::set-env name=prbranch::${branch}"
 
-    - name: Push changes
+    - name: Propose changes
       uses: ad-m/github-push-action@master
       with:
         directory: ./qcsk
         repository: loriab/QCSchema
-        branch: ${{ env.branch }}
+        #repository: MolSSI/QCSchema
+        branch: ${{ env.prbranch }}
         github_token: ${{ secrets.QCSK_TOKEN }}
-
-
-
-
-#jobs:
-#  build:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: actions/checkout@master
-#    - name: Create local changes
-#      run: |
-#        ...
-#    - name: Commit files
-#      run: |
-#        git config --local user.email "action@github.com"
-#        git config --local user.name "GitHub Action"
-#        git commit -m "Add changes" -a
-#    - name: Push changes
-#      uses: ad-m/github-push-action@master
-#      with:
-#        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -64,7 +64,6 @@ jobs:
         cd qcel
         make qcschema
         ls -l qcschema
-        cd ..
         #git clone https://github.com/loriab/QCSchema.git
         #cd QCSchema
         #git checkout py2json
@@ -73,10 +72,12 @@ jobs:
         #pwd
         #cp -p ../../QCElemental/qcschema/* .
         #git diff
-        cd qcsk
+        cd ../qcsk/qcschema_json
         ls -l
-        cp -p ../../QCElemental/qcschema/* .
+        cp -p ../../qcel/qcschema/* .
         git diff
+        # Note: `qcschema_json` is a folder in the py2json branch containing plain JSON files of the schema,
+        #       rather than the python module of the current repo
 
 
 #    - name: CodeCov  

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -52,33 +52,30 @@ jobs:
       run: |
         eval "$(conda shell.bash hook)" && conda activate test
         conda list --show-channel-urls
-        pwd
-        ls -l
 
-    - name: QCSchema
+    - name: QCSchema from QCElemental
       shell: bash
+      working-directory: ./qcel
       run: |
         eval "$(conda shell.bash hook)" && conda activate test
-        pwd
-        ls -l
-        cd qcel
+        #cd qcel
         make qcschema
         ls -l qcschema
-        #git clone https://github.com/loriab/QCSchema.git
-        #cd QCSchema
-        #git checkout py2json
-        #cd qcschema_json
-        #ls -l
-        #pwd
-        #cp -p ../../QCElemental/qcschema/* .
+        cp -p qcschema/* ../qcsk/qcschema_json/
+        #cd ../qcsk/qcschema_json
+        #cp -p ../../qcel/qcschema/* .
         #git diff
-        cd ../qcsk/qcschema_json
-        ls -l
-        cp -p ../../qcel/qcschema/* .
-        git diff
         # Note: `qcschema_json` is a folder in the py2json branch containing plain JSON files of the schema,
         #       rather than the python module of the current repo
 
+    - name ASDF
+      shell: bash
+      working-directory: ./qcsk
+      run: |
+        git diff
+        echo ${GITHUB_REF}
+        pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+        echo ${pull_number}
 
 #    - name: CodeCov  
 #      uses: codecov/codecov-action@v1

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -83,9 +83,15 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         directory: ./qcsk
-        repository: https://github.com/loriab/QCSchema.git
-        branch: ${branch}
+        repository: loriab/QCSchema
+#        branch: ${branch}
+        branch: "qcel-204"
         github_token: ${{ secrets.GITHUB_TOKEN }}
+
+
+#Push to branch ${branch}
+#remote: Not Found
+#fatal: repository 'https://github.com/https://github.com/loriab/QCSchema.git.git/' not found
 
 #github_token    string      Token for the repo. Can be passed in using ${{ secrets.GITHUB_TOKEN }}.
 #branch  string  'master'    Destination branch to push changes.

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -14,7 +14,19 @@ jobs:
       CONDA_ENV: ${{ matrix.conda-env }}
 
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        path: qcel
+
+    - name: Checkout schema repo
+      uses: actions/checkout@v2
+      with:
+        repository: loriab/QCSchema
+        #repository: MolSSI/QCSchema
+        path: qcsk
+        ref: py2json
+        #ref: master
 
     - name: Python Setup
       uses: actions/setup-python@v1
@@ -39,22 +51,31 @@ jobs:
         eval "$(conda shell.bash hook)" && conda activate test
         conda list --show-channel-urls
         pwd
+        ls -l
 
     - name: QCSchema
       shell: bash
       run: |
         eval "$(conda shell.bash hook)" && conda activate test
+        pwd
+        ls -l
+        cd qcel
         make qcschema
         ls -l qcschema
         cd ..
-        git clone https://github.com/loriab/QCSchema.git
-        cd QCSchema
-        git checkout py2json
-        cd qcschema_json
+        #git clone https://github.com/loriab/QCSchema.git
+        #cd QCSchema
+        #git checkout py2json
+        #cd qcschema_json
+        #ls -l
+        #pwd
+        #cp -p ../../QCElemental/qcschema/* .
+        #git diff
+        cd qcsk
         ls -l
-        pwd
         cp -p ../../QCElemental/qcschema/* .
         git diff
+
 
 #    - name: CodeCov  
 #      uses: codecov/codecov-action@v1

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -15,12 +15,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      #uses: actions/checkout@v2
+      uses: actions/checkout@v1
       with:
         path: qcel
 
     - name: Checkout schema repo
-      uses: actions/checkout@v2
+      #uses: actions/checkout@v2
+      uses: actions/checkout@v1
       with:
         repository: loriab/QCSchema
         #repository: MolSSI/QCSchema
@@ -79,16 +81,25 @@ jobs:
         git config --global user.name "Lori A. Burns"
         git add -A
         git commit -m "auto-generated from QCElemental"
-        git push origin ${branch}
+#        git push origin ${branch}
 
-    #- name: Push changes
-    #  uses: ad-m/github-push-action@master
-    #  with:
-    #    directory: ./qcsk
-    #    repository: loriab/QCSchema
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        directory: ./qcsk
+        repository: loriab/QCSchema
 #   #     branch: ${branch}
-    #    branch: "qcel-204"
-    #    github_token: ${{ secrets.QCSK_TOKEN }}
+        branch: "qcel-204"
+        github_token: ${{ secrets.QCSK_TOKEN }}
+
+
+#        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+#git pull github ${GITHUB_REF} --ff-only
+#
+#git add ...
+#
+#git commit -m "Update native model"
+#git push github HEAD:${GITHUB_REF}
 
 #remote_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
 

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -80,7 +80,7 @@ jobs:
         git config --global user.name "Lori A. Burns"
         git add -A
         git commit -m "auto-generated from QCElemental"
-        ::set-env name=branch::${branch}
+        echo "::set-env name=branch::${branch}"
 
     - name: Push changes
       uses: ad-m/github-push-action@master

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -68,7 +68,7 @@ jobs:
         # Note: `qcschema_json` is a folder in the py2json branch containing plain JSON files of the schema,
         #       rather than the python module of the current repo
 
-    - name ASDF
+    - name: ASDF
       shell: bash
       working-directory: ./qcsk
       run: |

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -74,6 +74,9 @@ jobs:
         branch=qcel-${pull_number}
         echo ${branch}
         git checkout -b ${branch}
+        git remote -v
+        git config --global user.email "lori.burns@gmail.com"
+        git config --global user.name "Lori A. Burns"
         git add -A
         git commit -m "auto-generated from QCElemental"
         git push origin ${branch}

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -80,16 +80,20 @@ jobs:
         git config --global user.name "Lori A. Burns"
         git add -A
         git commit -m "auto-generated from QCElemental"
-#        git push origin ${branch}
+        ::set-env name=branch::${branch}
 
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
         directory: ./qcsk
         repository: loriab/QCSchema
-#   #     branch: ${branch}
-        branch: "qcel-204"
+        branch: ${branch}
+        #branch: "qcel-204"
         github_token: ${{ secrets.QCSK_TOKEN }}
+
+
+#echo "::set-env name=action_state::yellow"
+
 
 
 #        git remote add github "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -27,6 +27,8 @@ jobs:
         path: qcsk
         ref: py2json
         #ref: master
+        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
     - name: Python Setup
       uses: actions/setup-python@v1

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -86,7 +86,7 @@ jobs:
         repository: loriab/QCSchema
 #        branch: ${branch}
         branch: "qcel-204"
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.QCSK_TOKEN }}
 
 
 #Push to branch ${branch}

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -38,6 +38,7 @@ jobs:
       run: |
         eval "$(conda shell.bash hook)" && conda activate test
         conda list --show-channel-urls
+        pwd
 
     - name: QCSchema
       shell: bash

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -77,5 +77,38 @@ jobs:
         git config --global user.name "Lori A. Burns"
         git add -A
         git commit -m "auto-generated from QCElemental"
-        git push origin ${branch}
+#        git push origin ${branch}
 
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        directory: ./qcsk
+        repository: https://github.com/loriab/QCSchema.git
+        branch: ${branch}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+#github_token    string      Token for the repo. Can be passed in using ${{ secrets.GITHUB_TOKEN }}.
+#branch  string  'master'    Destination branch to push changes.
+#force   boolean false   Determines if force push is used.
+#tags    boolean false   Determines if --tags is used.
+#directory   string  '.' Directory to change to before pushing.
+#repository  string  ''  Repository name. Default or empty repository name represents current github repository. If you want to push to other repository, you should make a personal access token and use it as the github_token input.
+
+
+#jobs:
+#  build:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@master
+#    - name: Create local changes
+#      run: |
+#        ...
+#    - name: Commit files
+#      run: |
+#        git config --local user.email "action@github.com"
+#        git config --local user.name "GitHub Action"
+#        git commit -m "Add changes" -a
+#    - name: Push changes
+#      uses: ad-m/github-push-action@master
+#      with:
+#        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -1,6 +1,6 @@
 name: QCSchema
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:
@@ -70,9 +70,7 @@ jobs:
       run: |
         git diff --color-words
         pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-        echo ${pull_number}
         branch=qcel-${pull_number}
-        echo ${branch}
         git checkout -b ${branch}
         git remote -v
         git config --global user.email "lori.burns@gmail.com"
@@ -81,15 +79,3 @@ jobs:
         git commit -m "auto-generated from QCElemental"
         git push origin ${branch}
 
-#    - name: CodeCov  
-#      uses: codecov/codecov-action@v1
-#      with:
-#        token: ${{ secrets.CODECOV_TOKEN }}
-#        file: ./coverage.xml
-#        flags: unittests
-#        yml: ./.codecov.yml 
-#
-
-#####
-#   pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-#####

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -35,12 +35,14 @@ jobs:
 
     - name: Create Environment
       shell: bash
+      working-directory: ./qcel
       run: |
         eval "$(conda shell.bash hook)" && conda activate
         python devtools/scripts/create_conda_env.py -n=test -p=$PYVER devtools/conda-envs/$CONDA_ENV.yaml
 
     - name: Install
       shell: bash
+      working-directory: ./qcel
       run: |
         eval "$(conda shell.bash hook)" && conda activate test
         python -m pip install . --no-deps

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -79,17 +79,20 @@ jobs:
         git config --global user.name "Lori A. Burns"
         git add -A
         git commit -m "auto-generated from QCElemental"
-#        git push origin ${branch}
+        git push origin ${branch}
 
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        directory: ./qcsk
-        repository: loriab/QCSchema
-#        branch: ${branch}
-        branch: "qcel-204"
-        github_token: ${{ secrets.QCSK_TOKEN }}
+    #- name: Push changes
+    #  uses: ad-m/github-push-action@master
+    #  with:
+    #    directory: ./qcsk
+    #    repository: loriab/QCSchema
+#   #     branch: ${branch}
+    #    branch: "qcel-204"
+    #    github_token: ${{ secrets.QCSK_TOKEN }}
 
+#remote_repo="https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+
+#git push "${remote_repo}" HEAD:${INPUT_BRANCH} --follow-tags $_FORCE_OPTION $_TAGS;
 
 #Push to branch ${branch}
 #remote: Not Found

--- a/.github/workflows/QCSchema.yml
+++ b/.github/workflows/QCSchema.yml
@@ -1,0 +1,68 @@
+name: QCSchema
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        conda-env: [base]
+        python-version: [3.7]
+    env:
+      PYVER: ${{ matrix.python-version }}
+      CONDA_ENV: ${{ matrix.conda-env }}
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Python Setup
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Create Environment
+      shell: bash
+      run: |
+        eval "$(conda shell.bash hook)" && conda activate
+        python devtools/scripts/create_conda_env.py -n=test -p=$PYVER devtools/conda-envs/$CONDA_ENV.yaml
+
+    - name: Install
+      shell: bash
+      run: |
+        eval "$(conda shell.bash hook)" && conda activate test
+        python -m pip install . --no-deps
+
+    - name: Environment Information
+      shell: bash
+      run: |
+        eval "$(conda shell.bash hook)" && conda activate test
+        conda list --show-channel-urls
+
+    - name: QCSchema
+      shell: bash
+      run: |
+        eval "$(conda shell.bash hook)" && conda activate test
+        make qcschema
+        cd ..
+        git clone https://github.com/loriab/QCSchema.git
+        cd QCSchema
+        git checkout py2json
+        cd qcschema_json
+        ls -l
+        pwd
+        cp -p ../../qcschema/* .
+        git diff
+
+#    - name: CodeCov  
+#      uses: codecov/codecov-action@v1
+#      with:
+#        token: ${{ secrets.CODECOV_TOKEN }}
+#        file: ./coverage.xml
+#        flags: unittests
+#        yml: ./.codecov.yml 
+#
+
+#####
+#   pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+#####

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ cpu_data:
 .PHONY: qcschema
 qcschema: #install
 	mkdir -p qcschema
-	python -c "exec(\"import qcelemental as qcel\nfrom pathlib import Path\nfor md in [qcel.models.Provenance, qcel.models.AtomicResultProperties]:\n\tmfile = (Path('qcschema') / md.__name__).with_suffix('.json')\n\twith open(mfile, 'w') as fp:\n\t\tfp.write(md.schema_json(indent=4))\")"
+	python -c "exec(\"import qcelemental as qcel\nfrom pathlib import Path\nfor md in qcel.models.qcschema_models():\n\tmfile = (Path('qcschema') / md.__name__).with_suffix('.json')\n\twith open(mfile, 'w') as fp:\n\t\tfp.write(md.schema_json(indent=4))\")"
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ data: cpu_data
 cpu_data:
 	(cd raw_data/cpu_data; python build_cpu_data.py; mv cpu_data_blob.py ../../qcelemental/info/data/)
 
+.PHONY: qcschema
+qcschema: #install
+	mkdir -p qcschema
+	echo -e "import qcelemental as qcel\nfrom pathlib import Path\nfor md in [qcel.models.Provenance, qcel.models.AtomicResultProperties]:\n\tmfile = (Path('qcschema') / md.__name__).with_suffix('.json')\n\twith open(mfile, 'w') as fp:\n\t\tfp.write(md.schema_json(indent=4))" | python
+
 .PHONY: clean
 clean:
 	rm -rf `find . -name __pycache__`

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ cpu_data:
 .PHONY: qcschema
 qcschema: #install
 	mkdir -p qcschema
-	echo -e "import qcelemental as qcel\nfrom pathlib import Path\nfor md in [qcel.models.Provenance, qcel.models.AtomicResultProperties]:\n\tmfile = (Path('qcschema') / md.__name__).with_suffix('.json')\n\twith open(mfile, 'w') as fp:\n\t\tfp.write(md.schema_json(indent=4))" | python
+	python -c "exec(\"import qcelemental as qcel\nfrom pathlib import Path\nfor md in [qcel.models.Provenance, qcel.models.AtomicResultProperties]:\n\tmfile = (Path('qcschema') / md.__name__).with_suffix('.json')\n\twith open(mfile, 'w') as fp:\n\t\tfp.write(md.schema_json(indent=4))\")"
 
 .PHONY: clean
 clean:

--- a/qcelemental/models/__init__.py
+++ b/qcelemental/models/__init__.py
@@ -14,3 +14,19 @@ from .common_models import ComputeError, DriverEnum, FailedOperation, Provenance
 from .molecule import Molecule
 from .procedures import Optimization, OptimizationInput, OptimizationResult
 from .results import AtomicInput, AtomicResult, AtomicResultProperties, Result, ResultInput, ResultProperties
+
+
+def qcschema_models():
+    return [
+        AtomicInput,
+        AtomicResult,
+        AtomicResultProperties,
+        basis.BasisCenter,
+        BasisSet,
+        basis.ElectronShell,
+        basis.ECPPotential,
+        common_models.Model,
+        Molecule,
+        Provenance,
+        results.WavefunctionProperties,
+    ]

--- a/qcelemental/models/common_models.py
+++ b/qcelemental/models/common_models.py
@@ -20,7 +20,7 @@ class Provenance(ProtoModel):
     """
 
     creator: str = Field(..., description="The creator of the object.")
-    version: Optional[str] = Field(None, description="The version of the creator.")
+    version: Optional[str] = Field(None, description="The version of the creator, which should be sortable by the very broad [PEP 440](https://www.python.org/dev/peps/pep-0440/).")
     routine: Optional[str] = Field(None, description="The routine of the creator.")
 
     class Config(ProtoModel.Config):

--- a/qcelemental/models/common_models.py
+++ b/qcelemental/models/common_models.py
@@ -20,7 +20,10 @@ class Provenance(ProtoModel):
     """
 
     creator: str = Field(..., description="The creator of the object.")
-    version: Optional[str] = Field(None, description="The version of the creator, which should be sortable by the very broad [PEP 440](https://www.python.org/dev/peps/pep-0440/).")
+    version: Optional[str] = Field(
+        None,
+        description="The version of the creator, which should be sortable by the very broad [PEP 440](https://www.python.org/dev/peps/pep-0440/).",
+    )
     routine: Optional[str] = Field(None, description="The routine of the creator.")
 
     class Config(ProtoModel.Config):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Continues from #204. Generate schema from pydantic qcel for models owned by qcsk, compare them, and issue PR to latter in case change to qcel would affect qcsk. Part of https://github.com/MolSSI/QCSchema/issues/68 effort to consolidate single source of truth here and community discussion there.

* because secrets not passed to PRs from forks, these'll have to be internal PRs. I don't understand how codecov is working from fork PRs.
* I think this is pretty much ready. the whole sequence is:
  * #217 needs to happen here
  * QCSk repo needs to switch to JSON files for each model instead of single python module
  * then the target in the action can switch from loriab/QCSchema to upstream
  * I'm thinking of leaving this PR as-is at the push branch stage, then adding https://github.com/marketplace/actions/github-pull-request-action to QCSk to listen for qcel-* branches

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
