### PR TITLE
rel diff in array compare, symm in gamess str, more digits in Mol ctor

### DIFF
--- a/qcelemental/models/align.py
+++ b/qcelemental/models/align.py
@@ -99,11 +99,10 @@ class AlignmentMill(ProtoModel):
     def align_gradient(self, grad) -> Array:
         """suitable for vector system attached to atoms"""
 
-        # sensible? TODO
-        # algrad = np.copy(grad)
-        # if self.mirror:
-        #    algrad[:, 1] *= -1
-        algrad = grad.dot(self.rotation)
+        algrad = np.copy(grad)
+        if self.mirror:
+            algrad[:, 1] *= -1.0
+        algrad = algrad.dot(self.rotation)
         algrad = algrad[self.atommap]
 
         return algrad

--- a/qcelemental/testing.py
+++ b/qcelemental/testing.py
@@ -166,7 +166,11 @@ def compare_values(
             diff[isclose] = 0.0
             diff_str = np.array_str(diff, max_line_width=120, precision=12, suppress_small=False)
             diff_str = "\n".join("    " + ln for ln in diff_str.splitlines())
-            digits_str += f" (o-e: RMS {_rms(cptd) - _rms(xptd):.1e}, MAX {np.amax(np.absolute(diff)):.1e})"
+            with np.errstate(divide="ignore", invalid="ignore"):
+                diffrel = np.divide(diff, xptd)
+            np.nan_to_num(diffrel, copy=False)
+            diffraw = cptd - xptd
+            digits_str += f" (o-e: RMS {_rms(diffraw):.1e}, MAX {np.amax(np.absolute(diffraw)):.1e}, RMAX {np.amax(np.absolute(diffrel)):.1e})"
             message = """\t{}: computed value does not match {}.\n  Expected:\n{}\n  Observed:\n{}\n  Difference (passed elements are zeroed):\n{}\n""".format(
                 label, digits_str, xptd_str, cptd_str, diff_str
             )

--- a/qcelemental/tests/test_testing.py
+++ b/qcelemental/tests/test_testing.py
@@ -79,7 +79,7 @@ _pass_message = "\t{:.<66}PASSED"
             False,
             (
                 None,
-                """test_compare_values: computed value does not match to atol=0.1 (o-e: RMS -1.2e-02, MAX 6.0e+00).
+                """test_compare_values: computed value does not match to atol=0.1 (o-e: RMS 3.7e+00, MAX 6.0e+00, RMAX 2.0e+00).
   Expected:
     [0. 1. 2. 3.]
   Observed:
@@ -104,7 +104,7 @@ _pass_message = "\t{:.<66}PASSED"
             False,
             (
                 None,
-                """test_compare_values: computed value does not match to atol=0.01 (o-e: RMS 1.2e-02, MAX 2.0e-02).
+                """test_compare_values: computed value does not match to atol=0.01 (o-e: RMS 1.4e-02, MAX 2.0e-02, RMAX 2.0e-02).
   Expected:
     [0. 1. 2. 3.]
   Observed:
@@ -122,7 +122,7 @@ _pass_message = "\t{:.<66}PASSED"
             False,
             (
                 None,
-                """test_compare_values: computed value does not match to atol=0.01 (o-e: RMS 1.2e-02, MAX 2.0e-02).
+                """test_compare_values: computed value does not match to atol=0.01 (o-e: RMS 1.4e-02, MAX 2.0e-02, RMAX 2.0e-02).
   Expected:
     [[0. 1.]
      [2. 3.]]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Changelog description
- [x] Molecule learned to create instances with geometry rounded to other than 8 decimal places through `Molecule(..., geometry_noise=<13>)` to optionally override `qcel.models.molecule.GEOMETRY_NOISE = 8`. This should be used sparingly, as it will make more molecules unique in the QCA database. But it is sometimes necessary for accurate finite difference steps and to preserve intrinsic symmetry upon geometry rotation. Previous route was to reset the qcel module variable for the duration of instance creation.
- [x] `Molecule.align` and `Molecule.scramble` learned to return a fuller copy of `self` than previously. Now has aligned `atom_labels`, `real`, and `mass_numbers` as well as incidentals like `Identifiers`. Fragmentation still not addressed.
- [x] `Molecule.to_string(dtype="gamess")` learned to write symmetry information to the prinaxis output if passed in through field `fix_symmetry`. This is provisional, as we'd like the field to be uniform across qcprogs.
- [x] `compare_values` on arrays corrected the RMS maximum o-e value displayed and added a relative value.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
