### PR TITLE
Models: Minor basis fix if center data is not valid

### DIFF
--- a/qcelemental/models/basis.py
+++ b/qcelemental/models/basis.py
@@ -145,7 +145,12 @@ class BasisSet(ProtoModel):
     @validator("atom_map")
     def _check_atom_map(cls, v, values):
         sv = set(v)
-        missing = sv - values["center_data"].keys()
+
+        # Center_data validation error, skipping
+        try:
+            missing = sv - values["center_data"].keys()
+        except KeyError:
+            return v
 
         if missing:
             raise ValueError(f"'atom_map' contains unknown keys to 'center_data': {missing}.")


### PR DESCRIPTION
Validation would fail with an incorrect error message if `center_data` did not validate in Basis. This PR fixes this issue to always ensure validation errors are thrown at the correct location.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
