### PR TITLE
Add t-amplitude driver to DriverEnum

### DIFF
--- a/qcelemental/models/common_models.py
+++ b/qcelemental/models/common_models.py
@@ -57,6 +57,7 @@ class Model(ProtoModel):
 class DriverEnum(str, Enum):
     """Allowed computation driver values."""
 
+    tamps = "tamps"
     energy = "energy"
     gradient = "gradient"
     hessian = "hessian"

--- a/qcelemental/models/procedures.py
+++ b/qcelemental/models/procedures.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-from pydantic import Field, constr, validator, conlist
+from pydantic import Field, conlist, constr, validator
 
 from ..util import provenance_stamp
 from .basemodels import ProtoModel


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
The goal of this pull request is to add a driver to obtain the t-amplitude tensor from a wavefunction. Most of the code for this is found in [https://github.com/psi4/psi4/pull/2328](https://github.com/psi4/psi4/pull/2328).

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Added "tamps" driver to obtain the T-amplitudes from MP2 and CCSD.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
