### PR TITLE
protocol for retaining DSL files

### DIFF
--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -618,7 +618,7 @@ class AtomicResult(AtomicInput):
         description="The primary logging output of the program, whether natively standard output or a file. Presence vs. absence (or null-ness?) configurable by protocol.",
     )
     stderr: Optional[str] = Field(None, description="The standard error of the program execution.")
-    native_files: Optional[Dict[str, str]] = Field(None, description="DSL files.")
+    native_files: Optional[Dict[str, Optional[str]]] = Field(None, description="DSL files.")
 
     success: bool = Field(..., description="The success of program execution. If False, other fields may be blank.")
     error: Optional[ComputeError] = Field(None, description=str(ComputeError.__base_doc__))
@@ -739,7 +739,10 @@ class AtomicResult(AtomicInput):
             return None
         elif ancp == "input":
             return_keep = ["input"]
-            files = value.copy()
+            if value is None:
+                files = {}
+            else:
+                files = value.copy()
         else:
             raise ValueError(f"Protocol `native_files:{ancp}` is not understood")
 

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -544,7 +544,7 @@ class AtomicResultProtocols(ProtoModel):
         default_factory=ErrorCorrectionProtocol, description="Policies for error correction"
     )
     native_files: NativeFilesProtocolEnum = Field(
-        default_factory=NativeFilesProtocolEnum.none,
+        NativeFilesProtocolEnum.none,
         description="Policies for keeping processed files from the computation",
     )
 

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -618,6 +618,7 @@ class AtomicResult(AtomicInput):
         description="The primary logging output of the program, whether natively standard output or a file. Presence vs. absence (or null-ness?) configurable by protocol.",
     )
     stderr: Optional[str] = Field(None, description="The standard error of the program execution.")
+    native_files: Optional[Dict[str, str]] = Field(None, description="DSL files.")
 
     success: bool = Field(..., description="The success of program execution. If False, other fields may be blank.")
     error: Optional[ComputeError] = Field(None, description=str(ComputeError.__base_doc__))

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -618,7 +618,7 @@ class AtomicResult(AtomicInput):
         description="The primary logging output of the program, whether natively standard output or a file. Presence vs. absence (or null-ness?) configurable by protocol.",
     )
     stderr: Optional[str] = Field(None, description="The standard error of the program execution.")
-    native_files: Optional[Dict[str, Optional[str]]] = Field(None, description="DSL files.")
+    native_files: Optional[Dict[str, Any]] = Field(None, description="DSL files.")
 
     success: bool = Field(..., description="The success of program execution. If False, other fields may be blank.")
     error: Optional[ComputeError] = Field(None, description=str(ComputeError.__base_doc__))

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -342,6 +342,7 @@ def test_wavefunction_protocols(protocol, restricted, provided, expected, wavefu
         expected_keys = set(expected) | {"scf_" + x for x in expected} | {"basis", "restricted"}
         assert wfn.wavefunction.dict().keys() == expected_keys
 
+
 @pytest.mark.parametrize(
     "protocol, provided, expected",
     [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
So the usual qcng philosophy is to collect stdout and any useful output files from a run (e.g., cfour's `GRD` and gamess's dat file) and process them (perhaps even rotating coordinates) into `AtomicResult` fields, then ditch the files. Whether stdout gets returned depends on the `protocols.stdout` and the files are dropped (except that I sometimes stash them in extras). However, folks like to see their files, esp. since they may be far more familiar with native file formats than with QCSchema format. Since we're more of a bring-everything-back rather than inspect-the-scratch-dir shop, it might be nice to let files be seen. Even if you're willing to abandon all output files, I'll throw in that the whole harness-composed input for a gamess run _is not available_ from the stdout, nor can it be forcibly made to be, so adding it to the AtomicResult is almost necessary to fully replicate the job.

Standard way to influence the layout of a model is with a protocol, so here's an untested proposition. Ideas for naming the field include "ancillary", "dsl", "native", "stdfiles". Thoughts on this?

ADDED: "vulgate", "vernacular", "auxilliary"

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
