### PR TITLE
add equal_phase option to testing

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,22 @@ Changelog
 .. +++++++++
 
 
+0.16.0 / 2020-MM-DD
+-------------------
+
+New Features
+++++++++++++
+
+Enhancements
+++++++++++++
+- (:pr:``) ``compare``, ``compare_values``, and ``compare_recursive`` learned new keyword ``equal_phase`` that when
+  ``True`` allows either ``computed`` or ``-computed`` to pass the comparison. For ``compare_recursive``, the leniency
+  can be restricted to specific leaves of the iterable by passing a list of allowed leaves.
+
+Bug Fixes
++++++++++
+
+
 0.15.1 / 2020-06-25
 -------------------
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
For when you know expected and computed are only good to a (real) phase but don't want to try/except/else or pre-match the signs. Or for when comparing complex data structure or when only certain leaves are free to negate. This came up for https://github.com/psi4/psi4/blob/master/tests/pytests/test_detci_opdm.py#L47 since `compare_matrices` is `compare_recursive` behind the scenes.

I'd really like a `equal_scaled` option, but that's harder.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
