### PR TITLE
Miscellaneous before v0.15.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,19 +14,27 @@ Changelog
 .. +++++++++
 
 
-0.15.0 / 2020-06-DD
+0.15.0 / 2020-06-25
 -------------------
 
 New Features
 ++++++++++++
+- (:pr:`182`) Added experimental protocol for controlling autocorrection attemps. (That is, when a calculation throws a
+  known error that QCEngine thinks it can tweak the input and rerun.) Currently in trial for NWChem.
 
 Enhancements
 ++++++++++++
-- (:pr:`223`) ``molparse.to_string`` MADNESS dtype developed.
+- (:pr:`186`, :pr:`223`) ``molparse.to_string`` Orca and MADNESS dtypes developed.
 - (:pr:`226`) Allow ``which_import`` to distinguish between ordinary and namespace packages.
+- (:pr:`227`) Add non-default ``strict`` argument to ``periodictable.to_Z``, ``to_symbol``, and ``to_element`` that fails when isotope information is given.
+- (:pr:`227`) Allow nonphysical masses to pass validation in ``molparse.from_schema(..., nonphysical=True)``.
+  Also allowed in forming ``qcel.models.Molecule(..., nonphysical=True)``.
 
 Bug Fixes
 +++++++++
+- (:pr:`227`) Fixed deception described in issue 225 where ``qcel.models.Molecule(..., symbols=["O18"])`` accepted "O18"
+  but did not influence the isotope, as user might have expected. That now raises ``NotAnElementError``, and an example
+  of correctly setting isotope/masses has been added. This error now caught at ``qcel.molparse.from_arrays`` so general.
 
 
 0.14.0 / 2020-03-06

--- a/docs/source/model_molecule.rst
+++ b/docs/source/model_molecule.rst
@@ -90,6 +90,7 @@ the ``from_data`` function or by passing explicit fragments in the
     >>>       Ne 0.000000 0.000000 0.000000
     >>>       --
     >>>       Ne 3.100000 0.000000 0.000000
+    >>>       units au
     >>>       """)
 
     >>> mol = qcel.models.Molecule(

--- a/qcelemental/exceptions.py
+++ b/qcelemental/exceptions.py
@@ -6,10 +6,12 @@ Exceptions for QCElemental
 class NotAnElementError(Exception):
     """Error when element or nuclide can't be identified."""
 
-    def __init__(self, atom):
-        self.message = "Atom identifier ({}) uninterpretable as atomic number, element symbol, or nuclide symbol".format(
-            atom
-        )
+    def __init__(self, atom, strict=False):
+        if strict:
+            msg = "atomic number or element"
+        else:
+            msg = "atomic number, element symbol, or nuclide symbol"
+        self.message = f"Atom identifier ({atom}) uninterpretable as {msg}"
 
 
 class DataUnavailableError(Exception):

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -281,7 +281,10 @@ class Molecule(ProtoModel):
             kwargs["schema_version"] = kwargs.pop("schema_version", 2)
             # original_keys = set(kwargs.keys())  # revive when ready to revisit sparsity
 
-            schema = to_schema(from_schema(kwargs), dtype=kwargs["schema_version"], copy=False, np_out=True)
+            nonphysical = kwargs.pop("nonphysical", False)
+            schema = to_schema(
+                from_schema(kwargs, nonphysical=nonphysical), dtype=kwargs["schema_version"], copy=False, np_out=True
+            )
             schema = _filter_defaults(schema)
 
             kwargs["validated"] = True
@@ -691,7 +694,7 @@ class Molecule(ProtoModel):
 
         Suggest psi4 --> psi4frag and psi4 route to to_string
         """
-        molrec = from_schema(self.dict())
+        molrec = from_schema(self.dict(), nonphysical=True)
         return to_string(
             molrec,
             dtype=dtype,

--- a/qcelemental/molparse/from_arrays.py
+++ b/qcelemental/molparse/from_arrays.py
@@ -188,6 +188,7 @@ def from_arrays(
     tooclose : float, optional
         Interatom distance (native `geom` units) nearer than which atoms not allowed.
     nonphysical : bool, optional
+        Do allow masses outside an element's natural range to pass validation?
     speclabel : bool, optional
         If `True`, interpret `elbl` as potentially full nucleus spec including
         ghosting, isotope, mass, tagging information, e.g., `@13C_mine` or

--- a/qcelemental/molparse/from_schema.py
+++ b/qcelemental/molparse/from_schema.py
@@ -7,13 +7,15 @@ from ..util import provenance_stamp
 from .from_arrays import from_arrays
 
 
-def from_schema(molschema, *, verbose: int = 1) -> Dict:
+def from_schema(molschema, *, nonphysical: bool = False, verbose: int = 1) -> Dict:
     """Construct molecule dictionary representation from non-Psi4 schema.
 
     Parameters
     ----------
     molschema : dict
         Dictionary form of Molecule following known schema.
+    nonphysical : bool, optional
+        Do allow masses outside an element's natural range to pass validation?
     verbose : int, optional
         Amount of printing.
 
@@ -82,7 +84,7 @@ def from_schema(molschema, *, verbose: int = 1) -> Dict:
         speclabel=False,
         # tooclose=tooclose,
         # zero_ghost_fragments=zero_ghost_fragments,
-        # nonphysical=nonphysical,
+        nonphysical=nonphysical,
         # mtol=mtol,
         verbose=verbose,
     )

--- a/qcelemental/molparse/nucleus.py
+++ b/qcelemental/molparse/nucleus.py
@@ -165,7 +165,7 @@ def reconcile_nucleus(
     def offer_element_symbol(e):
         """Given an element, what can be suggested and asserted about Z, A, mass?"""
 
-        _Z = periodictable.to_Z(e)
+        _Z = periodictable.to_Z(e, strict=True)
         offer_atomic_number(_Z)
 
     def offer_atomic_number(z):

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import qcelemental as qcel
+from qcelemental.exceptions import NotAnElementError
 from qcelemental.models import Molecule
 from qcelemental.testing import compare, compare_values
 
@@ -715,3 +716,21 @@ def test_sparse_molecule_connectivity():
 
     mol = Molecule(symbols=["He", "He"], geometry=[0, 0, -2, 0, 0, 2])
     assert "connectivity" not in mol.dict()
+
+
+def test_bad_isotope_spec():
+    with pytest.raises(NotAnElementError) as e:
+        qcel.models.Molecule(symbols=["He3"], geometry=[0, 0, 0])
+
+
+def test_good_isotope_spec():
+    assert compare_values(
+        [3.01602932], qcel.models.Molecule(symbols=["He"], mass_numbers=[3], geometry=[0, 0, 0]).masses, "nonstd mass"
+    )
+
+
+def test_nonphysical_spec():
+    mol = qcel.models.Molecule(symbols=["He"], masses=[100], geometry=[0, 0, 0], nonphysical=True)
+    assert compare_values([100.0], mol.masses, "nonphysical mass")
+
+    print(mol.to_string(dtype="psi4"))

--- a/qcelemental/tests/test_molparse_reconcile_nucleus.py
+++ b/qcelemental/tests/test_molparse_reconcile_nucleus.py
@@ -63,14 +63,21 @@ def test_reconcile_nucleus_assertionerror(inp):
         assert co_dominant_shortmass == qcelemental.molparse.reconcile_nucleus(**inp)
 
 
-@pytest.mark.parametrize("inp", [{"A": 80, "Z": 27}, {"Z": -27, "mass": 200, "nonphysical": True}])
+@pytest.mark.parametrize(
+    "inp",
+    [{"A": 80, "Z": 27}, {"Z": -27, "mass": 200, "nonphysical": True}, {"A": 100, "E": "He", "nonphysical": True}],
+)
 def test_reconcile_nucleus_notanelementerror(inp):
     with pytest.raises(qcelemental.NotAnElementError):
         qcelemental.molparse.reconcile_nucleus(**inp)
 
 
 def test_reconcile_nucleus_41():
-    qcelemental.molparse.reconcile_nucleus(Z=27, mass=200, nonphysical=True)
+    ans = qcelemental.molparse.reconcile_nucleus(Z=27, mass=200, nonphysical=True)
+    assert ans == (-1, 27, "Co", 200.0, True, "")
+
+    ans = qcelemental.molparse.reconcile_nucleus(A=None, Z=None, E="He", mass=100, label=None, nonphysical=True)
+    assert ans == (-1, 2, "He", 100.0, True, "")
 
 
 @pytest.mark.parametrize(

--- a/qcelemental/tests/test_periodictable.py
+++ b/qcelemental/tests/test_periodictable.py
@@ -4,19 +4,34 @@ from decimal import Decimal
 import pytest
 
 import qcelemental
+from qcelemental.exceptions import NotAnElementError
 
 
 @pytest.mark.parametrize(
-    "inp,expected", [("He", "He"), ("He", "He"), ("He4", "He"), ("he", "He"), ("2", "He"), (2, "He"), (2.0, "He")]
+    "inp,expected",
+    [("He", "He"), ("heliuM", "He"), ("He4", "He4"), ("he", "He"), ("2", "He"), (2, "He"), (2.0, "He"), ("D", "D")],
 )
 def test_id_resolution(inp, expected):
-    assert qcelemental.periodictable._resolve_atom_to_key("He") == "He"
+    assert qcelemental.periodictable._resolve_atom_to_key(inp) == expected
 
 
 @pytest.mark.parametrize("inp", ["He100", "-1", -1, -1.0, "cat", 200])
 def test_id_resolution_error(inp):
-    with pytest.raises(qcelemental.exceptions.NotAnElementError):
+    with pytest.raises(NotAnElementError):
         qcelemental.periodictable._resolve_atom_to_key(inp)
+
+
+@pytest.mark.parametrize(
+    "inp,expected", [("He", "He"), ("heliuM", "He"), ("he", "He"), ("2", "He"), (2, "He"), (2.0, "He")]
+)
+def test_id_resolution_strict(inp, expected):
+    assert qcelemental.periodictable._resolve_atom_to_key(inp, strict=True) == expected
+
+
+@pytest.mark.parametrize("inp", ["He100", "-1", -1, -1.0, "cat", 200, "He4", "D"])
+def test_id_resolution_strict_error(inp):
+    with pytest.raises(NotAnElementError):
+        qcelemental.periodictable._resolve_atom_to_key(inp, strict=True)
 
 
 # TODO test ghost
@@ -89,6 +104,32 @@ def test_to_atomic_number(inp, expected):
     "inp,expected",
     [
         # Kr 84
+        ("kr", 36),
+        ("KRYPTON", 36),
+        ("kr84", None),
+        (36, 36),
+        # Kr 86
+        ("kr86", None),
+        # Deuterium
+        ("D", None),
+        ("h2", None),
+    ],
+)
+def test_to_atomic_number_strict(inp, expected):
+    if expected is None:
+        with pytest.raises(NotAnElementError):
+            qcelemental.periodictable.to_Z(inp, strict=True)
+        with pytest.raises(NotAnElementError):
+            qcelemental.periodictable.to_atomic_number(inp, strict=True)
+    else:
+        assert qcelemental.periodictable.to_Z(inp, strict=True) == expected
+        assert qcelemental.periodictable.to_atomic_number(inp, strict=True) == expected
+
+
+@pytest.mark.parametrize(
+    "inp,expected",
+    [
+        # Kr 84
         ("kr", "Kr"),
         ("KRYPTON", "Kr"),
         ("kr84", "Kr"),
@@ -109,6 +150,32 @@ def test_to_symbol(inp, expected):
     "inp,expected",
     [
         # Kr 84
+        ("kr", "Kr"),
+        ("KRYPTON", "Kr"),
+        ("kr84", None),
+        (36, "Kr"),
+        # Kr 86
+        ("kr86", None),
+        # Deuterium
+        ("D", None),
+        ("h2", None),
+    ],
+)
+def test_to_symbol_strict(inp, expected):
+    if expected is None:
+        with pytest.raises(NotAnElementError):
+            qcelemental.periodictable.to_E(inp, strict=True)
+        with pytest.raises(NotAnElementError):
+            qcelemental.periodictable.to_symbol(inp, strict=True)
+    else:
+        assert qcelemental.periodictable.to_E(inp, strict=True) == expected
+        assert qcelemental.periodictable.to_symbol(inp, strict=True) == expected
+
+
+@pytest.mark.parametrize(
+    "inp,expected",
+    [
+        # Kr 84
         ("kr", "Krypton"),
         ("KRYPTON", "Krypton"),
         ("kr84", "Krypton"),
@@ -123,6 +190,32 @@ def test_to_symbol(inp, expected):
 def test_to_element(inp, expected):
     assert qcelemental.periodictable.to_element(inp) == expected
     assert qcelemental.periodictable.to_name(inp) == expected
+
+
+@pytest.mark.parametrize(
+    "inp,expected",
+    [
+        # Kr 84
+        ("kr", "Krypton"),
+        ("KRYPTON", "Krypton"),
+        ("kr84", None),
+        (36, "Krypton"),
+        # Kr 86
+        ("kr86", None),
+        # Deuterium
+        ("D", None),
+        ("h2", None),
+    ],
+)
+def test_to_element_strict(inp, expected):
+    if expected is None:
+        with pytest.raises(NotAnElementError):
+            qcelemental.periodictable.to_element(inp, strict=True)
+        with pytest.raises(NotAnElementError):
+            qcelemental.periodictable.to_name(inp, strict=True)
+    else:
+        assert qcelemental.periodictable.to_element(inp, strict=True) == expected
+        assert qcelemental.periodictable.to_name(inp, strict=True) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
squash a few issues.

## Changelog description
* allow nonphysical masses validation through `from_schema` needed for psi4 findif frequencies.
* add `strict` option to `to_Z`, `to_symbol` and `to_element` so that `"O18"` can error out. Useful when these are used for validation (like `models.Molecule`) and you don't want the user to think their misplaced mass info has been accepted.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
