### PR TITLE
Add mrchem dtype to to_string function

### DIFF
--- a/qcelemental/molparse/to_string.py
+++ b/qcelemental/molparse/to_string.py
@@ -427,7 +427,7 @@ def to_string(
 
     elif dtype == "mrchem":
         atom_format = "{elem}"
-        ghost_format = "@{elem}"
+        ghost_format = "{elem}"
         atoms = _atoms_formatter(molrec, geom, atom_format, ghost_format, width, prec, 2)
 
         smol = (

--- a/qcelemental/molparse/to_string.py
+++ b/qcelemental/molparse/to_string.py
@@ -85,6 +85,7 @@ def to_string(
         "terachem": "Bohr",
         "turbomole": "Bohr",
         "madness": "Bohr",  # madness by default reads au and optionally can read angs/angstrom
+        "mrchem": "Bohr",  # MRChem by default reads au and optionally can read angs/angstrom
     }
     if dtype not in default_units:
         raise KeyError(f"dtype '{dtype}' not understood.")
@@ -423,6 +424,32 @@ def to_string(
         if "fix_symmetry" in molrec.keys() and molrec["fix_symmetry"] == "c1":
             data.keywords["sym_ignore"] = True
             data.keywords["symmetry"] = False
+
+    elif dtype == "mrchem":
+        atom_format = "{elem}"
+        ghost_format = "@{elem}"
+        atoms = _atoms_formatter(molrec, geom, atom_format, ghost_format, width, prec, 2)
+
+        smol = (
+            [
+                "Molecule {",
+                f"charge = {int(molrec['molecular_charge'])}",
+                f"multiplicity = {molrec['molecular_multiplicity']}",
+                f"translate = {molrec['fix_com']}",
+                "$coords",
+            ]
+            + atoms
+            + ["$end\n}"]
+        )
+
+        # this is what we are actually interested in:
+        # when dtype="mrchem", we always want to set return_data=True
+        data.keywords = {
+            "charge": int(molrec["molecular_charge"]),
+            "multiplicity": molrec["molecular_multiplicity"],
+            "translate": molrec["fix_com"],
+            "coords": "\n".join(atoms),
+        }
 
     else:
         raise KeyError(f"dtype '{dtype}' not understood.")

--- a/qcelemental/tests/test_molparse_to_string.py
+++ b/qcelemental/tests/test_molparse_to_string.py
@@ -110,6 +110,28 @@ GH                    {au2:.12f}     0.000000000000     0.000000000000
 H                    -{au2:.12f}     0.000000000000     0.000000000000
 end
 """,
+    "ans2_mrchem_au": """Molecule {
+charge = 0
+multiplicity = 3
+translate = False
+$coords
+Co                    0.000000000000     0.000000000000     0.000000000000
+H                     2.000000000000     0.000000000000     0.000000000000
+H                    -2.000000000000     0.000000000000     0.000000000000
+$end
+}
+""",
+    "ans2_mrchem_ang": f"""Molecule {{
+charge = 0
+multiplicity = 3
+translate = False
+$coords
+Co                    0.000000000000     0.000000000000     0.000000000000
+H                     {au2:.12f}     0.000000000000     0.000000000000
+H                    -{au2:.12f}     0.000000000000     0.000000000000
+$end
+}}
+""",
     "ans2_terachem_au": """3 au
 CoH2
 Co                    0.000000000000     0.000000000000     0.000000000000
@@ -222,6 +244,8 @@ QCElemental
         (("subject2", {"dtype": "nwchem", "units": "angstrom"}), "ans2_nwchem_ang"),
         (("subject2", {"dtype": "madness", "units": "bohr"}), "ans2_madness_au"),
         (("subject2", {"dtype": "madness", "units": "angstrom"}), "ans2_madness_ang"),
+        (("subject2", {"dtype": "mrchem", "units": "bohr"}), "ans2_mrchem_au"),
+        (("subject2", {"dtype": "mrchem", "units": "angstrom"}), "ans2_mrchem_ang"),
         (("subject2", {"dtype": "terachem", "units": "angstrom"}), "ans2_terachem_ang"),
         (("subject2", {"dtype": "terachem"}), "ans2_terachem_au"),
         (("subject2", {"dtype": "psi4", "units": "bohr"}), "ans2_psi4_au"),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR adds the `mrchem` `dtype` to the `to_string` function, to translate to the format recognized by the MRChem program.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Added `mrchem` as a `dtype` to the `to_string` function.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
