### PR TITLE
Remove more deprecated aliases from NumPy to built-in types

### DIFF
--- a/qcelemental/util/scipy_hungarian.py
+++ b/qcelemental/util/scipy_hungarian.py
@@ -94,14 +94,14 @@ def linear_sum_assignment(cost_matrix, return_cost=False):
     if len(cost_matrix.shape) != 2:
         raise ValueError("expected a matrix (2-d array), got a %r array" % (cost_matrix.shape,))
 
-    if not (np.issubdtype(cost_matrix.dtype, np.number) or cost_matrix.dtype == np.dtype(np.bool)):
+    if not (np.issubdtype(cost_matrix.dtype, np.number) or cost_matrix.dtype == np.dtype(bool)):
         raise ValueError("expected a matrix containing numerical entries, got %s" % (cost_matrix.dtype,))
 
     if np.any(np.isinf(cost_matrix) | np.isnan(cost_matrix)):
         raise ValueError("matrix contains invalid numeric entries")
 
-    if cost_matrix.dtype == np.dtype(np.bool):
-        cost_matrix = cost_matrix.astype(np.int)
+    if cost_matrix.dtype == np.dtype(bool):
+        cost_matrix = cost_matrix.astype(int)
 
     # The algorithm expects more columns than rows in the cost matrix.
     if cost_matrix.shape[1] < cost_matrix.shape[0]:

--- a/qcelemental/util/test_scipy_hungarian.py
+++ b/qcelemental/util/test_scipy_hungarian.py
@@ -88,7 +88,7 @@ def test_linear_sum_assignment_input_validation():
     #                    linear_sum_assignment(matrix(C)))
 
     I = np.identity(3)
-    assert_array_equal(linear_sum_assignment(I.astype(np.bool)), linear_sum_assignment(I))
+    assert_array_equal(linear_sum_assignment(I.astype(bool)), linear_sum_assignment(I))
     assert_raises(ValueError, linear_sum_assignment, I.astype(str))
 
     I[0][0] = np.nan


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
This is a minor cleanup after #246 / https://github.com/MolSSI/QCElemental/pull/246#issuecomment-772085011. I don't get any locally, but I might not have the right setup; worth checking the logs

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Remove NumPy aliases to built-in types deprecated in 1.20

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
