### PR TITLE
Use empty dictionary for empty native_files to maintain consistency w…

### DIFF
--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -620,7 +620,7 @@ class AtomicResult(AtomicInput):
         description="The primary logging output of the program, whether natively standard output or a file. Presence vs. absence (or null-ness?) configurable by protocol.",
     )
     stderr: Optional[str] = Field(None, description="The standard error of the program execution.")
-    native_files: Optional[Dict[str, Any]] = Field(None, description="DSL files.")
+    native_files: Dict[str, Any] = Field({}, description="DSL files.")
 
     success: bool = Field(..., description="The success of program execution. If False, other fields may be blank.")
     error: Optional[ComputeError] = Field(None, description=str(ComputeError.__base_doc__))
@@ -738,7 +738,7 @@ class AtomicResult(AtomicInput):
         if ancp == "all":
             return value
         elif ancp == "none":
-            return None
+            return {}
         elif ancp == "input":
             return_keep = ["input"]
             if value is None:

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -371,7 +371,7 @@ def test_native_protocols(protocol, provided, expected, native_data_fixture, req
     drop_qcsk(wfn, request.node.name)
 
     if len(expected) == 0:
-        assert wfn.native_files is None
+        assert isinstance(wfn.native_files, dict)
     else:
         expected_keys = set(expected)
         assert wfn.native_files.keys() == expected_keys

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -371,7 +371,7 @@ def test_native_protocols(protocol, provided, expected, native_data_fixture, req
     drop_qcsk(wfn, request.node.name)
 
     if len(expected) == 0:
-        assert isinstance(wfn.native_files, dict)
+        assert wfn.native_files == {}
     else:
         expected_keys = set(expected)
         assert wfn.native_files.keys() == expected_keys


### PR DESCRIPTION
…ith keywords, extras and other dict objects in models

<!-- Thank you for your contribution! -->

## Description
`QCElemental's` default behavior has been to include empty dictionaries for `dict` objects on `AtomicInput/AtomicResult` objects. This default allows for nice behavior like checking for the presence of keys of interest with the usual code without having to first check that `keywords` or `extras` is not `None`:

```python
if my_atomic_input.keywords.get('mykey'):
    # do something

if my_atomic_input.extras.get('mykey'):
    # do something
```

The `native_files` field deviates from this standard and requires additional checks to access its fields:
```python
if my_atomic_result.native_files:
    if my_atomic_result.native_files.get("mykey")
        # do something
```
I propose the previous standard be maintained as I think it makes working with the objects cleaner and more consistent :)

## Changelog description
Use empty dictionary for empty `native_files` to maintain consistency with `keywords`, `extras` and other dict objects in models

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ x] Code base linted
- [ x] Ready to go

@bennybp lemme know if you have any thoughts :)