### PR TITLE
typehints in docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,6 +2,7 @@
 #
 
 # You can set these variables from the command line.
+#SPHINXOPTS    = -n -W --keep-going
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = qcelemental

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,16 +54,20 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
     'sphinx.ext.graphviz',
+    "sphinx_autodoc_typehints",
     # from Astropy
     'sphinx_automodapi.automodapi',
     'sphinx_automodapi.automodsumm',
-    #'sphinx_automodapi.smart_resolver',
+    'sphinx_automodapi.smart_resolver',
 ]
 
 autosummary_generate = True
 automodapi_toctreedirnm = 'api'
 #numpydoc_show_class_members = False
 #automodsumm_inherited_members = True
+autodoc_typehints = "description"
+napoleon_use_param = True
+napoleon_use_rtype = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/model_molecule.rst
+++ b/docs/source/model_molecule.rst
@@ -3,7 +3,7 @@ Molecule
 
 A Python implementation of the `MolSSI QCSchema
 <https://github.com/MolSSI/QCSchema>`_ ``Molecule`` object.
-A "Molecule" many definitions of ``Molecule`` depending on the domain; this particular
+There are many definitions of ``Molecule`` depending on the domain; this particular
 ``Molecule`` is an immutable 3D Cartesian representation with support for
 quantum chemistry constructs.
 
@@ -99,7 +99,7 @@ the ``from_data`` function or by passing explicit fragments in the
     >>>       fragments=[[0], [1]]
     >>>       )
 
-Fragments from a molecule containing fragment information can be aquired by:
+Fragments from a molecule containing fragment information can be acquired by:
 
 .. code-block:: python
 
@@ -136,4 +136,5 @@ API
 .. autoclass:: qcelemental.models.Molecule
    :members:
    :no-special-members:
+   :noindex:
 

--- a/docs/source/model_result.rst
+++ b/docs/source/model_result.rst
@@ -1,5 +1,5 @@
 AtomicResult
-======
+============
 
 A Python implementation of the `MolSSI QCSchema
 <https://github.com/MolSSI/QCSchema>`_ ``AtomicResult`` object.
@@ -11,7 +11,7 @@ AtomicInput
 .. autoclass:: qcelemental.models.AtomicInput
 
 AtomicResult
-------
+------------
 
 .. autoclass:: qcelemental.models.AtomicResult
 

--- a/qcelemental/covalent_radii.py
+++ b/qcelemental/covalent_radii.py
@@ -12,16 +12,17 @@ from .periodic_table import periodictable
 
 
 class CovalentRadii:
-    """Covalent radii sets.
+    r"""Covalent radii sets.
 
     Parameters
     ----------
-    context : {'ALVAREZ2008'}
+    context : str
+        {'ALVAREZ2008'}
         Origin of loaded data.
 
     Attributes
     ----------
-    cr : dict of Datum
+    cr : Dict[str, Datum]
         Each covalent radius is an entry in `cr`, where key is the
         "Fe"-cased element symbol if generic or symbol-prefixed label
         if specialized within element. The value is a Datum object with
@@ -75,19 +76,19 @@ class CovalentRadii:
     def get(
         self, atom: Union[int, str], *, return_tuple: bool = False, units: str = "bohr", missing: float = None
     ) -> Union[float, "Datum"]:  # lgtm [py/similar-function]
-        """
+        r"""
         Access a covalent radius for species `atom`.
 
         Parameters
         ----------
-        atom : int or str
+        atom
             Identifier for element or nuclide, e.g., ``H``, ``D``, ``H2``, ``He``, ``hE4``.
             In general, one value recommended for each element; however, certain other exact labels may be available.
             ALVAREZ2008: C_sp3, C_sp2, C_sp, Mn_lowspin, Mn_highspin, Fe_lowspin, Fe_highspin, Co_lowspin, Co_highspin
-        units : str, optional
+        units
             Units of returned value. To return in native unit (ALVAREZ2008: angstrom), pass it explicitly.
             Only relevant for ``return_tuple=False`` since ``True`` returns underlying data structure with native units.
-        missing : float or None, optional
+        missing
             How to handle when ``atom`` is valid but outside the available data range. When ``None``, raises DataUnavailableError.
             When a float, returns that float, so supply in ``units`` units. Supplying a float is a more compact assurance
             that a call will work over all the periodic table than the equivalent
@@ -100,7 +101,7 @@ class CovalentRadii:
                     rad = 4.0
 
             Only relevant for ``return_tuple=False``.
-        return_tuple : bool, optional
+        return_tuple
             See below.
 
         Returns
@@ -145,13 +146,13 @@ class CovalentRadii:
         return print_variables(self.cr)
 
     def write_c_header(self, filename: str = "covrad.h", missing: float = 2.0) -> None:  # lgtm[py/similar-function]
-        """Write C header file defining covalent radii array.
+        r"""Write C header file defining covalent radii array.
 
         Parameters
         ----------
-        filename : str, optional
+        filename
             File name for header. Note that changing this won't change the header guard.
-        missing : float, optional
+        missing
             In order that the C array be atomic-number indexable and that it span the
             periodic table, this value is used anywhere data is missing.
 

--- a/qcelemental/datum.py
+++ b/qcelemental/datum.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, validator
 
 
 class Datum(BaseModel):
-    """Facilitates the storage of quantum chemical results by labeling them with basic metadata.
+    r"""Facilitates the storage of quantum chemical results by labeling them with basic metadata.
 
     Attributes
     ----------
@@ -18,15 +18,15 @@ class Datum(BaseModel):
         Official label for `data`, often qcvar. May contain spaces.
     units : str
         ASCII, LaTeX-like representation of units, without square brackets.
-    data : float or Decimal or or :py:class:`numpy.ndarray`
+    data : float or decimal.Decimal or numpy.ndarray
         Value for `label`.
-    comment : str, optional
+    comment : str
         Additional notes.
-    doi : str, optional
+    doi : str
         Literature citation or definition DOI link.
-    glossary : str, optional
+    glossary : str
         Extended description or definition.
-    numeric : bool, optional
+    numeric : bool
         Whether `data` is numeric. Pass `True` to disable validating `data` as float/Decimal/np.ndarray.
 
     """
@@ -102,11 +102,11 @@ class Datum(BaseModel):
 
 
 def print_variables(qcvars: Dict[str, "Datum"]) -> str:
-    """Form a printable representation of qcvariables.
+    r"""Form a printable representation of qcvariables.
 
     Parameters
     ----------
-    qcvars : dict of Datum
+    qcvars
         Group of Datum objects to print.
 
     Returns

--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -35,7 +35,7 @@ class ProtoModel(BaseModel):
 
     @classmethod
     def parse_raw(cls, data: Union[bytes, str], *, encoding: str = None) -> "ProtoModel":  # type: ignore
-        """
+        r"""
         Parses raw string or bytes into a Model object.
 
         Parameters
@@ -70,7 +70,7 @@ class ProtoModel(BaseModel):
 
     @classmethod
     def parse_file(cls, path: Union[str, Path], *, encoding: str = None) -> "ProtoModel":  # type: ignore
-        """Parses a file into a Model object.
+        r"""Parses a file into a Model object.
 
         Parameters
         ----------
@@ -128,7 +128,7 @@ class ProtoModel(BaseModel):
         exclude_defaults: Optional[bool] = None,
         exclude_none: Optional[bool] = None,
     ) -> Union[bytes, str]:
-        """Generates a serialized representation of the model
+        r"""Generates a serialized representation of the model
 
         Parameters
         ----------
@@ -172,7 +172,7 @@ class ProtoModel(BaseModel):
         return self.serialize("json", **kwargs)
 
     def compare(self, other: Union["ProtoModel", BaseModel], **kwargs) -> bool:
-        """Compares the current object to the provided object recursively.
+        r"""Compares the current object to the provided object recursively.
 
         Parameters
         ----------

--- a/qcelemental/models/basis.py
+++ b/qcelemental/models/basis.py
@@ -57,7 +57,7 @@ class ElectronShell(ProtoModel):
         return v
 
     def nfunctions(self) -> int:
-        """
+        r"""
         Computes the number of basis functions on this shell.
 
         Returns
@@ -72,7 +72,7 @@ class ElectronShell(ProtoModel):
             return sum(((L + 1) * (L + 2) // 2) for L in self.angular_momentum)
 
     def is_contracted(self) -> bool:
-        """
+        r"""
         Checks if the shell represents a contracted Gaussian or not.
 
         Returns
@@ -208,7 +208,7 @@ class BasisSet(ProtoModel):
 
     @classmethod
     def _calculate_nbf(cls, atom_map, center_data) -> int:
-        """
+        r"""
         Number of basis functions in the basis set.
 
         Returns

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -45,7 +45,7 @@ _extension_map = {
 
 
 def float_prep(array, around):
-    """
+    r"""
     Rounds floats to a common value and build positive zeros to prevent hash conflicts.
     """
     if isinstance(array, (list, np.ndarray)):
@@ -74,7 +74,7 @@ class BondOrderFloat(ConstrainedFloat):
 
 
 class Identifiers(ProtoModel):
-    """Canonical chemical identifiers"""
+    r"""Canonical chemical identifiers"""
 
     molecule_hash: Optional[str] = None
     molecular_formula: Optional[str] = None
@@ -95,7 +95,7 @@ class Identifiers(ProtoModel):
 
 
 class Molecule(ProtoModel):
-    """
+    r"""
     The physical Cartesian representation of the molecular system.
 
     A QCSchema representation of a Molecule. This model contains
@@ -106,9 +106,10 @@ class Molecule(ProtoModel):
     Notes
     -----
     All arrays are stored flat but must be reshapable into the dimensions in attribute ``shape``, with abbreviations as follows:
-        nat: number of atomic = calcinfo_natom
-        nfr: number of fragments
-        <varies>: irregular dimension not systematically reshapable
+
+      * nat: number of atomic = calcinfo_natom
+      * nfr: number of fragments
+      * <varies>: irregular dimension not systematically reshapable
 
     """
 
@@ -310,15 +311,15 @@ class Molecule(ProtoModel):
             schema["$schema"] = qcschema_draft
 
     def __init__(self, orient: bool = False, validate: Optional[bool] = None, **kwargs: Any) -> None:
-        """Initializes the molecule object from dictionary-like values.
+        r"""Initializes the molecule object from dictionary-like values.
 
         Parameters
         ----------
-        orient : bool, optional
+        orient
             If True, orientates the Molecule to a common reference frame.
-        validate : Optional[bool], optional
+        validate
             If ``None`` validation is always applied unless the ``validated`` flag is set. Otherwise uses the boolean to decide to validate the Molecule or not.
-        **kwargs : Any
+        **kwargs
             The values of the Molecule object attributes.
         """
         if validate is None:
@@ -469,12 +470,12 @@ class Molecule(ProtoModel):
     ### Non-Pydantic API functions
 
     def show(self, ngl_kwargs: Optional[Dict[str, Any]] = None) -> "nglview.NGLWidget":  # type: ignore
-        """Creates a 3D representation of a moleucle that can be manipulated in Jupyter Notebooks and exported as
+        r"""Creates a 3D representation of a moleucle that can be manipulated in Jupyter Notebooks and exported as
         images (`.png`).
 
         Parameters
         ----------
-        ngl_kwargs : Optional[Dict[str, Any]], optional
+        ngl_kwargs
             Addition nglview NGLWidget kwargs
 
         Returns
@@ -500,15 +501,15 @@ class Molecule(ProtoModel):
     def measure(
         self, measurements: Union[List[int], List[List[int]]], *, degrees: bool = True
     ) -> Union[float, List[float]]:
-        """
+        r"""
         Takes a measurement of the moleucle from the indicies provided.
 
         Parameters
         ----------
-        measurements : Union[List[int], List[List[int]]]
+        measurements
             Either a single list of indices or multiple. Return a distance, angle, or dihedral depending if
             2, 3, or 4 indices is provided, respectively. Values are returned in Bohr (distance) or degree.
-        degrees : bool, optional
+        degrees
             Returns degrees by default, radians otherwise.
 
         Returns
@@ -520,7 +521,7 @@ class Molecule(ProtoModel):
         return measure_coordinates(self.geometry, measurements, degrees=degrees)
 
     def orient_molecule(self):
-        """
+        r"""
         Centers the molecule and orients via inertia tensor before returning a new Molecule
         """
         return Molecule(orient=True, **self.dict())
@@ -532,7 +533,7 @@ class Molecule(ProtoModel):
         return self == other
 
     def __eq__(self, other):
-        """
+        r"""
         Checks if two molecules are identical. This is a molecular identity defined
         by scientific terms, and not programing terms, so it's less rigorous than
         a programmatic equality or a memory equivalent `is`.
@@ -553,7 +554,7 @@ class Molecule(ProtoModel):
         return super().dict(*args, **kwargs)
 
     def pretty_print(self):
-        """Print the molecule in Angstroms. Same as :py:func:`print_out` only always in Angstroms.
+        r"""Print the molecule in Angstroms. Same as :py:func:`print_out` only always in Angstroms.
         (method name in libmints is print_in_angstrom)
 
         """
@@ -583,7 +584,7 @@ class Molecule(ProtoModel):
         orient: bool = False,
         group_fragments: bool = True,
     ) -> "Molecule":
-        """Get new Molecule with fragments preserved, dropped, or ghosted.
+        r"""Get new Molecule with fragments preserved, dropped, or ghosted.
 
         Parameters
         ----------
@@ -603,8 +604,8 @@ class Molecule(ProtoModel):
 
         Returns
         -------
-        mol
-            New ``py::class:qcelemental.model.Molecule`` with ``self``\'s fragments present, ghosted, or absent.
+        Molecule
+            New qcelemental.models.Molecule with ``self``\'s fragments present, ghosted, or absent.
 
         """
         if isinstance(real, int):
@@ -732,7 +733,7 @@ class Molecule(ProtoModel):
         prec: int = 12,
         return_data: bool = False,
     ):
-        """Returns a string that can be used by a variety of programs.
+        r"""Returns a string that can be used by a variety of programs.
 
         Unclear if this will be removed or renamed to "to_psi4_string" in the future
 
@@ -751,7 +752,7 @@ class Molecule(ProtoModel):
         )
 
     def get_hash(self):
-        """
+        r"""
         Returns the hash of the molecule.
         """
 
@@ -776,7 +777,7 @@ class Molecule(ProtoModel):
         return m.hexdigest()
 
     def get_molecular_formula(self, order: str = "alphabetical") -> str:
-        """
+        r"""
         Returns the molecular formula for a molecule.
 
         Parameters
@@ -820,27 +821,27 @@ class Molecule(ProtoModel):
     @classmethod
     def from_data(
         cls,
-        data: Union[str, Dict[str, Any], np.array, bytes],
+        data: Union[str, Dict[str, Any], np.ndarray, bytes],
         dtype: Optional[str] = None,
         *,
         orient: bool = False,
         validate: bool = None,
         **kwargs: Dict[str, Any],
     ) -> "Molecule":
-        """
+        r"""
         Constructs a molecule object from a data structure.
 
         Parameters
         ----------
-        data : Union[str, Dict[str, Any], np.array]
+        data
             Data to construct Molecule from
-        dtype : Optional[str], optional
+        dtype
             How to interpret the data, if not passed attempts to discover this based on input type.
-        orient : bool, optional
+        orient
             Orientates the molecule to a standard frame or not.
-        validate : bool, optional
+        validate
             Validates the molecule or not.
-        **kwargs : Dict[str, Any]
+        **kwargs
             Additional kwargs to pass to the constructors. kwargs take precedence over data.
 
         Returns
@@ -906,16 +907,16 @@ class Molecule(ProtoModel):
 
     @classmethod
     def from_file(cls, filename: str, dtype: Optional[str] = None, *, orient: bool = False, **kwargs):
-        """
+        r"""
         Constructs a molecule object from a file.
 
         Parameters
         ----------
-        filename : str
+        filename
             The filename to build
-        dtype : Optional[str], optional
+        dtype
             The type of file to interpret.
-        orient : bool, optional
+        orient
             Orientates the molecule to a standard frame or not.
         **kwargs
             Any additional keywords to pass to the constructor
@@ -956,13 +957,13 @@ class Molecule(ProtoModel):
         return cls.from_data(data, dtype, orient=orient, **kwargs)
 
     def to_file(self, filename: str, dtype: Optional[str] = None) -> None:
-        """Writes the Molecule to a file.
+        r"""Writes the Molecule to a file.
 
         Parameters
         ----------
-        filename : str
+        filename
             The filename to write to
-        dtype : Optional[str], optional
+        dtype
             The type of file to write, attempts to infer dtype from the filename if not provided.
 
         """
@@ -997,7 +998,7 @@ class Molecule(ProtoModel):
     ### Non-Pydantic internal functions
 
     def _orient_molecule_internal(self):
-        """
+        r"""
         Centers the molecule and orients via inertia tensor before returning a new set of the
         molecule geometry
         """
@@ -1055,7 +1056,7 @@ class Molecule(ProtoModel):
 
     @staticmethod
     def _inertial_tensor(geom, *, weight):
-        """
+        r"""
         Compute the moment inertia tensor for a given geometry.
         """
         # Build inertia tensor
@@ -1074,16 +1075,17 @@ class Molecule(ProtoModel):
         return tensor
 
     def nuclear_repulsion_energy(self, ifr: int = None) -> float:
-        """Nuclear repulsion energy.
+        r"""Nuclear repulsion energy.
 
         Parameters
         ----------
-        ifr : int, optional
+        ifr
             If not `None`, only compute for the `ifr`-th (0-indexed) fragment.
 
         Returns
         -------
-        Nuclear repulsion energy in entire molecule or in fragment.
+        nre : float
+            Nuclear repulsion energy in entire molecule or in fragment.
 
         """
         Zeff = [z * int(real) for z, real in zip(cast(Iterable[int], self.atomic_numbers), self.real)]
@@ -1100,16 +1102,17 @@ class Molecule(ProtoModel):
         return nre
 
     def nelectrons(self, ifr: int = None) -> int:
-        """Number of electrons.
+        r"""Number of electrons.
 
         Parameters
         ----------
-        ifr : int, optional
+        ifr
             If not `None`, only compute for the `ifr`-th (0-indexed) fragment.
 
         Returns
         -------
-        Number of electrons in entire molecule or in fragment.
+        nelec : int
+            Number of electrons in entire molecule or in fragment.
 
         """
         Zeff = [z * int(real) for z, real in zip(cast(Iterable[int], self.atomic_numbers), self.real)]
@@ -1135,48 +1138,49 @@ class Molecule(ProtoModel):
         uno_cutoff: float = 1.0e-3,
         run_mirror: bool = False,
     ):
-        """Finds shift, rotation, and atom reordering of `concern_mol` (self)
+        r"""Finds shift, rotation, and atom reordering of `concern_mol` (self)
         that best aligns with `ref_mol`.
 
-        Wraps :py:func:`qcel.molutil.B787` for :py:class:`qcel.models.Molecule`.
+        Wraps :py:func:`qcelemental.molutil.B787` for :py:class:`qcelemental.models.Molecule`.
         Employs the Kabsch, Hungarian, and Uno algorithms to exhaustively locate
         the best alignment for non-oriented, non-ordered structures.
 
         Parameters
         ----------
-        ref_mol : qcel.models.Molecule
+        ref_mol : qcelemental.models.Molecule
             Molecule to match.
-        atoms_map : bool, optional
+        atoms_map
             Whether atom1 of `ref_mol` corresponds to atom1 of `concern_mol`, etc.
             If true, specifying `True` can save much time.
-        mols_align : bool or float, optional
+        mols_align
             Whether ref_mol and concern_mol have identical geometries
             (barring orientation or atom mapping) and expected final RMSD = 0.
             If `True`, procedure is truncated when RMSD condition met, saving time.
             If float, RMSD tolerance at which search for alignment stops. If provided,
             the alignment routine will throw an error if it fails to align
             the molecule within the specified RMSD tolerance.
-        do_plot : bool, optional
+        do_plot
             Pops up a mpl plot showing before, after, and ref geometries.
-        run_to_completion : bool, optional
+        run_to_completion
             Run reorderings to completion (past RMSD = 0) even if unnecessary because
             `mols_align=True`. Used to test worst-case timings.
-        run_resorting : bool, optional
+        run_resorting
             Run the resorting machinery even if unnecessary because `atoms_map=True`.
-        uno_cutoff : float, optional
+        uno_cutoff
             TODO
-        run_mirror : bool, optional
+        run_mirror
             Run alternate geometries potentially allowing best match to `ref_mol`
             from mirror image of `concern_mol`. Only run if system confirmed to
             be nonsuperimposable upon mirror reflection.
-        verbose : int, optional
+        verbose
             Print level.
 
         Returns
         -------
-        Molecule, data
+        mol : Molecule
+        data : Dict[key, Any]
             Molecule is internal geometry of `self` optimally aligned and atom-ordered
-              to `ref_mol`. Presently all fragment information is discarded.
+            to `ref_mol`. Presently all fragment information is discarded.
             `data['rmsd']` is RMSD [A] between `ref_mol` and the optimally aligned
             geometry computed.
             `data['mill']` is a AlignmentMill with fields
@@ -1264,56 +1268,57 @@ class Molecule(ProtoModel):
     def scramble(
         self,
         *,
-        do_shift: bool = True,
-        do_rotate=True,
-        do_resort=True,
-        deflection=1.0,
-        do_mirror=False,
-        do_plot=False,
-        do_test=False,
-        run_to_completion=False,
-        run_resorting=False,
-        verbose=0,
+        do_shift: Union[bool, Array[float], List] = True,
+        do_rotate: Union[bool, Array[float], List[List]] = True,
+        do_resort: Union[bool, List] = True,
+        deflection: float = 1.0,
+        do_mirror: bool = False,
+        do_plot: bool = False,
+        do_test: bool = False,
+        run_to_completion: bool = False,
+        run_resorting: bool = False,
+        verbose: int = 0,
     ):
-        """Generate a Molecule with random or directed translation, rotation, and atom shuffling.
+        r"""Generate a Molecule with random or directed translation, rotation, and atom shuffling.
         Optionally, check that the aligner returns the opposite transformation.
 
         Parameters
         ----------
-        ref_mol : qcel.models.Molecule
+        ref_mol : qcelemental.models.Molecule
             Molecule to perturb.
-        do_shift : bool or array-like, optional
+        do_shift
             Whether to generate a random atom shift on interval [-3, 3) in each
             dimension (`True`) or leave at current origin. To shift by a specified
             vector, supply a 3-element list.
-        do_rotate : bool or array-like, optional
+        do_rotate
             Whether to generate a random 3D rotation according to algorithm of Arvo.
             To rotate by a specified matrix, supply a 9-element list of lists.
-        do_resort : bool or array-like, optional
+        do_resort
             Whether to shuffle atoms (`True`) or leave 1st atom 1st, etc. (`False`).
             To specify shuffle, supply a nat-element list of indices.
-        deflection : float, optional
+        deflection
             If `do_rotate`, how random a rotation: 0.0 is no change, 0.1 is small
             perturbation, 1.0 is completely random.
-        do_mirror : bool, optional
+        do_mirror
             Whether to construct the mirror image structure by inverting y-axis.
-        do_plot : bool, optional
+        do_plot
             Pops up a mpl plot showing before, after, and ref geometries.
-        do_test : bool, optional
+        do_test
             Additionally, run the aligner on the returned Molecule and check that
             opposite transformations obtained.
-        run_to_completion : bool, optional
+        run_to_completion
             By construction, scrambled systems are fully alignable (final RMSD=0).
             Even so, `True` turns off the mechanism to stop when RMSD reaches zero
             and instead proceed to worst possible time.
-        run_resorting : bool, optional
+        run_resorting
             Even if atoms not shuffled, test the resorting machinery.
-        verbose : int, optional
+        verbose
             Print level.
 
         Returns
         -------
-        Molecule, data
+        mol : Molecule
+        data : Dict[key, Any]
             Molecule is scrambled copy of `ref_mol` (self).
             `data['rmsd']` is RMSD [A] between `ref_mol` and the scrambled geometry.
             `data['mill']` is a AlignmentMill with fields

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -17,13 +17,12 @@ if TYPE_CHECKING:
 
 
 class AtomicResultProperties(ProtoModel):
-    """Named properties of quantum chemistry computations following the MolSSI QCSchema.
+    r"""Named properties of quantum chemistry computations following the MolSSI QCSchema.
 
-    Notes
-    -----
     All arrays are stored flat but must be reshapable into the dimensions in attribute ``shape``, with abbreviations as follows:
-        nao: number of atomic orbitals = calcinfo_nbasis
-        nmo: number of molecular orbitals
+
+      * nao: number of atomic orbitals = calcinfo_nbasis
+      * nmo: number of molecular orbitals
     """
 
     # Calcinfo
@@ -253,7 +252,7 @@ class AtomicResultProperties(ProtoModel):
 
 
 class WavefunctionProperties(ProtoModel):
-    """Wavefunction properties resulting from a computation. Matrix quantities are stored in column-major order. Presence and contents configurable by protocol."""
+    r"""Wavefunction properties resulting from a computation. Matrix quantities are stored in column-major order. Presence and contents configurable by protocol."""
 
     # Class properties
     _return_results_names: Set[str] = {
@@ -451,7 +450,7 @@ class WavefunctionProperties(ProtoModel):
 
 
 class WavefunctionProtocolEnum(str, Enum):
-    """Wavefunction to keep from a computation."""
+    r"""Wavefunction to keep from a computation."""
 
     all = "all"
     orbitals_and_eigenvalues = "orbitals_and_eigenvalues"
@@ -460,7 +459,7 @@ class WavefunctionProtocolEnum(str, Enum):
 
 
 class ErrorCorrectionProtocol(ProtoModel):
-    """Configuration for how QCEngine handles error correction
+    r"""Configuration for how QCEngine handles error correction
 
     WARNING: These protocols are currently experimental and only supported by NWChem tasks
     """
@@ -482,7 +481,7 @@ class ErrorCorrectionProtocol(ProtoModel):
 
 
 class AtomicResultProtocols(ProtoModel):
-    """Protocols regarding the manipulation of computational result data."""
+    r"""Protocols regarding the manipulation of computational result data."""
 
     wavefunction: WavefunctionProtocolEnum = Field(
         WavefunctionProtocolEnum.none, description=str(WavefunctionProtocolEnum.__doc__)
@@ -500,7 +499,7 @@ class AtomicResultProtocols(ProtoModel):
 
 
 class AtomicInput(ProtoModel):
-    """The MolSSI Quantum Chemistry Schema"""
+    r"""The MolSSI Quantum Chemistry Schema"""
 
     id: Optional[str] = Field(None, description="The optional ID for the computation.")
     schema_name: constr(strip_whitespace=True, regex="^(qc_?schema_input)$") = Field(  # type: ignore
@@ -541,7 +540,7 @@ class AtomicInput(ProtoModel):
 
 
 class AtomicResult(AtomicInput):
-    """Results from a CMS program execution."""
+    r"""Results from a CMS program execution."""
 
     schema_name: constr(strip_whitespace=True, regex="^(qc_?schema_output)$") = Field(  # type: ignore
         qcschema_output_default,
@@ -569,7 +568,7 @@ class AtomicResult(AtomicInput):
 
     @validator("schema_name", pre=True)
     def _input_to_output(cls, v):
-        """If qcschema_input is passed in, cast it to output, otherwise no"""
+        r"""If qcschema_input is passed in, cast it to output, otherwise no"""
         if v.lower().strip() in [qcschema_input_default, qcschema_output_default]:
             return qcschema_output_default
         raise ValueError(

--- a/qcelemental/molparse/chgmult.py
+++ b/qcelemental/molparse/chgmult.py
@@ -39,42 +39,42 @@ def _parity_ok(z, c, m):
 
 
 def validate_and_fill_chgmult(
-    zeff,
-    fragment_separators,
+    zeff: np.ndarray,
+    fragment_separators: np.ndarray,
     molecular_charge: Union[float, None],
-    fragment_charges,
+    fragment_charges: Union[List[float], None],
     molecular_multiplicity: Union[int, None],
-    fragment_multiplicities,
+    fragment_multiplicities: Union[List[int], None],
     zero_ghost_fragments: bool = False,
     verbose: int = 1,
 ) -> Dict[str, Any]:
-    """Forms molecular and fragment charge and multiplicity specification
+    r"""Forms molecular and fragment charge and multiplicity specification
     by completing and reconciling information from argument, supplemented
     by physical constraints and sensible defaults.
 
     Parameters
     ----------
-    zeff : ndarray of float
-        (nat,) electron counts for neutral atoms, generally Z nuclear charge.
+    zeff
+        (nat,) electron counts (float) for neutral atoms, generally Z nuclear charge.
         0 indicates ghosts such that a full fragment of 0s will be constained
         to `0 1` charge & multiplicity.
-    fragment_separators : ndarray of int
+    fragment_separators
         (nfr - 1, ) indices splitting `zeff` into nfr fragments.
-    molecular_charge : float or None
+    molecular_charge
         Total charge for molecular system.
-    fragment_charges : list of float or None
+    fragment_charges
         (nfr,) known fragment charges with `None` as placeholder for
         unknown. Expected pre-defaulted so even if nothing known, if
         `fragment_separators` breaks `zeff` into `nfr=2` fragments, input
         value should be ``fragment_charges=[None, None]``.
-    molecular_multiplicity : int or None
+    molecular_multiplicity
         Total multiplicity for molecular system.
-    fragment_multiplicities : list of int or None
+    fragment_multiplicities
         (nfr,) known fragment charges with `None` as placeholder for
         unknown. Expected pre-defaulted so even if nothing known, if
         `fragment_separators` breaks `zeff` into `nfr=2` fragments, input
         value should be ``fragment_multiplicities=[None, None]``.
-    zero_ghost_fragments : bool, optional
+    zero_ghost_fragments
         Fragments composed entirely of ghost atoms (Zeff=0) are required to have
         chgmult `0 1`. When `False`, violations of this will cause a
         ValidationError. When `True`, treat ghost fragments indicated by `zeff` to
@@ -83,7 +83,7 @@ def validate_and_fill_chgmult(
         `molecular_charge` and `molecular_multiplicity` and sets ghost fragments
         to `0 1`, leaving other positions free to readjust. Unused (prefer to set
         up such manipulations outside function call) but works.
-    verbose : int, optional
+    verbose
         Amount of printing.
 
     Returns

--- a/qcelemental/molparse/from_arrays.py
+++ b/qcelemental/molparse/from_arrays.py
@@ -162,42 +162,43 @@ def from_arrays(
     geom_unsettled=None,
     variables=None,
     domain="qm",
-    missing_enabled_return="error",
-    np_out=True,
-    speclabel=True,
-    tooclose=0.1,
+    missing_enabled_return: str = "error",
+    np_out: bool = True,
+    speclabel: bool = True,
+    tooclose: float = 0.1,
     zero_ghost_fragments=False,
-    nonphysical=False,
+    nonphysical: bool = False,
     mtol=1.0e-3,
     copy=True,
     verbose=1,
 ):
-    """Compose a Molecule dict from unvalidated arrays and variables, returning dict.
+    r"""Compose a Molecule dict from unvalidated arrays and variables, returning dict.
 
     See fields of Return molrec below. Required parameters (for QM XYZ)
     are `geom` and one of `elem`, `elez`, `elbl` (`speclabel=True`)
 
     Parameters
     ----------
-    geom : array-like
+    geom : Union[List[List[float]], numpy.ndarray]
         (nat, 3) or (3 * nat, ) ndarray or list o'lists of Cartesian coordinates.
-    fragment_separators : array-like of int, optional
+    fragment_separators : Union[List[int], numpy.ndarray]
         (nfr - 1, ) list of atom indices at which to split `geom` into fragments.
-    elbl : ndarray of str
+    elbl : Union[List[str], numpy.ndarray]
         (nat, ) Label extending `elem` symbol, possibly conveying ghosting, isotope, mass, tagging information.
-    tooclose : float, optional
+    tooclose
         Interatom distance (native `geom` units) nearer than which atoms not allowed.
-    nonphysical : bool, optional
+    nonphysical
         Do allow masses outside an element's natural range to pass validation?
-    speclabel : bool, optional
+    speclabel
         If `True`, interpret `elbl` as potentially full nucleus spec including
         ghosting, isotope, mass, tagging information, e.g., `@13C_mine` or
         `He4@4.01`. If `False`, interpret `elbl` as only the user/tagging
         extension to nucleus label, e.g. `_mine` or `4` in the previous examples.
-    missing_enabled_return : {'minimal', 'none', 'error'}
+    missing_enabled_return
+        {'minimal', 'none', 'error'}
         What to do when an enabled domain is of zero-length? Respectively, return
         a fully valid but empty molrec, return empty dictionary, or throw error.
-    np_out : bool, optional
+    np_out
         When `True`, fields geom, elea, elez, elem, mass, real, elbl will be ndarray.
         Use `False` to get a json-able version.
 

--- a/qcelemental/molparse/from_schema.py
+++ b/qcelemental/molparse/from_schema.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List, Union
 
 import numpy as np
 
@@ -7,16 +7,16 @@ from ..util import provenance_stamp
 from .from_arrays import from_arrays
 
 
-def from_schema(molschema, *, nonphysical: bool = False, verbose: int = 1) -> Dict:
-    """Construct molecule dictionary representation from non-Psi4 schema.
+def from_schema(molschema: Dict, *, nonphysical: bool = False, verbose: int = 1) -> Dict:
+    r"""Construct molecule dictionary representation from non-Psi4 schema.
 
     Parameters
     ----------
-    molschema : dict
+    molschema
         Dictionary form of Molecule following known schema.
-    nonphysical : bool, optional
+    nonphysical
         Do allow masses outside an element's natural range to pass validation?
-    verbose : int, optional
+    verbose
         Amount of printing.
 
     Returns
@@ -96,24 +96,29 @@ def from_schema(molschema, *, nonphysical: bool = False, verbose: int = 1) -> Di
 
 
 def contiguize_from_fragment_pattern(
-    frag_pattern, *, geom=None, verbose: int = 1, throw_reorder: bool = False, **kwargs
+    frag_pattern: List[List[int]],
+    *,
+    geom: Union[np.ndarray, List[List]] = None,
+    verbose: int = 1,
+    throw_reorder: bool = False,
+    **kwargs,
 ):
-    """Take (nat, ?) array-like arrays and return with atoms arranged by (nfr, ?) `frag_pattern`.
+    r"""Take (nat, ?) array-like arrays and return with atoms arranged by (nfr, ?) `frag_pattern`.
 
     Parameters
     ----------
-    frag_pattern : list of lists of ints
+    frag_pattern
         (nfr, ?) list of indices (0-indexed) grouping atoms into
         molecular fragments within the topology.
-    geom : array-like, optional
+    geom
         (nat, 3) or (3 * nat, ) ndarray or list o'lists of Cartesian
         coordinates, possibly with atoms belonging to the same fragment
         being dispersed in `geom`.
-    throw_reorder : bool, optional
+    throw_reorder
         Whether, when non-contiguous fragments detected, to raise
         ValidationError (``True``) or to proceed to reorder atoms to
         contiguize fragments (``False``).
-    verbose : int, optional
+    verbose
         Quantity of printing
     kwargs : None or array-like
         Each additional array will be returned with ordering applied

--- a/qcelemental/molparse/from_string.py
+++ b/qcelemental/molparse/from_string.py
@@ -12,58 +12,61 @@ __all__ = ["from_string"]
 
 
 def from_string(
-    molstr,
-    dtype=None,
+    molstr: str,
+    dtype: str = None,
     *,
-    name=None,
-    fix_com=None,
-    fix_orientation=None,
-    fix_symmetry=None,
-    return_processed=False,
-    enable_qm=True,
-    enable_efp=True,
-    missing_enabled_return_qm="none",
-    missing_enabled_return_efp="none",
+    name: str = None,
+    fix_com: bool = None,
+    fix_orientation: bool = None,
+    fix_symmetry: str = None,
+    return_processed: bool = False,
+    enable_qm: bool = True,
+    enable_efp: bool = True,
+    missing_enabled_return_qm: str = "none",
+    missing_enabled_return_efp: str = "none",
     verbose=1,
 ) -> Union[Dict, Tuple[Dict, Dict]]:
-    """Construct a molecule dictionary from any recognized string format.
+    r"""Construct a molecule dictionary from any recognized string format.
 
     Parameters
     ----------
-    molstr : str
+    molstr
         Multiline string specification of molecule in a recognized format.
-    dtype : {'xyz', 'xyz+', 'psi4', 'psi4+'}, optional
+    dtype
+        {'xyz', 'xyz+', 'psi4', 'psi4+'}
         Molecule format name; see below for details.
-    return_processed : bool, optional
+    return_processed
         Additionally return intermediate dictionary.
-    enable_qm : bool, optional
+    enable_qm
         Consider quantum mechanical domain in processing the string constants
         into the returned molrec.
-    enable_efp: bool, optional
+    enable_efp
         Consider effective fragment potential domain in processing the string
         contents into the returned molrec. Only relevant if `dtype` supports EFP.
-    missing_enabled_return_qm : {'minimal', 'none', 'error'}
+    missing_enabled_return_qm
+        {'minimal', 'none', 'error'}
         If `enable_qm=True`, what to do if it has no atoms/fragments?
         Respectively, return a fully valid but empty molrec, return empty
         dictionary, or throw error.
-    missing_enabled_return_efp : {'minimal', 'none', 'error'}
+    missing_enabled_return_efp
+        {'minimal', 'none', 'error'}
         If `enable_efp=True`, what to do if it has no atoms/fragments?
         Respectively, return a fully valid but empty molrec, return empty
         dictionary, or throw error.
-    name : str, optional
+    name
         Override `molstr` information for label for molecule; should
         be valid Python identifier. One of a very limited number of
         fields (three others follow) for trumping `molstr`. Provided
         for convenience, since the alternative would be collect the
         resulting molrec (discarding the Mol if called from class),
         editing it, then remaking the Mol.
-    fix_com : bool, optional
+    fix_com
         Override `molstr` information for whether translation of `geom`
         is allowed or disallowed.
-    fix_orientation : bool, optional
+    fix_orientation
         Override `molstr` information for whether rotation of `geom`
         is allowed or disallowed.
-    fix_symmetry : str, optional
+    fix_symmetry
         Override `molstr` information for maximal point group symmetry
         which geometry should be treated.
 
@@ -85,7 +88,9 @@ def from_string(
 
     Notes
     -----
-    Several formats are interpretable ::
+    Several formats are interpretable:
+
+    .. code-block:: none
 
         xyz - Strict XYZ format
         -----------------------
@@ -526,7 +531,7 @@ variable = re.compile(
 
 
 def _filter_mints(string, unsettled=False):
-    """Handle extracting fragment, atom, and chg/mult lines from `string`.
+    r"""Handle extracting fragment, atom, and chg/mult lines from `string`.
 
     Returns
     -------
@@ -667,7 +672,7 @@ atom_cartesian = re.compile(
 
 
 def _filter_xyz(string, strict):
-    """Handle extracting atom, units, and chg/mult lines from `string`.
+    r"""Handle extracting atom, units, and chg/mult lines from `string`.
 
     Parameters
     ----------

--- a/qcelemental/molparse/nucleus.py
+++ b/qcelemental/molparse/nucleus.py
@@ -22,40 +22,40 @@ def reconcile_nucleus(
     mtol: float = 1.0e-3,
     verbose: int = 1,
 ) -> Tuple[int, int, str, float, bool, str]:
-    """Forms consistent set of nucleus descriptors from all information
+    r"""Forms consistent set of nucleus descriptors from all information
     from arguments, supplemented by the periodic table. At the least,
     must provide element identity somehow. Defaults to most-abundant
     isotope.
 
     Parameters
     ----------
-    A : int, optional
+    A
         Mass number, number of protons and neutrons.
-    Z : int, optional
+    Z
         Atomic number, number of protons.
-    E : str, optional
+    E
         Element symbol from periodic table.
-    mass : float, optional
+    mass
         Atomic mass [u].
-    real : bool, optional
+    real
         Whether real or ghost/absent.
-    label : str, optional
+    label
         Atom label according to :py:data:`qcelemental.molparse.regex.NUCLEUS`.
-    speclabel : bool, optional
+    speclabel
         If `True`, interpret `label` as potentially full nucleus spec including
         ghosting, isotope, mass, tagging information, e.g., ``@13C_mine`` or
         ``He4@4.01``. If `False`, interpret `label` as only the user/tagging
         extension to nucleus label, e.g. ``_mine`` or ``4`` in the previous examples.
-    nonphysical : bool, optional
+    nonphysical
         When `True`, turns off sanity checking that prevents periodic table
         violations (e.g, light uranium: ``1U@1.007``).
-    mtol : float, optional
+    mtol
         How different `mass` can be from a known nuclide mass and still
         merit the mass number assignment. Note that for elements dominated
         by a single isotope, the default may not be tight enough to
         prevent standard atomic weight (abundance-average of isotopes)
         from being labeled as the dominant isotope for A.
-    verbose : int, optional
+    verbose
         Quantity of printing.
 
     Returns
@@ -345,12 +345,12 @@ def reconcile_nucleus(
     return (A_final, Z_final, E_final, mass_final, real_final, user_final)
 
 
-def parse_nucleus_label(label):
-    """Separate molecule nucleus string into fields.
+def parse_nucleus_label(label: str):
+    r"""Separate molecule nucleus string into fields.
 
     Parameters
     ----------
-    label : str
+    label
         Conveys at least element and ghostedness and possibly isotope, mass, and
         user info in accordance with :py:data:`qcelemental.molparse.regex.NUCLEUS`.
 

--- a/qcelemental/molparse/to_schema.py
+++ b/qcelemental/molparse/to_schema.py
@@ -12,23 +12,24 @@ from .to_string import formula_generator
 def to_schema(
     molrec: Dict[str, Any], dtype: Union[str, int], units: str = "Bohr", *, np_out: bool = False, copy: bool = True
 ) -> Dict[str, Any]:
-    """Translate molparse internal Molecule spec into dictionary from other schemas.
+    r"""Translate molparse internal Molecule spec into dictionary from other schemas.
 
     Parameters
     ----------
-    molrec : dict
+    molrec
         Psi4 json Molecule spec.
-    dtype : {'psi4', 1, 2}
+    dtype
+        {'psi4', 1, 2}
         Molecule schema format.
         ``1`` is https://molssi-qc-schema.readthedocs.io/en/latest/auto_topology.html V1 + #44 + #53
         ``2`` is ``1`` with internal schema_name/version (https://github.com/MolSSI/QCSchema/pull/60)
-    units : {'Bohr', 'Angstrom'}
+    units
+        {'Bohr', 'Angstrom'}
         Units in which to write string. There is not an option to write in
         intrinsic/input units. Some `dtype` may not allow all units.
-    np_out : bool, optional
+    np_out
         When `True`, fields originating from geom, elea, elez, elem, mass, real, elbl will be ndarray.
         Use `False` to get a json-able version.
-    #return_type : {'json', 'yaml'} Serialization format string to return.
 
     Returns
     -------

--- a/qcelemental/molparse/to_string.py
+++ b/qcelemental/molparse/to_string.py
@@ -18,38 +18,38 @@ def to_string(
     prec: int = 12,
     return_data: bool = False,
 ) -> Union[str, Tuple[str, Dict]]:
-    """Format a string representation of QM molecule.
+    r"""Format a string representation of QM molecule.
 
     Parameters
     ----------
-    molrec : Dict
+    molrec
         Psi4 json Molecule spec.
-    dtype : str, {'xyz', 'cfour', 'nwchem', 'molpro', 'orca', 'turbomole',
-                  'qchem'}
+    dtype
+        {'xyz', 'cfour', 'nwchem', 'molpro', 'orca', 'turbomole', 'qchem'}
         Overall string format. Note that it's possible to request variations
         that don't fit the dtype spec so may not be re-readable (e.g., ghost
         and mass in nucleus label with ``'xyz'``).
         'cfour' forces nucleus label, ignoring atom_format, ghost_format
-    units : str, optional
+    units
         Units in which to write string. Usually ``Angstrom`` or ``Bohr``
         but may be any length unit.  There is not an option to write in
         intrinsic/input units. For ``dtype='xyz', units='Bohr'`` where the
         format doesn't have a slot to specify units, "au" is added so that
         readable as ``dtype='xyz+'``.
-    atom_format : str, optional
+    atom_format
         General format is ``'{elem}'``. A format string that may contain fields
         'elea' (-1 will be ''), 'elez', 'elem', 'mass', 'elbl' in any
         arrangement. For example, if a format naturally uses element symbol
         and you want atomic number instead with mass info, too, pass
         ``'{elez}@{mass}'``. See `ghost_format` for handling field 'real'.
-    ghost_format : str, optional
+    ghost_format
         General format is ``'@{elem}'``. Like `atom_format`, but this formatter
         is used when `real=False`. To suppress ghost atoms, use `ghost_format=''`.
-    width : int, optional
+    width
         Field width for formatting coordinate float.
-    prec : int, optional
+    prec
         Number of decimal places for formatting coordinate float.
-    return_data : bool, optional
+    return_data
         Whether to return dictionary with additional info from the molrec that's
         not expressible in the string but may be of interest to the QC program.
         Note that field names are in QCSchema, not molrec, language.
@@ -59,10 +59,10 @@ def to_string(
     str
         String representation of the molecule.
     str, dict
-        When ``return_data=True`, return additionally a dictionary
-            keywords: key, value pairs for processing molecule info into options
-            fields: aspects of ``qcelemental.models.Molecule`` expressed into
-                    string _or_ keywords.
+        When ``return_data=True``, return additionally a dictionary
+
+          * keywords: key, value pairs for processing molecule info into options
+          * fields: aspects of ``qcelemental.models.Molecule`` expressed into string *or* keywords.
 
     """
 

--- a/qcelemental/molutil/align.py
+++ b/qcelemental/molutil/align.py
@@ -1,6 +1,7 @@
 import collections
 import itertools
 import time
+from typing import Union
 
 import numpy as np
 
@@ -31,64 +32,65 @@ def _pseudo_nre(Zhash, geom):
 
 
 def B787(
-    cgeom,
-    rgeom,
-    cuniq,
-    runiq,
-    do_plot=False,
-    verbose=1,
-    atoms_map=False,
-    run_resorting=False,
-    mols_align=False,
-    run_to_completion=False,
-    algorithm="hungarian_uno",
-    uno_cutoff=1.0e-3,
-    run_mirror=False,
+    cgeom: np.ndarray,
+    rgeom: np.ndarray,
+    cuniq: np.ndarray,
+    runiq: np.ndarray,
+    do_plot: bool = False,
+    verbose: int = 1,
+    atoms_map: bool = False,
+    run_resorting: bool = False,
+    mols_align: Union[bool, float] = False,
+    run_to_completion: bool = False,
+    algorithm: str = "hungarian_uno",
+    uno_cutoff: float = 1.0e-3,
+    run_mirror: bool = False,
 ):
-    """Use Kabsch algorithm to find best alignment of geometry `cgeom` onto
+    r"""Use Kabsch algorithm to find best alignment of geometry `cgeom` onto
     `rgeom` while sampling atom mappings restricted by `runiq` and `cuniq`.
 
     Parameters
     ----------
-    rgeom : ndarray of float
+    rgeom
         (nat, 3) array of reference/target/unchanged geometry. Assumed [a0]
         for RMSD purposes.
-    cgeom : ndarray of float
+    cgeom
         (nat, 3) array of concern/changeable geometry. Assumed [a0] for RMSD
         purposes. Must have same nat, units, and atom content as rgeom.
-    runiq : ndarray of str
-        (nat,) array indicating which rows (atoms) in `rgeom` are shuffleable
+    runiq
+        (nat,) array of str indicating which rows (atoms) in `rgeom` are shuffleable
         without changing the molecule. Generally hashes of element symbol and
         mass are used, but could be as simple as ['C', 'H', 'H', 'D', 'H'] for
         monodeuterated methane.
-    cuniq : ndarray of str
-        (nat,) array indicating which rows (atoms) in `cgeom` are shuffleable.
+    cuniq
+        (nat,) array of str indicating which rows (atoms) in `cgeom` are shuffleable.
         See `runiq` for more details. Strings and count in `cuniq` must match
         `runiq`. That is, `sorted(cuniq) == sorted(runiq)`.
-    do_plot : bool, optional
+    do_plot
         Pops up a mpl plot showing before, after, and ref geometries.
-    verbose : int, optional
+    verbose
         Quantity of printing. 0 to silence.
-    atoms_map : bool, optional
+    atoms_map
         Whether atom1 of rgeom already corresponds to atom1 of cgeom and so on.
         If `True`, no resorting will be run, parameters `runiq` and `cuniq`
         may be passed as `None`, and much time will be saved.
-    run_resorting : bool, optional
+    run_resorting
         Run the resorting machinery even if unnecessary because `atoms_map=True`.
-    mols_align : bool or float, optional
+    mols_align
         Whether ref_mol and concern_mol have identical geometries by eye
         (barring orientation or atom mapping) and expected final RMSD = 0.
         If `True`, procedure is truncated when RMSD condition met, saving time.
         If float, convcrit at which search for minimium truncates.
-    run_to_completion : bool, optional
+    run_to_completion
         Run reorderings to completion (past RMSD = 0) even if unnecessary because
         `mols_align=True`. Used to test worst-case timings.
-    algorithm : {'hungarian_uno', 'permutative'}, optional
+    algorithm
+        {'hungarian_uno', 'permutative'}
         When `atoms_map=False`, screening algorithm for plausible atom mappings.
         `permutative` suitable only for small systems.
-    uno_cutoff : float, optional
+    uno_cutoff
         TODO
-    run_mirror : bool, optional
+    run_mirror
         Run alternate geometries potentially allowing best match to `rgeom`
         from mirror image of `cgeom`. Only run if system confirmed to
         be nonsuperimposable upon mirror reflection.
@@ -292,7 +294,7 @@ def B787(
 
 
 def _plausible_atom_orderings(ref, current, rgeom, cgeom, algorithm="hungarian_uno", verbose=1, uno_cutoff=1.0e-3):
-    """
+    r"""
 
     Parameters
     ----------
@@ -430,7 +432,7 @@ def _plausible_atom_orderings(ref, current, rgeom, cgeom, algorithm="hungarian_u
 
 
 def kabsch_align(rgeom, cgeom, weight=None):
-    """Finds optimal translation and rotation to align `cgeom` onto `rgeom` via
+    r"""Finds optimal translation and rotation to align `cgeom` onto `rgeom` via
     Kabsch algorithm by minimizing the norm of the residual, || R - U * C ||.
 
     Parameters
@@ -553,7 +555,7 @@ def kabsch_quaternion(P, Q):
 
 
 def compute_scramble(nat, do_resort=True, do_shift=True, do_rotate=True, deflection=1.0, do_mirror=False):
-    """Generate a random or directed translation, rotation, and atom shuffling.
+    r"""Generate a random or directed translation, rotation, and atom shuffling.
 
     Parameters
     ----------

--- a/qcelemental/molutil/connectivity.py
+++ b/qcelemental/molutil/connectivity.py
@@ -11,7 +11,7 @@ __all__ = ["guess_connectivity"]
 def guess_connectivity(
     symbols: np.ndarray, geometry: np.ndarray, threshold: float = 1.2, default_connectivity: Optional[float] = None
 ) -> List[Union[Tuple[int, int], Tuple[int, int, float]]]:
-    """
+    r"""
     Finds connected atoms based off of a covalent radii metric.
 
     Parameters

--- a/qcelemental/molutil/molecular_formula.py
+++ b/qcelemental/molutil/molecular_formula.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 
 
 def order_molecular_formula(formula: str, order: str = "alphabetical") -> str:
-    """
+    r"""
     Reorders a molecular formula.
 
     Parameters
@@ -37,7 +37,7 @@ def order_molecular_formula(formula: str, order: str = "alphabetical") -> str:
 
 
 def molecular_formula_from_symbols(symbols: List[str], order: str = "alphabetical") -> str:
-    """
+    r"""
     Returns the molecular formula for a list of symbols.
 
     Parameters

--- a/qcelemental/periodic_table.py
+++ b/qcelemental/periodic_table.py
@@ -10,7 +10,7 @@ from .exceptions import NotAnElementError
 
 
 class PeriodicTable:
-    """Nuclear and mass data about chemical elements from NIST.
+    r"""Nuclear and mass data about chemical elements from NIST.
 
     Parameters
     ----------
@@ -18,22 +18,23 @@ class PeriodicTable:
 
     Attributes
     ----------
-    A : list of int
+    A : List[int]
         Mass number, number of protons and neutrons, starting with 0 for dummies.
-    Z : list of int
+    Z : List[int]
         Atomic number, number of protons, starting with 0 for dummies.
-    E : list of str
+    E : List[str]
         Element symbol from periodic table, starting with "X" for dummies. "Fe" capitalization.
-    EA : list of str
+    EA : List[str]
         Nuclide symbol in E + A form, e.g., "Li6".
         List `EA` is a superset of `E`; that is, both "Li6" and "Li" present.
         For hydrogen, "D" and "T" also included.
-    mass : list of :py:class:`decimal.Decimal`
+    mass : List[decimal.Decimal]
         Atomic mass [u].
-        For nuclides (e.g., "Li6"), the reported mass.
-        For stable elements (e.g., "Li"), the mass of the most abundant isotope ("Li7").
-        For unstable elements (e.g., "Pu"), the mass of the longest-lived isotope ("Pu244").
-    name : list of str
+
+          * For nuclides (e.g., "Li6"), the reported mass.
+          * For stable elements (e.g., "Li"), the mass of the most abundant isotope ("Li7").
+          * For unstable elements (e.g., "Pu"), the mass of the longest-lived isotope ("Pu244").
+    name : List[str]
         Element name from periodic table, starting with "Dummy". "Iron" capitalization.
 
     """
@@ -98,22 +99,23 @@ class PeriodicTable:
         return eliso
 
     def to_mass(self, atom: Union[int, str], *, return_decimal: bool = False) -> Union[float, "Decimal"]:
-        """Get atomic mass of `atom`.
+        r"""Get atomic mass of `atom`.
 
         Parameters
         ----------
-        atom : int or str
+        atom
             Identifier for element or nuclide, e.g., `H`, `D`, `H2`, `He`, `hE4`.
-        return_decimal : bool, optional
+        return_decimal
             Whether to preserve significant figures information by returning as Decimal (`True`) or to convert to float (`False`).
 
         Returns
         -------
         decimal.Decimal or float
             Atomic mass [u]. See above for type.
-            If `atom` is nuclide (e.g., "Li6"), the reported mass.
-            If `atom` is stable element (e.g., "Li"), the mass of the most abundant isotope, "Li7".
-            If `atom` is unstable element (e.g., "Pu"), the mass of the longest-lived isotope, "Pu244".
+
+              * If `atom` is nuclide (e.g., "Li6"), the reported mass.
+              * If `atom` is stable element (e.g., "Li"), the mass of the most abundant isotope, "Li7".
+              * If `atom` is unstable element (e.g., "Pu"), the mass of the longest-lived isotope, "Pu244".
 
         Raises
         ------
@@ -130,22 +132,23 @@ class PeriodicTable:
             return float(mass)
 
     def to_A(self, atom: Union[int, str]) -> int:
-        """Get mass number of `atom`.
+        r"""Get mass number of `atom`.
 
         Functions :py:func:`to_A` and :py:func:`to_mass_number` are aliases.
 
         Parameters
         ----------
-        atom : int or str
+        atom
             Identifier for element or nuclide, e.g., `H`, `D`, `H2`, `He`, `hE4`.
 
         Returns
         -------
         int
             Mass number, number of protons and neutrons.
-            If `atom` is nuclide (e.g., "Li6"), the corresponding mass number, 6.
-            If `atom` is stable element (e.g., "Li"), the mass number of the most abundant isotope, 7.
-            If `atom` is unstable element (e.g., "Pu"), the mass number of the longest-lived isotope, 244.
+
+              * If `atom` is nuclide (e.g., "Li6"), the corresponding mass number, 6.
+              * If `atom` is stable element (e.g., "Li"), the mass number of the most abundant isotope, 7.
+              * If `atom` is unstable element (e.g., "Pu"), the mass number of the longest-lived isotope, 244.
 
         Raises
         ------
@@ -157,13 +160,13 @@ class PeriodicTable:
         return self._eliso2a[identifier]
 
     def to_Z(self, atom: Union[int, str], strict: bool = False) -> int:
-        """Get atomic number of `atom`.
+        r"""Get atomic number of `atom`.
 
         Functions :py:func:`to_Z` and :py:func:`to_atomic_number` are aliases.
 
         Parameters
         ----------
-        atom : int or str
+        atom
             Identifier for element or nuclide, e.g., `H`, `D`, `H2`, `He`, `hE4`.
         strict
             Allow only element identification in `atom`, not nuclide.
@@ -184,13 +187,13 @@ class PeriodicTable:
         return self._el2z[self._eliso2el[identifier]]
 
     def to_E(self, atom: Union[int, str], strict: bool = False) -> str:
-        """Get element symbol of `atom`.
+        r"""Get element symbol of `atom`.
 
         Functions :py:func:`to_E` and :py:func:`to_symbol` are aliases.
 
         Parameters
         ----------
-        atom : Union[int, str]
+        atom
             Identifier for element or nuclide, e.g., `H`, `D`, `H2`, `He`, `hE4`.
         strict
             Allow only element identification in `atom`, not nuclide.
@@ -211,13 +214,13 @@ class PeriodicTable:
         return self._eliso2el[identifier]
 
     def to_element(self, atom: Union[int, str], strict: bool = False) -> str:
-        """Get element name of `atom`.
+        r"""Get element name of `atom`.
 
         Functions :py:func:`to_element` and :py:func:`to_name` are aliases.
 
         Parameters
         ----------
-        atom : int or str
+        atom
             Identifier for element or nuclide, e.g., `H`, `D`, `H2`, `He`, `hE4`.
         strict
             Allow only element identification in `atom`, not nuclide.
@@ -243,11 +246,11 @@ class PeriodicTable:
     to_name = to_element
 
     def to_period(self, atom: Union[int, str]) -> int:
-        """Get period (horizontal row in periodic table) of `atom`.
+        r"""Get period (horizontal row in periodic table) of `atom`.
 
         Parameters
         ----------
-        atom : int or str
+        atom
             Identifier for element or nuclide, e.g., `H`, `D`, `H2`, `He`, `hE4`.
 
         Returns
@@ -281,11 +284,11 @@ class PeriodicTable:
             return 8
 
     def to_group(self, atom: Union[int, str]) -> Union[int, None]:
-        """Get group (vertical column in periodic table) of `atom`.
+        r"""Get group (vertical column in periodic table) of `atom`.
 
         Parameters
         ----------
-        atom : int or str
+        atom
             Identifier for element or nuclide, e.g., `H`, `D`, `H2`, `He`, `hE4`.
 
         Returns
@@ -452,11 +455,11 @@ def run_comparison():
 
 
 def write_c_header(filename: str = "masses.h") -> None:
-    """Write C header file defining arrays of mass and element information.
+    r"""Write C header file defining arrays of mass and element information.
 
     Parameters
     ----------
-    filename : str, optional
+    filename
         The filename to write to.
     """
     self = PeriodicTable()

--- a/qcelemental/physical_constants/context.py
+++ b/qcelemental/physical_constants/context.py
@@ -15,11 +15,12 @@ if TYPE_CHECKING:
 
 
 class PhysicalConstantsContext:
-    """CODATA physical constants set from NIST.
+    r"""CODATA physical constants set from NIST.
 
     Parameters
     ----------
-    context : {'CODATA2014', 'CODATA2018'}
+    context : str
+        {'CODATA2014', 'CODATA2018'}
         Origin of loaded data.
 
     Attributes
@@ -28,7 +29,7 @@ class PhysicalConstantsContext:
         The DOI of the current context.
     name : str
         The name of the context ('CODATA2014')
-    pc : dict of Datum
+    pc : Dict[str, Datum]
         Each physical constant is an entry in `pc`, where key is the
         lowercased string of the NIST name (or any alias) and the
         value is a Datum object with `lbl` the exact NIST name string,
@@ -206,7 +207,7 @@ class PhysicalConstantsContext:
 
     @property
     def ureg(self) -> "UnitRegistry":
-        """Returns the internal Pint units registry.
+        r"""Returns the internal Pint units registry.
 
         Returns
         -------
@@ -219,18 +220,18 @@ class PhysicalConstantsContext:
         return self._ureg
 
     def get(self, physical_constant: str, return_tuple: bool = False) -> Union[float, Datum]:
-        """Access a physical constant, `physical_constant`.
+        r"""Access a physical constant, `physical_constant`.
 
         Parameters
         ----------
-        physical_constant : str
+        physical_constant
             Case-insensitive string of physical constant with NIST name.
-        return_tuple : bool, optional
+        return_tuple
             See below.
 
         Returns
         -------
-        Union[float, 'Datum']
+        Union[float, Datum]
             When ``return_tuple=False``, value of physical constant.
             When ``return_tuple=True``, Datum with units, description, uncertainty, and value of physical constant as Decimal.
 
@@ -277,15 +278,15 @@ class PhysicalConstantsContext:
     def conversion_factor(
         self, base_unit: Union[str, "quantity._Quantity"], conv_unit: Union[str, "quantity._Quantity"]
     ) -> float:
-        """Provides the conversion factor from one unit to another.
+        r"""Provides the conversion factor from one unit to another.
 
         The conversion factor is based on the current contexts CODATA.
 
         Parameters
         ----------
-        base_unit : Union[str, 'Quantity']
+        base_unit
             The original units
-        conv_unit : Union[str, 'Quantity']
+        conv_unit
             The units to convert to
 
         Examples
@@ -434,11 +435,11 @@ def run_internal_comparison(old_context: str, new_context: str) -> None:
 
 
 def _get_pi(from_scratch: bool = False) -> "Decimal":
-    """Get pi to 36 digits (or more with mpmath).
+    r"""Get pi to 36 digits (or more with mpmath).
 
     Parameters
     ----------
-    from_scratch : bool, optional
+    from_scratch
         If True, recomputes Pi from mpmath.
 
     Returns

--- a/qcelemental/physical_constants/ureg.py
+++ b/qcelemental/physical_constants/ureg.py
@@ -8,7 +8,7 @@ __all__ = ["build_units_registry"]
 
 
 def build_units_registry(context):
-    """Builds a pint UnitRegistry based on a given PhysicalConstantsContext.
+    r"""Builds a pint UnitRegistry based on a given PhysicalConstantsContext.
 
     Parameters
     ----------
@@ -144,7 +144,7 @@ def build_units_registry(context):
         return None
 
     def build_transformer(right_unit, default):
-        """Builds a transformer that attempts first to use the NIST values exactly and then falls back
+        r"""Builds a transformer that attempts first to use the NIST values exactly and then falls back
         on to canonical Pint tech. The NIST values are not "exact" and will
         fail the triangle rule due to the inherent uncertainties of the values.
 

--- a/qcelemental/testing.py
+++ b/qcelemental/testing.py
@@ -2,7 +2,7 @@ import copy
 import logging
 import pprint
 import sys
-from typing import Callable, Dict, List, Union
+from typing import Callable, Dict, List, Tuple, Union
 
 import numpy as np
 from pydantic import BaseModel
@@ -33,8 +33,8 @@ def tnm() -> str:
 
 
 def compare_values(
-    expected,
-    computed,
+    expected: Union[float, List, np.ndarray],
+    computed: Union[float, List, np.ndarray],
     label: str = None,
     *,
     atol: float = 1.0e-6,
@@ -45,42 +45,44 @@ def compare_values(
     quiet: bool = False,
     return_message: bool = False,
     return_handler: Callable = None,
-) -> bool:
-    """Returns True if two floats or float arrays are element-wise equal within a tolerance.
+) -> Union[bool, Tuple[bool, str]]:
+    r"""Returns True if two floats or float arrays are element-wise equal within a tolerance.
 
     Parameters
     ----------
-    expected : float or float array-like
+    expected
+        float or float array-like
         Reference value against which `computed` is compared.
-    computed : float or float array-like
+    computed
+        float or float array-like
         Input value to compare against `expected`.
-    atol : float, optional
+    atol
         Absolute tolerance (see formula below).
-    label : str, optional
+    label
         Label for passed and error messages. Defaults to calling function name.
-    rtol : float, optional
+    rtol
         Relative tolerance (see formula below). By default set to zero so `atol` dominates.
-    equal_nan : bool, optional
+    equal_nan
         Passed to np.isclose. Compare NaN's as equal.
-    equal_phase : bool, optional
+    equal_phase
         Compare computed *or its opposite* as equal.
-    passnone : bool, optional
+    passnone
         Return True when both expected and computed are None.
-    quiet : bool, optional
+    quiet
         Whether to log the return message.
-    return_message : bool, optional
+    return_message
         Whether to return tuple. See below.
 
     Returns
     -------
     allclose : bool
         Returns True if `expected` and `computed` are equal within tolerance; False otherwise.
-    message : str, optional
+    message : str
         When return_message=True, also return passed or error message.
 
     Other Parameters
     ----------------
-    return_handler : function, optional
+    return_handler
         Function to control printing, logging, raising, and returning.
         Specialized interception for interfacing testing systems.
 
@@ -172,38 +174,44 @@ def compare_values(
 
 
 def compare(
-    expected,
-    computed,
+    expected: Union[int, bool, str, List[int], np.ndarray],
+    computed: Union[int, bool, str, List[int], np.ndarray],
     label: str = None,
     *,
     equal_phase: bool = False,
     quiet: bool = False,
     return_message: bool = False,
     return_handler: Callable = None,
-) -> bool:
-    """Returns True if two integers, strings, booleans, or integer arrays are element-wise equal.
+) -> Union[bool, Tuple[bool, str]]:
+    r"""Returns True if two integers, strings, booleans, or integer arrays are element-wise equal.
 
     Parameters
     ----------
-    expected : int, bool, str or int array-like
+    expected
+        int, bool, str or array-like of same.
         Reference value against which `computed` is compared.
-    computed : int, bool, str or int array-like
+    computed
+        int, bool, str or array-like of same.
         Input value to compare against `expected`.
-    label : str, optional
+    label
         Label for passed and error messages. Defaults to calling function name.
-    equal_phase : bool, optional
+    equal_phase
         Compare computed *or its opposite* as equal.
+    quiet
+        Whether to log the return message.
+    return_message
+        Whether to return tuple. See below.
 
     Returns
     -------
     allclose : bool
         Returns True if `expected` and `computed` are equal; False otherwise.
-    message : str, optional
+    message : str
         When return_message=True, also return passed or error message.
 
     Other Parameters
     ----------------
-    return_handler : function, optional
+    return_handler
         Function to control printing, logging, raising, and returning.
         Specialized interception for interfacing testing systems.
 
@@ -369,34 +377,38 @@ def compare_recursive(
     quiet: bool = False,
     return_message: bool = False,
     return_handler: Callable = None,
-) -> bool:
-    """
+) -> Union[bool, Tuple[bool, str]]:
+    r"""
     Recursively compares nested structures such as dictionaries and lists.
 
     Parameters
     ----------
-    expected : dict
+    expected
         Reference value against which `computed` is compared.
         Dict may be of any depth but should contain Plain Old Data.
-    computed : int, bool, str or int array-like
+    computed
         Input value to compare against `expected`.
         Dict may be of any depth but should contain Plain Old Data.
-    atol : int or float, optional
+    atol
         Absolute tolerance (see formula below).
-    label : str, optional
+    label
         Label for passed and error messages. Defaults to calling function name.
-    rtol : float, optional
+    rtol
         Relative tolerance (see formula below). By default set to zero so `atol` dominates.
-    forgive : list, optional
+    forgive
         Keys in top level which may change between `expected` and `computed` without triggering failure.
-    equal_phase : bool, optional
+    equal_phase
         Compare computed *or its opposite* as equal.
+    quiet
+        Whether to log the return message.
+    return_message
+        Whether to return tuple. See below.
 
     Returns
     -------
     allclose : bool
         Returns True if `expected` and `computed` are equal within tolerance; False otherwise.
-    message : str, optional
+    message : str
         When return_message=True, also return passed or error message.
 
     Notes

--- a/qcelemental/util/gph_uno_bipartite.py
+++ b/qcelemental/util/gph_uno_bipartite.py
@@ -32,7 +32,7 @@ import numpy as np
 
 
 def _formDirected(g, match):
-    """Form directed graph D from G and matching M.
+    r"""Form directed graph D from G and matching M.
 
     Parameters
     ----------
@@ -71,7 +71,7 @@ def _formDirected(g, match):
 
 
 def _enumMaximumMatching(g, starter_match=None):
-    """Find all maximum matchings in an undirected bipartite graph `g`.
+    r"""Find all maximum matchings in an undirected bipartite graph `g`.
 
     Parameters
     ----------
@@ -117,7 +117,7 @@ def _enumMaximumMatching(g, starter_match=None):
 
 
 def _enumMaximumMatchingIter(g, match, all_matches, add_e=None):
-    """Recurively search maximum matchings.
+    r"""Recurively search maximum matchings.
 
     Parameters
     ----------
@@ -274,7 +274,7 @@ def _enumMaximumMatchingIter(g, match, all_matches, add_e=None):
 
 
 def _enumMaximumMatching2(g):
-    """Find all maximum matchings in an undirected bipartite graph `g`.
+    r"""Find all maximum matchings in an undirected bipartite graph `g`.
     Similar to _enumMaximumMatching but implemented using adjacency matrix
     of graph for slight speed boost.
 
@@ -334,7 +334,7 @@ def _enumMaximumMatching2(g):
 
 
 def _enumMaximumMatchingIter2(adj, matchadj, all_matches, n1, add_e=None, check_cycle=True):
-    """Recurively search maximum matchings.
+    r"""Recurively search maximum matchings.
        Similar to _enumMaximumMatching but implemented using adjacency matrix
        of graph for a slight speed boost.
 

--- a/qcelemental/util/importing.py
+++ b/qcelemental/util/importing.py
@@ -13,7 +13,7 @@ def which_import(
     package: str = None,
     namespace_ok: bool = False,
 ) -> Union[bool, None, str, List[str]]:
-    """Tests to see if a Python module is available.
+    r"""Tests to see if a Python module is available.
 
     Returns
     -------
@@ -62,7 +62,7 @@ def which_import(
 def which(
     command: str, *, return_bool: bool = False, raise_error: bool = False, raise_msg: str = None, env: str = None
 ) -> Union[bool, None, str]:
-    """Test to see if a command is available.
+    r"""Test to see if a command is available.
 
     Returns
     -------

--- a/qcelemental/util/misc.py
+++ b/qcelemental/util/misc.py
@@ -93,7 +93,7 @@ def filter_comments(string: str) -> str:
 
 
 def unnp(dicary: Dict, _path=None, *, flat: bool = False) -> Dict:
-    """Return `dicary` with any ndarray values replaced by lists.
+    r"""Return `dicary` with any ndarray values replaced by lists.
 
     Parameters
     ----------
@@ -184,7 +184,7 @@ def measure_coordinates(coordinates, measurements, degrees=False):
 
 
 def compute_distance(points1, points2) -> np.ndarray:
-    """
+    r"""
     Computes the distance between the provided points on a per-row basis.
 
     Parameters
@@ -217,7 +217,7 @@ def compute_distance(points1, points2) -> np.ndarray:
 
 
 def compute_angle(points1, points2, points3, *, degrees: bool = False) -> np.ndarray:
-    """
+    r"""
     Computes the angle (p1, p2 [vertex], p3) between the provided points on a per-row basis.
 
     Parameters
@@ -260,7 +260,7 @@ def compute_angle(points1, points2, points3, *, degrees: bool = False) -> np.nda
 
 
 def compute_dihedral(points1, points2, points3, points4, *, degrees: bool = False) -> np.ndarray:
-    """
+    r"""
     Computes the dihedral angle (p1, p2, p3, p4) between the provided points on a per-row basis using the Praxeolitic formula.
 
     Parameters

--- a/qcelemental/util/np_blockwise.py
+++ b/qcelemental/util/np_blockwise.py
@@ -27,7 +27,7 @@ def blockwise_contract(arr):
 
 
 def blockwise_expand(a, blockshape, aslist=False, require_aligned_blocks=True):
-    """
+    r"""
     Return a 2N-D view of the given N-D array, rearranged so each ND block (tile)
     of the original array is indexed by its block address using the first N
     indexes of the output array.

--- a/qcelemental/util/np_rand3drot.py
+++ b/qcelemental/util/np_rand3drot.py
@@ -2,7 +2,7 @@ import numpy as np
 
 
 def random_rotation_matrix(deflection: float = 1.0, randnums=None) -> np.ndarray:
-    """Generates a random 3D rotation matrix.
+    r"""Generates a random 3D rotation matrix.
 
     Parameters
     ----------

--- a/qcelemental/util/scipy_hungarian.py
+++ b/qcelemental/util/scipy_hungarian.py
@@ -17,7 +17,7 @@ import numpy as np
 
 
 def linear_sum_assignment(cost_matrix, return_cost=False):
-    """Solve the linear sum assignment problem.
+    r"""Solve the linear sum assignment problem.
 
     The linear sum assignment problem is also known as minimum weight matching
     in bipartite graphs. A problem instance is described by a matrix C, where
@@ -133,7 +133,7 @@ def linear_sum_assignment(cost_matrix, return_cost=False):
 
 
 class _Hungary(object):
-    """State of the Hungarian algorithm.
+    r"""State of the Hungarian algorithm.
 
     Parameters
     ----------

--- a/qcelemental/util/serialization.py
+++ b/qcelemental/util/serialization.py
@@ -17,7 +17,7 @@ _msgpack_which_msg = "Please install via `conda install msgpack-python`."
 
 
 def msgpackext_encode(obj: Any) -> Any:
-    """
+    r"""
     Encodes an object using pydantic and NumPy array serialization techniques suitable for msgpack.
 
     Parameters
@@ -52,7 +52,7 @@ def msgpackext_encode(obj: Any) -> Any:
 
 
 def msgpackext_decode(obj: Any) -> Any:
-    """
+    r"""
     Decodes a msgpack objects from a dictionary representation.
 
     Parameters
@@ -77,7 +77,7 @@ def msgpackext_decode(obj: Any) -> Any:
 
 
 def msgpackext_dumps(data: Any) -> bytes:
-    """Safe serialization of a Python object to msgpack binary representation using all known encoders.
+    r"""Safe serialization of a Python object to msgpack binary representation using all known encoders.
     For NumPy, encodes a specialized object format to encode all shape and type data.
 
     Parameters
@@ -96,7 +96,7 @@ def msgpackext_dumps(data: Any) -> bytes:
 
 
 def msgpackext_loads(data: bytes) -> Any:
-    """Deserializes a msgpack byte representation of known objects into those objects.
+    r"""Deserializes a msgpack byte representation of known objects into those objects.
 
     Parameters
     ----------
@@ -150,7 +150,7 @@ def jsonext_decode(obj: Any) -> Any:
 
 
 def jsonext_dumps(data: Any) -> str:
-    """Safe serialization of Python objects to JSON string representation using all known encoders.
+    r"""Safe serialization of Python objects to JSON string representation using all known encoders.
     The JSON serializer uses a custom array syntax rather than flat JSON lists.
 
     Parameters
@@ -168,7 +168,7 @@ def jsonext_dumps(data: Any) -> str:
 
 
 def jsonext_loads(data: Union[str, bytes]) -> Any:
-    """Deserializes a json representation of known objects into those objects.
+    r"""Deserializes a json representation of known objects into those objects.
 
     Parameters
     ----------
@@ -204,7 +204,7 @@ class JSONArrayEncoder(json.JSONEncoder):
 
 
 def json_dumps(data: Any) -> str:
-    """Safe serialization of a Python dictionary to JSON string representation using all known encoders.
+    r"""Safe serialization of a Python dictionary to JSON string representation using all known encoders.
 
     Parameters
     ----------
@@ -221,7 +221,7 @@ def json_dumps(data: Any) -> str:
 
 
 def json_loads(data: str) -> Any:
-    """Deserializes a json representation of known objects into those objects.
+    r"""Deserializes a json representation of known objects into those objects.
 
     Parameters
     ----------
@@ -242,7 +242,7 @@ def json_loads(data: str) -> Any:
 
 
 def serialize(data: Any, encoding: str) -> Union[str, bytes]:
-    """Encoding Python objects using the provided encoder.
+    r"""Encoding Python objects using the provided encoder.
 
     Parameters
     ----------
@@ -268,7 +268,7 @@ def serialize(data: Any, encoding: str) -> Union[str, bytes]:
 
 
 def deserialize(blob: Union[str, bytes], encoding: str) -> Any:
-    """Encoding Python objects using .
+    r"""Encoding Python objects using .
 
     Parameters
     ----------

--- a/qcelemental/vanderwaals_radii.py
+++ b/qcelemental/vanderwaals_radii.py
@@ -12,16 +12,17 @@ from .periodic_table import periodictable
 
 
 class VanderWaalsRadii:
-    """Van der Waals radii sets.
+    r"""Van der Waals radii sets.
 
     Parameters
     ----------
-    context : {'MANTINA2009'}
+    context : str
+        {'MANTINA2009'}
         Origin of loaded data.
 
     Attributes
     ----------
-    vdwr : dict of Datum
+    vdwr : Dict[str, Datum]
         Each van der Waals radius is an entry in `vdwr`, where key is the
         "Fe"-cased element symbol if generic or symbol-prefixed label
         if specialized within element. The value is a Datum object with
@@ -61,17 +62,17 @@ class VanderWaalsRadii:
     def get(
         self, atom: Union[int, str], *, return_tuple: bool = False, units: str = "bohr", missing: float = None
     ) -> Union[float, "Datum"]:  # lgtm [py/similar-function]
-        """
+        r"""
         Access a van der Waals radius for species ``atom``.
 
         Parameters
         ----------
-        atom : int or str
+        atom
             Identifier for element or nuclide, e.g., ``H``, ``C``, ``Al``.
-        units : str, optional
+        units
             Units of returned value. To return in native unit (MANTINA2009: angstrom), pass it explicitly.
             Only relevant for ``return_tuple=False`` since ``True`` returns underlying data structure with native units.
-        missing : float or None, optional
+        missing
             How to handle when ``atom`` is valid but outside the available data range. When ``None``, raises DataUnavailableError.
             When a float, returns that float, so supply in ``units`` units. Supplying a float is a more compact assurance
             that a call will work over all the periodic table than the equivalent
@@ -84,7 +85,7 @@ class VanderWaalsRadii:
                     rad = 4.0
 
             Only relevant for ``return_tuple=False``.
-        return_tuple : bool, optional
+        return_tuple
             See below.
 
         Returns
@@ -129,13 +130,13 @@ class VanderWaalsRadii:
         return print_variables(self.vdwr)
 
     def write_c_header(self, filename: str = "vdwrad.h", missing: float = 2.0) -> None:  # lgtm [py/similar-function]
-        """Write C header file defining Van der Waals radii array.
+        r"""Write C header file defining Van der Waals radii array.
 
         Parameters
         ----------
-        filename : str, optional
+        filename
             File name for header. Note that changing this won't change the header guard.
-        missing : float, optional
+        missing
             In order that the C array be atomic-number indexable and that it span the
             periodic table, this value is used anywhere data is missing.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Edits to the docstrings to obtain a clean docs build for Psi4, which references several objects. Add typehint extension to QCEl Sphinx docs, so remove many of the duplicate typehints in docstrings.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
