### PR TITLE
fix circular import in docs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:
@@ -16,7 +20,7 @@ jobs:
             python-version: 3.6
             label: minpy
           - conda-env: base-cf
-            python-version: 3.9
+            python-version: 3.10
             label: full
     env:
       PYVER: ${{ matrix.cfg.python-version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
             python-version: 3.6
             label: minpy
           - conda-env: base-cf
-            python-version: 3.10
+            python-version: "3.10"
             label: full
     env:
       PYVER: ${{ matrix.cfg.python-version }}

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -1,6 +1,10 @@
 name: Format
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ srd121, respectively ([details](raw_data/README.md)) in a renewable manner
 This project also contains a generator, validator, and translator for [Molecule
 QCSchema](https://molssi-qc-schema.readthedocs.io/en/latest/auto_topology.html).
 
+It is intended to keep the QCElemental code compatible with Python 3.6+
+as long as dependencies allow. Packages are assured for Python 3.8+.
+
+
 ### Periodic Table
 
 A variety of periodic table quantities are available using virtually any alias:

--- a/devtools/conda-envs/base-cf.yaml
+++ b/devtools/conda-envs/base-cf.yaml
@@ -15,7 +15,7 @@ dependencies:
   - nglview
 
     # Testing
-  - pytest>=4.0.0
+  - pytest
   - pytest-cov
   - codecov
   - scipy  # tests an aspect of a helper fn not used by qcel functionality

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -17,7 +17,7 @@ dependencies:
   - nglview
 
     # Testing
-  - pytest>=4.0.0
+  - pytest
   - pytest-cov
   - codecov
   - scipy  # tests an aspect of a helper fn not used by qcel functionality

--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -20,7 +20,7 @@ dependencies:
   - sphinx_rtd_theme
 
     # testing
-  - pytest>=4.0.0
+  - pytest
   - pytest-cov
   - codecov
 

--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -25,4 +25,4 @@ dependencies:
   - codecov
 
   - pip:
-     - git+git://github.com/MolSSI/qcarchive-sphinx-theme#egg=qcarchive_sphinx_theme
+     - git+https://github.com/MolSSI/qcarchive-sphinx-theme#egg=qcarchive_sphinx_theme

--- a/docs/requirements.yml
+++ b/docs/requirements.yml
@@ -15,4 +15,4 @@ dependencies:
     - graphviz
 
     - pip:
-      - git+git://github.com/MolSSI/qcarchive-sphinx-theme#egg=qcarchive_sphinx_theme
+      - git+https://github.com/MolSSI/qcarchive-sphinx-theme#egg=qcarchive_sphinx_theme

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -33,8 +33,6 @@ Bug Fixes
 +++++++++
 - (:pr:`286`) Sphinx autodocumentation with typing of ``qcelemental.testing.compare_recursive`` no longer
   warns about circular import.
-- (:pr:`286`) Some devtools/conda-envs/ were pinning to ``pytest>=4.0.0``. While correct, the
-  restriction didn't allow major version updates. Since pytest is now on v7, pinning lifted.
 
 
 0.24.0 / 2021-11-18

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-.. X.Y.0 / 2021-MM-DD
+.. X.Y.0 / 2022-MM-DD
 .. -------------------
 ..
 .. Breaking Changes
@@ -15,6 +15,27 @@ Changelog
 ..
 .. Bug Fixes
 .. +++++++++
+
+
+0.25.0 / 2022-MM-DD
+-------------------
+
+Breaking Changes
+++++++++++++++++
+
+New Features
+++++++++++++
+
+Enhancements
+++++++++++++
+
+Bug Fixes
++++++++++
+- (:pr:`286`) Sphinx autodocumentation with typing of ``qcelemental.testing.compare_recursive`` no longer
+  warns about circular import.
+- (:pr:`286`) Some devtools/conda-envs/ were pinning to ``pytest>=4.0.0``. While correct, the
+  restriction didn't allow major version updates. Since pytest is now on v7, pinning lifted.
+
 
 0.24.0 / 2021-11-18
 -------------------

--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Optional, Set, Union
 import numpy as np
 from pydantic import BaseModel, BaseSettings
 
-from qcelemental.testing import compare_recursive
 from qcelemental.util import deserialize, serialize
 from qcelemental.util.autodocs import AutoPydanticDocGenerator
 
@@ -186,6 +185,8 @@ class ProtoModel(BaseModel):
         bool
             True if the objects match.
         """
+        from ..testing import compare_recursive
+
         return compare_recursive(self, other, **kwargs)
 
 

--- a/qcelemental/models/procedures.py
+++ b/qcelemental/models/procedures.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-from pydantic import Field, constr, validator, conlist
+from pydantic import Field, conlist, constr, validator
 
 from ..util import provenance_stamp
 from .basemodels import ProtoModel

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -642,7 +642,7 @@ class AtomicResult(AtomicInput):
             v = np.asarray(v).reshape(-1, 3)
         elif values["driver"] == "hessian":
             v = np.asarray(v)
-            nsq = int(v.size ** 0.5)
+            nsq = int(v.size**0.5)
             v.shape = (nsq, nsq)
 
         return v

--- a/qcelemental/molparse/from_arrays.py
+++ b/qcelemental/molparse/from_arrays.py
@@ -600,7 +600,7 @@ def validate_and_fill_geometry(geom=None, tooclose=0.1, copy=True):
     npgeom = np.array(geom, copy=copy, dtype=float).reshape((-1, 3))
 
     # Upper triangular
-    metric = tooclose ** 2
+    metric = tooclose**2
     tooclose_inds = []
     for x in range(npgeom.shape[0]):
         diffs = npgeom[x] - npgeom[x + 1 :]

--- a/qcelemental/testing.py
+++ b/qcelemental/testing.py
@@ -7,6 +7,8 @@ from typing import Callable, Dict, List, Tuple, Union
 import numpy as np
 from pydantic import BaseModel
 
+from qcelemental.models.basemodels import ProtoModel
+
 pp = pprint.PrettyPrinter(width=120)
 
 


### PR DESCRIPTION
## Description
- [x] Sphinx warns about can't import `ProtoModel` when documenting (with autodoc and typing utilities) `qcel.testing.compare_recursive`. Can't be evaded by import guards b/c Sphinx uses runtime. This works around it and will be for Psi4 docs.
- [x] Fixes some `git+git` to `git+https` since GH doesn't authenticate the former anymore.
- [x] Removes some pytest>=4 restrictions now that pytest has reached 7
- [x] linted
- [x] test py310 and try to remove double testing for branches on upstream

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
