### PR TITLE
acknowledge namespace packages

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,21 @@ Changelog
 .. +++++++++
 
 
+0.15.0 / 2020-06-DD
+-------------------
+
+New Features
+++++++++++++
+
+Enhancements
+++++++++++++
+- (:pr:`223`) ``molparse.to_string`` MADNESS dtype developed.
+- (:pr:`226`) Allow ``which_import`` to distinguish between ordinary and namespace packages.
+
+Bug Fixes
++++++++++
+
+
 0.14.0 / 2020-03-06
 -------------------
 

--- a/qcelemental/tests/test_importing.py
+++ b/qcelemental/tests/test_importing.py
@@ -1,4 +1,6 @@
 import os
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -66,6 +68,36 @@ def test_which_import_f_submodule_altsyntax():
 
 def test_which_import_f_bool_submodule():
     ans = qcel.util.which_import("evilpint.util", return_bool=True)
+    assert ans is False
+
+
+def test_which_import_t_namespacemodule():
+    testdir = Path(__file__).parent
+    sys.path.append(str(testdir))  # brings to Py's notice a non-Py dir that qualifies as a namespace package
+    ans = qcel.util.which_import("namespacemodule", namespace_ok=True)
+    sys.path.pop()
+    assert len(ans) == 1
+    assert str(ans[0]) == str(testdir / "namespacemodule")
+
+
+def test_which_import_t_bool_namespacemodule():
+    sys.path.append(str(Path(__file__).parent))
+    ans = qcel.util.which_import("namespacemodule", return_bool=True, namespace_ok=True)
+    sys.path.pop()
+    assert ans is True
+
+
+def test_which_import_f_namespacemodule():
+    sys.path.append(str(Path(__file__).parent))
+    ans = qcel.util.which_import("namespacemodule", namespace_ok=False)
+    sys.path.pop()
+    assert ans is None
+
+
+def test_which_import_f_bool_namespacemodule():
+    sys.path.append(str(Path(__file__).parent))
+    ans = qcel.util.which_import("namespacemodule", return_bool=True, namespace_ok=False)
+    sys.path.pop()
     assert ans is False
 
 

--- a/qcelemental/tests/test_importing.py
+++ b/qcelemental/tests/test_importing.py
@@ -77,7 +77,7 @@ def test_which_import_t_namespacemodule():
     ans = qcel.util.which_import("namespacemodule", namespace_ok=True)
     sys.path.pop()
     assert len(ans) == 1
-    assert str(ans[0]) == str(testdir / "namespacemodule")
+    assert str(next(iter(ans))) == str(testdir / "namespacemodule")
 
 
 def test_which_import_t_bool_namespacemodule():

--- a/qcelemental/util/importing.py
+++ b/qcelemental/util/importing.py
@@ -37,7 +37,8 @@ def which_import(
     except ModuleNotFoundError:
         module_spec = None
 
-    namespace_package = module_spec is not None and module_spec.origin is None
+    # module_spec.origin is 'namespace' for py36, None for >=py37
+    namespace_package = module_spec is not None and module_spec.origin in [None, "namespace"]
 
     if (module_spec is None) or (namespace_package and not namespace_ok):
         if raise_error:

--- a/qcelemental/util/importing.py
+++ b/qcelemental/util/importing.py
@@ -5,31 +5,41 @@ from typing import Union
 
 
 def which_import(
-    module: str, *, return_bool: bool = False, raise_error: bool = False, raise_msg: str = None, package: str = None
+    module: str,
+    *,
+    return_bool: bool = False,
+    raise_error: bool = False,
+    raise_msg: str = None,
+    package: str = None,
+    namespace_ok: bool = False,
 ) -> Union[bool, None, str]:
     """Tests to see if a Python module is available.
 
     Returns
     -------
     str or None
-        By default, returns `__init__.py`-like path if module found or `None` if not.
+        By default, returns `__init__.py`-like path if `module` found or `None` if not.
+        For namespace packages and if `namespace_ok=True`, returns the list of pieces locations if `module` found or `None` if not.
     bool
         When `return_bool=True`, returns whether or not found.
+        Namespace packages only `True` if `namespace_ok=True`.
 
     Raises
     ------
     ModuleNotFoundError
-        When `raises_error=True` and module not found. Raises generic message plus any `raise_msg`.
+        When `raise_error=True` and module not found. Raises generic message plus any `raise_msg`.
 
     """
-    import importlib
+    from importlib import util
 
     try:
-        module_spec = importlib.util.find_spec(module, package=package)
+        module_spec = util.find_spec(module, package=package)
     except ModuleNotFoundError:
         module_spec = None
 
-    if module_spec is None:
+    namespace_package = module_spec is not None and module_spec.origin is None
+
+    if (module_spec is None) or (namespace_package and not namespace_ok):
         if raise_error:
             raise ModuleNotFoundError(
                 f"Python module '{module}' not found in envvar PYTHONPATH.{' ' + raise_msg if raise_msg else ''}"
@@ -42,7 +52,10 @@ def which_import(
         if return_bool:
             return True
         else:
-            return module_spec.origin
+            if namespace_package:
+                return module_spec.submodule_search_locations
+            else:
+                return module_spec.origin
 
 
 def which(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
So this came about because conditional tests were running in psi4 even though the module whose presence was the condition wasn't there. Turned out, `which_import` was detecting a non-python directory (CTest to be exact) with the module name as a namespace module and so activating the test. This PR allows that behavior (mostly for testing purposes) but generally stamps it out.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
