### PR TITLE
collect qcschema samples

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: QCSchema Examples Deploy
       uses: JamesIves/github-pages-deploy-action@4.1.1
-      if: github.event_name == 'push' && github.repository == 'MolSSI/QCElemental' && ( startsWith( github.ref, 'refs/tags/' ) || github.re
+      if: github.event_name == 'push' && github.repository == 'MolSSI/QCElemental' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/master' )
       with:
         branch: qcschema-examples
         folder: qcelemental/tests/qcschema_instances

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,8 +66,7 @@ jobs:
 
     - name: QCSchema Examples Deploy
       uses: JamesIves/github-pages-deploy-action@4.1.1
-      if: matrix.cfg.label == 'full'
-      # if: github.event_name == 'push' && github.repository == 'MolSSI/QCElemental' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/master' )
+      if: matrix.cfg.label == 'full' && github.event_name == 'push' && github.repository == 'MolSSI/QCElemental' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/master' )
       with:
         branch: qcschema-examples
         folder: qcelemental/tests/qcschema_instances

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,6 +64,13 @@ jobs:
         eval "$(conda shell.bash hook)" && conda activate test
         pytest -rws -v --color=yes --validate qcelemental/
 
+    - name: QCSchema Examples Deploy
+      uses: JamesIves/github-pages-deploy-action@4.1.1
+      if: github.event_name == 'push' && github.repository == 'MolSSI/QCElemental' && ( startsWith( github.ref, 'refs/tags/' ) || github.re
+      with:
+        branch: qcschema-examples
+        folder: qcelemental/tests/qcschema_instances
+
     - name: CodeCov  
       uses: codecov/codecov-action@v1
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,7 +66,8 @@ jobs:
 
     - name: QCSchema Examples Deploy
       uses: JamesIves/github-pages-deploy-action@4.1.1
-      if: github.event_name == 'push' && github.repository == 'MolSSI/QCElemental' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/master' )
+      if: matrix.cfg.label == 'full'
+      # if: github.event_name == 'push' && github.repository == 'MolSSI/QCElemental' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/master' )
       with:
         branch: qcschema-examples
         folder: qcelemental/tests/qcschema_instances

--- a/qcelemental/tests/addons.py
+++ b/qcelemental/tests/addons.py
@@ -68,8 +68,10 @@ def drop_qcsk(instance, tnm: str, schema_name: str = None):
 
     with open(drop, "w") as fp:
         if isinstance(instance, qcelemental.models.ProtoModel):
-            fp.write(instance.json(exclude_unset=True, exclude_none=True))
+            # fp.write(instance.json(exclude_unset=True, exclude_none=True))  # works but file is one-line
+            instance = json.loads(instance.json(exclude_unset=True, exclude_none=True))
         elif isinstance(instance, dict):
-            json.dump(instance, fp, sort_keys=True, indent=2)
+            pass
         else:
             raise TypeError
+        json.dump(instance, fp, sort_keys=True, indent=2)


### PR DESCRIPTION
## Description
People often like to see examples of QCSchema. The qcel test suite already caters to this by writing selected model instances to files. This PR publishes those files to a branch so they can be browsed: https://github.com/MolSSI/QCElemental/tree/qcschema-examples . At some point, we may want to filter out the provenance.version so that every file doesn't change every time.

@bennybp has verbally approved this PR.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
