### PR TITLE
Fix compatibility with pydantic v1.8 / Remove useless connectivity validation

### DIFF
--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -389,12 +389,6 @@ class Molecule(ProtoModel):
                 )
         return v
 
-    @validator("connectivity_", each_item=True)
-    def _min_zero(cls, v):
-        if v < 0:
-            raise ValueError("Connectivity entries must be greater than 0")
-        return v
-
     @property
     def hash_fields(self):
         return [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Removes a useless check of the elements of the connectivity field. This is causing problems due to a breaking change in pydantic 1.8, and is not required anyway due to the values being handled elsewhere.

Previous pydantic behavior for `each_item=True` was to recurse down into nested lists, tuples, etc. The new behavior is to only validate the top level, which for us attempts to compare a `tuple` with an `int`.

But this validator is not required anyway, since now we check with NonNegativeInt and BondOrderFloat.

See https://github.com/samuelcolvin/pydantic/releases/tag/v1.8

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Fix compatibility with pydantic v1.8 w.r.t. connectivity validation

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
