### PR TITLE
add return_gradient property

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,25 @@ Changelog
 .. +++++++++
 
 
+0.22.0 / 2021-MM-DD
+-------------------
+ 
+New Features
+++++++++++++
+- (:pr:`268`) Add models for TorsionDrive procedures. @SimonBoothroyd
+- (:pr:`272`) Add SCF and return gradient and Hessian fields to ``AtomicResultProperties``.
+
+Enhancements
+++++++++++++
+- (:pr:`271`) ``Molecule`` learned to create instances with geometry rounded to other than 8 decimal places through ``Molecule(..., geometry_n
+- (:pr:`271`) ``Molecule.align`` and ``Molecule.scramble`` learned to return a fuller copy of self than previously. Now has aligned atom_label
+- (:pr:`271`) ``Molecule.to_string(dtype="gamess")`` learned to write symmetry information to the prinaxis output if passed in through field f
+
+Bug Fixes
++++++++++
+- (:pr:`271`) Testing function ``compare_values()`` on arrays corrected the RMS maximum o-e value displayed and added a relative value.
+
+
 0.21.0 / 2021-06-30
 -------------------
 

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -412,6 +412,20 @@ def test_result_properties_array(request):
     assert obj.dict()["scf_quadrupole_moment"] == lquad
 
 
+def test_result_derivatives_array(request):
+    nat = 4
+    lgrad = list(range(nat * 3))
+    lhess = list(range(nat * nat * 9))
+
+    obj = qcel.models.AtomicResultProperties(calcinfo_natom=nat, return_gradient=lgrad, scf_total_hessian=lhess)
+    drop_qcsk(obj, request.node.name)
+
+    assert obj.calcinfo_natom == 4
+    assert obj.return_gradient.shape == (4, 3)
+    assert obj.scf_total_hessian.shape == (12, 12)
+    assert obj.dict().keys() == {"calcinfo_natom", "return_gradient", "scf_total_hessian"}
+
+
 @pytest.mark.parametrize(
     "smodel", ["molecule", "atomicresultproperties", "atomicinput", "atomicresult", "optimizationresult"]
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
When one runs a driver=energy, the energy is available through the return and the `atres.properties["return_energy"]`. For driver=gradient, the gradient is returned and the corresponding energy is still available in properties but not the grad. For driver=hessian, there's no place at all for the gradient if available. This rounds out the return fields in properties. There was discussion of this at some point, but I can't find it in qcsk, qcel, or qcng repos.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
