### PR TITLE
better molecule-from-string error message

### DIFF
--- a/qcelemental/molparse/from_string.py
+++ b/qcelemental/molparse/from_string.py
@@ -259,7 +259,7 @@ def from_string(
                         if len(str(e)) < min_error_length:
                             min_error_length = len(str(e))
                             min_error = e
-                        raise(e)
+                        raise e
     else:
         raise KeyError(f"Molecule: dtype of `{dtype}` not recognized.")
 

--- a/qcelemental/molparse/from_string.py
+++ b/qcelemental/molparse/from_string.py
@@ -259,7 +259,7 @@ def from_string(
                         if len(str(e)) < min_error_length:
                             min_error_length = len(str(e))
                             min_error = e
-                        raise e
+                        raise min_error
     else:
         raise KeyError(f"Molecule: dtype of `{dtype}` not recognized.")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
See psi4/psi4#2287 . When there's a syntax error in a mol string, and it can't be matched in any format/dtype (psi4, xyz, etc.), presently the last error that gets raised includes the whole molecule string. This isn't helpful when one dtype might have _nearly_ matched it, so now the code stores the shortest error and re-raises that.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
