### PR TITLE
fixing search path construction

### DIFF
--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -9,6 +9,7 @@ dependencies:
   - python
   - pint>=0.10.0
   - pydantic>=1.5.0,!=1.6.0,!=1.8.0
+  - dataclasses 
 
     # Optional depends
   - msgpack-python

--- a/qcelemental/util/importing.py
+++ b/qcelemental/util/importing.py
@@ -79,7 +79,7 @@ def which(
 
     """
     if env is None:
-        lenv = {"PATH": os.environ.get("PATH", "") + os.pathsep + os.path.dirname(sys.executable)}
+        lenv = {"PATH": os.pathsep + os.environ.get("PATH", "") + os.pathsep + os.path.dirname(sys.executable)}
     else:
         lenv = {"PATH": os.pathsep.join([os.path.abspath(x) for x in env.split(os.pathsep) if x != ""])}
     lenv = {k: v for k, v in lenv.items() if v is not None}

--- a/qcelemental/util/importing.py
+++ b/qcelemental/util/importing.py
@@ -79,7 +79,7 @@ def which(
 
     """
     if env is None:
-        lenv = {"PATH": os.pathsep + os.environ.get("PATH", "") + os.path.dirname(sys.executable)}
+        lenv = {"PATH": os.environ.get("PATH", "") + os.pathsep + os.path.dirname(sys.executable)}
     else:
         lenv = {"PATH": os.pathsep.join([os.path.abspath(x) for x in env.split(os.pathsep) if x != ""])}
     lenv = {k: v for k, v in lenv.items() if v is not None}


### PR DESCRIPTION
## Description
When constructing the search path for executables, the string concatenation prepends the pathseparator and append the python executable path to the original search path. Both should be appended. In consequence, the last path in `$PATH` becomes invalid at the moment (and in my case fails to find `define` from turbomole as this is the last directory in my `$PATH`). This PR fixes the construction of the path.

## Changelog description
fixes invalid last entry in search path construnction

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [x] Ready to go
