### PR TITLE
Replaces deprecated numpy dtypes

### DIFF
--- a/qcelemental/molparse/from_arrays.py
+++ b/qcelemental/molparse/from_arrays.py
@@ -596,7 +596,7 @@ def validate_and_fill_efp(fragment_files=None, hint_types=None, geom_hints=None)
 def validate_and_fill_geometry(geom=None, tooclose=0.1, copy=True):
     """Check `geom` for overlapping atoms. Return flattened"""
 
-    npgeom = np.array(geom, copy=copy, dtype=np.float).reshape((-1, 3))
+    npgeom = np.array(geom, copy=copy, dtype=float).reshape((-1, 3))
 
     # Upper triangular
     metric = tooclose ** 2
@@ -695,11 +695,11 @@ def validate_and_fill_nuclei(
     else:
         A = Z = E = mass = real = label = []
     return {
-        "elea": np.array(A, dtype=np.int),
-        "elez": np.array(Z, dtype=np.int),
+        "elea": np.array(A, dtype=int),
+        "elez": np.array(Z, dtype=int),
         "elem": np.array(E),
-        "mass": np.array(mass, dtype=np.float),
-        "real": np.array(real, dtype=np.bool),
+        "mass": np.array(mass, dtype=float),
+        "real": np.array(real, dtype=bool),
         "elbl": np.array(label),
     }
 
@@ -712,7 +712,7 @@ def validate_and_fill_fragments(nat, fragment_separators=None, fragment_charges=
     """
     if fragment_separators is None:
         if fragment_charges is None and fragment_multiplicities is None:
-            frs = []  # np.array([], dtype=np.int)  # if empty, needs to be both ndarray and int
+            frs = []  # np.array([], dtype=int)  # if empty, needs to be both ndarray and int
             frc = [None]
             frm = [None]
         else:

--- a/qcelemental/testing.py
+++ b/qcelemental/testing.py
@@ -108,7 +108,7 @@ def compare_values(
     if np.iscomplexobj(expected):
         dtype = np.complex
     else:
-        dtype = np.float
+        dtype = float
 
     try:
         xptd, cptd = np.array(expected, dtype=dtype), np.array(computed, dtype=dtype)

--- a/qcelemental/tests/test_datum.py
+++ b/qcelemental/tests/test_datum.py
@@ -14,7 +14,7 @@ def dataset():
         "decimal": qcel.Datum(
             "a label", "mdyn/angstrom", Decimal("4.4"), comment="force constant", doi="10.1000/182", numeric=False
         ),
-        "ndarray": qcel.Datum("an array", "cm^-1", np.arange(4, dtype=np.float) * 4 / 3, comment="freqs"),
+        "ndarray": qcel.Datum("an array", "cm^-1", np.arange(4, dtype=float) * 4 / 3, comment="freqs"),
         "float": qcel.Datum("a float", "kg", 4.4, doi="10.1000/182"),
         "string": qcel.Datum("ze lbl", "ze unit", "ze data", numeric=False),
         "lststr": qcel.Datum("ze lbl", "ze unit", ["V", "R", None], numeric=False),
@@ -54,7 +54,7 @@ def test_creation_error():
         (("decimal", None), 4.4),
         (("decimal", "N/m"), 440),
         (("decimal", "hartree/bohr/bohr"), 0.282614141011 if qcel.constants.name == "CODATA2014" else 0.28261413658),
-        (("ndarray", "1/m"), np.arange(4, dtype=np.float) * 400 / 3),
+        (("ndarray", "1/m"), np.arange(4, dtype=float) * 400 / 3),
     ],
 )
 def test_units(dataset, inp, expected):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Replaces deprecated data types np.float/np.int/np.bool with native float/int/bool.
See [Notes](https://numpy.org/devdocs/release/1.20.0-notes.html) in v1.20.0 on Deprecations.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
