### PR TITLE
try pushing docs only from master

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,6 +106,7 @@ jobs:
         make html
     - name: GitHub Pages Deploy
       uses: JamesIves/github-pages-deploy-action@4.1.1
+      if: github.event_name == 'push' && github.repository == 'MolSSI/QCElemental' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/master' )
       with:
         branch: gh-pages
         folder: docs/build/html


### PR DESCRIPTION
Either because PR author doesn't have permissions to write to `gh-pages` branch or because we don't want unmerged changes becoming part of master docs, turn off fork docs-pushing.