### PR TITLE
Pydanticdocs

### DIFF
--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -18,11 +18,12 @@ dependencies:
   - sphinx-autodoc-typehints
   - sphinx-automodapi
   - sphinx_rtd_theme
+  - autodoc-pydantic
 
     # testing
   - pytest
   - pytest-cov
   - codecov
 
-  - pip:
-     - git+https://github.com/MolSSI/qcarchive-sphinx-theme#egg=qcarchive_sphinx_theme
+  #- pip:
+  #   - git+https://github.com/MolSSI/qcarchive-sphinx-theme#egg=qcarchive_sphinx_theme

--- a/docs/requirements.yml
+++ b/docs/requirements.yml
@@ -15,5 +15,5 @@ dependencies:
     - graphviz
     - autodoc-pydantic
 
-    - pip:
-      - git+https://github.com/MolSSI/qcarchive-sphinx-theme#egg=qcarchive_sphinx_theme
+    #- pip:
+    #  - git+https://github.com/MolSSI/qcarchive-sphinx-theme#egg=qcarchive_sphinx_theme

--- a/docs/requirements.yml
+++ b/docs/requirements.yml
@@ -13,6 +13,7 @@ dependencies:
     - sphinx-automodapi
     - sphinx-autodoc-typehints
     - graphviz
+    - autodoc-pydantic
 
     - pip:
       - git+https://github.com/MolSSI/qcarchive-sphinx-theme#egg=qcarchive_sphinx_theme

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,6 +7,8 @@ QCElemental API
 
 .. automodapi:: qcelemental.molparse
 
+.. automodapi:: qcelemental.molutil
+
 .. automodapi:: qcelemental.testing
    :skip:tnm
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -4,20 +4,13 @@ QCElemental API
 
 .. automodapi:: qcelemental
    :include-all-objects:
-   :skip: covalentradii
-
-.. automodapi:: qcelemental.periodic_table
-   :skip: NotAnElementError
-   :skip: Decimal
-
-.. automodapi:: qcelemental.physical_constants
-
-.. automodapi:: qcelemental.covalent_radii
-   :skip: DataUnavailableError
-   :skip: Datum
-   :skip: Decimal
 
 .. automodapi:: qcelemental.molparse
 
 .. automodapi:: qcelemental.testing
+   :skip:tnm
+
+.. automodapi:: qcelemental.models
+   :skip:Optimization
+   :skip:qcschema_models
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -33,6 +33,8 @@ Bug Fixes
 +++++++++
 - (:pr:`286`) Sphinx autodocumentation with typing of ``qcelemental.testing.compare_recursive`` no longer
   warns about circular import.
+- (:pr:`286`) Some devtools/conda-envs/ were pinning to ``pytest>=4.0.0``. While correct, the
+  restriction didn't allow major version updates. Since pytest is now on v7, pinning lifted.
 
 
 0.24.0 / 2021-11-18

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -33,8 +33,6 @@ Bug Fixes
 +++++++++
 - (:pr:`286`) Sphinx autodocumentation with typing of ``qcelemental.testing.compare_recursive`` no longer
   warns about circular import.
-- (:pr:`286`) Some devtools/conda-envs/ were pinning to ``pytest>=4.0.0``. While correct, the
-  restriction didn't allow major version updates. Since pytest is now on v7, pinning lifted.
 
 
 0.24.0 / 2021-11-18

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -28,6 +28,12 @@ New Features
 
 Enhancements
 ++++++++++++
+- (:pr:`285`) Standardized default on ``AtomicResult.native_files`` to ``{}``
+  from ``None``.
+- (:pr:`289`) Transition from some early documentation tools (class
+  ``AutodocBaseSettings`` and ``qcarchive_sphinx_theme``) to externally
+  maintained ones (project https://github.com/mansenfranzen/autodoc_pydantic
+  and ``sphinx_rtd_theme``). Expand API docs.
 
 Bug Fixes
 +++++++++

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -703,7 +703,7 @@ New Features
 Enhancements
 ++++++++++++
 
-- (:pr:`12`) Adds single dictionary provenance consistent with `QCSchema <https://github.com/MolSSI/QCSchema/blob/master/qcschema/dev/definitions.py#L23-L41>`_ rather than previous list o'dicts.
+- (:pr:`12`) Adds single dictionary provenance consistent with `QCSchema <https://github.com/MolSSI/QCSchema/blob/master/qcschema/dev/definitions.py>`_ (line 23) rather than previous list o'dicts.
 
 
 0.1.2 / 2018-11-3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,12 +53,12 @@ extensions = [
     'sphinx.ext.graphviz',
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
-    'sphinx.ext.graphviz',
-    "sphinx_autodoc_typehints",
     # from Astropy
     'sphinx_automodapi.automodapi',
     'sphinx_automodapi.automodsumm',
     'sphinx_automodapi.smart_resolver',
+    "sphinx_autodoc_typehints",
+    "sphinxcontrib.autodoc_pydantic",
 ]
 
 autosummary_generate = True
@@ -68,6 +68,9 @@ automodapi_toctreedirnm = 'api'
 autodoc_typehints = "description"
 napoleon_use_param = True
 napoleon_use_rtype = True
+autodoc_pydantic_model_hide_paramlist = True
+autodoc_pydantic_model_show_config_summary = False
+autodoc_pydantic_field_swap_name_and_alias = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -102,11 +105,7 @@ pygments_style = 'default'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-try:
-    import qcarchive_sphinx_theme  # lgtm: [py/unused-import]
-    html_theme = 'qcarchive_sphinx_theme'
-except ModuleNotFoundError:
-    html_theme = 'sphinx_rtd_theme'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -198,10 +197,12 @@ extlinks = {
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3.7', None),
-                       'numpy': ('https://docs.scipy.org/doc/numpy/', None),
-                       'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
-                       'matplotlib': ('https://matplotlib.org/', None),
+intersphinx_mapping = {'python': ('https://docs.python.org/3.10', None),
+                       "numpy": ("https://numpy.org/doc/stable/", None),
+                       'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+                       'matplotlib': ('https://matplotlib.org/stable/', None),
+                       "qcengine": ("http://docs.qcarchive.molssi.org/projects/QCEngine/en/latest/", None),
+                       "qcfractal": ("http://docs.qcarchive.molssi.org/projects/QCFractal/en/latest/", None),
                       }
 
 # -- Options for todo extension ----------------------------------------------

--- a/docs/source/covalent_radii.rst
+++ b/docs/source/covalent_radii.rst
@@ -46,5 +46,7 @@ Function Definitions
 --------------------
 
 .. autofunction:: get
+   :noindex:
 
 .. autofunction:: string_representation
+   :noindex:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,7 +45,7 @@ Molecule Handlers
 -----------------
 
 Molecules can be translated to/from the `MolSSI QCSchema
-<https://github.com/MolSSI/QC_JSON_Schema>`_ format or quantum chemistry
+<https://github.com/MolSSI/QCSchema>`_ format or quantum chemistry
 program specific input specifications such as NWChem, Psi4, and CFour. In
 addition, databases such as PubChem can be searched:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -29,7 +29,7 @@ You can also install QCElemental using ``pip``:
 Test the Installation
 ---------------------
 
-You can test to make sure that Elemental is installed correctly by first installing ``pytest``.
+You can test to make sure that QCElemental is installed correctly by first installing ``pytest``.
 
 From ``conda``:
 
@@ -53,5 +53,5 @@ Then, run the following command:
 Developing from Source
 ----------------------
 
-If you are a developer and want to make contributions Elemental, you can access the source code from
+If you are a developer and want to make contributions to QCElemental, you can access the source code from
 `github <https://github.com/molssi/qcelemental>`_.

--- a/docs/source/model_common.rst
+++ b/docs/source/model_common.rst
@@ -6,26 +6,41 @@ Common Models used throughout the QCArchive ecosystem.
 BasisSet
 --------
 
-.. autoclass:: qcelemental.models.BasisSet
+.. autopydantic_model:: qcelemental.models.BasisSet
+   :noindex:
 
-.. autoclass:: qcelemental.models.basis.BasisCenter
+.. autopydantic_model:: qcelemental.models.basis.BasisCenter
+   :noindex:
 
-.. autoclass:: qcelemental.models.basis.ElectronShell
+.. autopydantic_model:: qcelemental.models.basis.ElectronShell
+   :noindex:
 
-.. autoclass:: qcelemental.models.basis.ECPPotential
+.. autopydantic_model:: qcelemental.models.basis.ECPPotential
+   :noindex:
 
 ComputeError
 ------------
 
-.. autoclass:: qcelemental.models.ComputeError
+.. autopydantic_model:: qcelemental.models.ComputeError
+   :noindex:
 
 FailedOperation
 ---------------
 
-.. autoclass:: qcelemental.models.FailedOperation
+.. autopydantic_model:: qcelemental.models.FailedOperation
+   :noindex:
 
 Provenance
 ----------
 
-.. autoclass:: qcelemental.models.Provenance
+.. autopydantic_model:: qcelemental.models.Provenance
+   :noindex:
+
+DriverEnum
+----------
+
+.. autoclass:: qcelemental.models.DriverEnum
+   :noindex:
+   :members:
+   :undoc-members:
 

--- a/docs/source/model_molecule.rst
+++ b/docs/source/model_molecule.rst
@@ -124,17 +124,9 @@ Obtaining fragments with ghost atoms is also supported:
         Ne      (Gh)      3.100000000572     0.000000000000     0.000000000000
     >
 
-Fields
-------
-
-.. autoclass:: qcelemental.models.Molecule
-
-
 API
 ---
 
-.. autoclass:: qcelemental.models.Molecule
-   :members:
-   :no-special-members:
+.. autopydantic_model:: qcelemental.models.Molecule
    :noindex:
 

--- a/docs/source/model_result.rst
+++ b/docs/source/model_result.rst
@@ -8,20 +8,25 @@ A Python implementation of the `MolSSI QCSchema
 AtomicInput
 -----------
 
-.. autoclass:: qcelemental.models.AtomicInput
+.. autopydantic_model:: qcelemental.models.AtomicInput
+   :noindex:
 
 AtomicResult
 ------------
 
-.. autoclass:: qcelemental.models.AtomicResult
+.. autopydantic_model:: qcelemental.models.AtomicResult
+   :noindex:
 
 
 API
 ---
 
-.. autoclass:: qcelemental.models.results.AtomicResultProtocols
+.. autopydantic_model:: qcelemental.models.results.AtomicResultProtocols
+   :noindex:
 
-.. autoclass:: qcelemental.models.results.AtomicResultProperties
+.. autopydantic_model:: qcelemental.models.results.AtomicResultProperties
+   :noindex:
 
-.. autoclass:: qcelemental.models.results.WavefunctionProperties
+.. autopydantic_model:: qcelemental.models.results.WavefunctionProperties
+   :noindex:
 

--- a/docs/source/periodic_table.rst
+++ b/docs/source/periodic_table.rst
@@ -65,15 +65,22 @@ Function Definitions
 --------------------
 
 .. autofunction:: to_mass
+   :noindex:
 
 .. autofunction:: to_mass_number
+   :noindex:
 
 .. autofunction:: to_atomic_number
+   :noindex:
 
 .. autofunction:: to_symbol
+   :noindex:
 
 .. autofunction:: to_name
+   :noindex:
 
 .. autofunction:: to_period
+   :noindex:
 
 .. autofunction:: to_group
+   :noindex:

--- a/docs/source/physconst.rst
+++ b/docs/source/physconst.rst
@@ -148,10 +148,13 @@ Function Definitions
            due to the way the LRU Cache wraps it. Please disregard the marking of it being a "class."
 
 .. autoclass:: conversion_factor
+   :noindex:
 
 .. autofunction:: get
+   :noindex:
 
 .. autofunction:: Quantity
+   :noindex:
 
 .. autofunction:: string_representation
-
+   :noindex:

--- a/docs/source/vanderwaals_radii.rst
+++ b/docs/source/vanderwaals_radii.rst
@@ -47,5 +47,7 @@ Function Definitions
 --------------------
 
 .. autofunction:: get
+   :noindex:
 
 .. autofunction:: string_representation
+   :noindex:

--- a/qcelemental/models/__init__.py
+++ b/qcelemental/models/__init__.py
@@ -8,7 +8,7 @@ except ImportError:  # pragma: no cover
 
 from . import types
 from .align import AlignmentMill
-from .basemodels import AutodocBaseSettings, ProtoModel
+from .basemodels import ProtoModel
 from .basis import BasisSet
 from .common_models import ComputeError, DriverEnum, FailedOperation, Provenance
 from .molecule import Molecule

--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -31,15 +31,15 @@ class ProtoModel(BaseModel):
             cls.__str__ = _repr
 
     @classmethod
-    def parse_raw(cls, data: Union[bytes, str], *, encoding: str = None) -> "ProtoModel":  # type: ignore
+    def parse_raw(cls, data: Union[bytes, str], *, encoding: Optional[str] = None) -> "ProtoModel":  # type: ignore
         r"""
         Parses raw string or bytes into a Model object.
 
         Parameters
         ----------
-        data : Union[bytes, str]
+        data
             A serialized data blob to be deserialized into a Model.
-        encoding : str, optional
+        encoding
             The type of the serialized array, available types are: {'json', 'json-ext', 'msgpack-ext', 'pickle'}
 
         Returns
@@ -66,14 +66,14 @@ class ProtoModel(BaseModel):
         return cls.parse_obj(obj)
 
     @classmethod
-    def parse_file(cls, path: Union[str, Path], *, encoding: str = None) -> "ProtoModel":  # type: ignore
+    def parse_file(cls, path: Union[str, Path], *, encoding: Optional[str] = None) -> "ProtoModel":  # type: ignore
         r"""Parses a file into a Model object.
 
         Parameters
         ----------
-        path : Union[str, Path]
+        path
             The path to the file.
-        encoding : str, optional
+        encoding
             The type of the files, available types are: {'json', 'msgpack', 'pickle'}. Attempts to
             automatically infer the file type from the file extension if None.
 
@@ -129,22 +129,22 @@ class ProtoModel(BaseModel):
 
         Parameters
         ----------
-        encoding : str
+        encoding
             The serialization type, available types are: {'json', 'json-ext', 'msgpack-ext'}
-        include : Optional[Set[str]], optional
+        include
             Fields to be included in the serialization.
-        exclude : Optional[Set[str]], optional
+        exclude
             Fields to be excluded in the serialization.
-        exclude_unset : Optional[bool], optional
+        exclude_unset
             If True, skips fields that have default values provided.
-        exclude_defaults: Optional[bool], optional
+        exclude_defaults
             If True, skips fields that have set or defaulted values equal to the default.
-        exclude_none: Optional[bool], optional
+        exclude_none
             If True, skips fields that have value ``None``.
 
         Returns
         -------
-        Union[bytes, str]
+        ~typing.Union[bytes, str]
             The serialized model.
         """
 
@@ -173,7 +173,7 @@ class ProtoModel(BaseModel):
 
         Parameters
         ----------
-        other : Model
+        other
             The model to compare to.
         **kwargs
             Additional kwargs to pass to :func:`~qcelemental.compare_recursive`.

--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -6,7 +6,6 @@ import numpy as np
 from pydantic import BaseModel, BaseSettings
 
 from qcelemental.util import deserialize, serialize
-from qcelemental.util.autodocs import AutoPydanticDocGenerator
 
 
 def _repr(self) -> str:
@@ -24,7 +23,6 @@ class ProtoModel(BaseModel):
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
-        cls.__doc__ = AutoPydanticDocGenerator(cls, always_apply=True)
 
         if "pydantic" in cls.__repr__.__module__:
             cls.__repr__ = _repr
@@ -178,7 +176,7 @@ class ProtoModel(BaseModel):
         other : Model
             The model to compare to.
         **kwargs
-            Additional kwargs to pass to ``qcelemental.compare_recursive``.
+            Additional kwargs to pass to :func:`~qcelemental.compare_recursive`.
 
         Returns
         -------
@@ -188,11 +186,6 @@ class ProtoModel(BaseModel):
         from ..testing import compare_recursive
 
         return compare_recursive(self, other, **kwargs)
-
-
-class AutodocBaseSettings(BaseSettings):
-    def __init_subclass__(cls) -> None:
-        cls.__doc__ = AutoPydanticDocGenerator(cls, always_apply=True)
 
 
 qcschema_draft = "http://json-schema.org/draft-04/schema#"

--- a/qcelemental/models/basis.py
+++ b/qcelemental/models/basis.py
@@ -156,7 +156,7 @@ class BasisSet(ProtoModel):
         description=(f"The QCSchema specification to which this model conforms. Explicitly fixed as qcschema_basis."),
     )
     schema_version: int = Field(  # type: ignore
-        1, description="The version number of ``schema_name`` to which this model conforms."
+        1, description="The version number of :attr:`~qcelemental.models.BasisSet.schema_name` to which this model conforms."
     )
 
     name: str = Field(..., description="The standard basis name if available (e.g., 'cc-pVDZ').")

--- a/qcelemental/models/basis.py
+++ b/qcelemental/models/basis.py
@@ -156,7 +156,8 @@ class BasisSet(ProtoModel):
         description=(f"The QCSchema specification to which this model conforms. Explicitly fixed as qcschema_basis."),
     )
     schema_version: int = Field(  # type: ignore
-        1, description="The version number of :attr:`~qcelemental.models.BasisSet.schema_name` to which this model conforms."
+        1,
+        description="The version number of :attr:`~qcelemental.models.BasisSet.schema_name` to which this model conforms.",
     )
 
     name: str = Field(..., description="The standard basis name if available (e.g., 'cc-pVDZ').")

--- a/qcelemental/models/common_models.py
+++ b/qcelemental/models/common_models.py
@@ -21,7 +21,7 @@ class Provenance(ProtoModel):
     creator: str = Field(..., description="The name of the program, library, or person who created the object.")
     version: str = Field(
         "",
-        description="The version of the creator, blank otherwise. This should be sortable by the very broad [PEP 440](https://www.python.org/dev/peps/pep-0440/).",
+        description="The version of the creator, blank otherwise. This should be sortable by the very broad `PEP 440 <https://www.python.org/dev/peps/pep-0440/>`_.",
     )
     routine: str = Field("", description="The name of the routine or function within the creator, blank otherwise.")
 

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -120,7 +120,8 @@ class Molecule(ProtoModel):
         ),
     )
     schema_version: int = Field(  # type: ignore
-        2, description="The version number of :attr:`~qcelemental.models.Molecule.schema_name` to which this model conforms."
+        2,
+        description="The version number of :attr:`~qcelemental.models.Molecule.schema_name` to which this model conforms.",
     )
     validated: bool = Field(  # type: ignore
         False,
@@ -273,7 +274,8 @@ class Molecule(ProtoModel):
         "guidance: A consumer who rotates the geometry must not reattach the input (pre-rotation) molecule schema instance to any output (post-rotation) frame-sensitive results (e.g., molecular vibrations).",
     )
     fix_symmetry: Optional[str] = Field(  # type: ignore
-        None, description="Maximal point group symmetry which :attr:`~qcelemental.models.Molecule.geometry` should be treated. Lowercase."
+        None,
+        description="Maximal point group symmetry which :attr:`~qcelemental.models.Molecule.geometry` should be treated. Lowercase.",
     )
     # Extra
     provenance: Provenance = Field(

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -120,7 +120,7 @@ class Molecule(ProtoModel):
         ),
     )
     schema_version: int = Field(  # type: ignore
-        2, description="The version number of ``schema_name`` to which this model conforms."
+        2, description="The version number of :attr:`~qcelemental.models.Molecule.schema_name` to which this model conforms."
     )
     validated: bool = Field(  # type: ignore
         False,
@@ -135,9 +135,9 @@ class Molecule(ProtoModel):
     symbols: Array[str] = Field(  # type: ignore
         ...,
         description="The ordered array of atomic elemental symbols in title case. This field's index "
-        "sets atomic order for all other per-atom fields like ``real`` and the first dimension of "
-        "``geometry``. Ghost/virtual atoms must have an entry here in ``symbols``; ghostedness is "
-        "indicated through the ``real`` field.",
+        "sets atomic order for all other per-atom fields like :attr:`~qcelemental.models.Molecule.real` and the first dimension of "
+        ":attr:`~qcelemental.models.Molecule.geometry`. Ghost/virtual atoms must have an entry here in :attr:`~qcelemental.models.Molecule.symbols`; ghostedness is "
+        "indicated through the :attr:`~qcelemental.models.Molecule.real` field.",
         shape=["nat"],
     )
     geometry: Array[float] = Field(  # type: ignore
@@ -146,7 +146,7 @@ class Molecule(ProtoModel):
         "Atom ordering is fixed; that is, a consumer who shuffles atoms must not reattach the input "
         "(pre-shuffling) molecule schema instance to any output (post-shuffling) per-atom results "
         "(e.g., gradient). Index of the first dimension matches the 0-indexed indices of all other "
-        "per-atom settings like ``symbols`` and ``real``."
+        "per-atom settings like :attr:`~qcelemental.models.Molecule.symbols` and :attr:`~qcelemental.models.Molecule.real`."
         "\n"
         "Serialized storage is always flat, (3*nat,), but QCSchema implementations will want to reshape it. "
         "QCElemental can also accept array-likes which can be mapped to (nat,3) such as a 1-D list of length 3*nat, "
@@ -159,12 +159,12 @@ class Molecule(ProtoModel):
     # Molecule data
     name: Optional[str] = Field(  # type: ignore
         None,
-        description="Common or human-readable name to assign to this molecule. This field can be arbitrary; see ``identifiers`` for well-defined labels.",
+        description="Common or human-readable name to assign to this molecule. This field can be arbitrary; see :attr:`~qcelemental.models.Molecule.identifiers` for well-defined labels.",
     )
     identifiers: Optional[Identifiers] = Field(  # type: ignore
         None,
         description="An optional dictionary of additional identifiers by which this molecule can be referenced, "
-        "such as INCHI, canonical SMILES, etc. See the :class:``Identifiers`` model for more details.",
+        "such as INCHI, canonical SMILES, etc. See the :class:`~qcelemental.models.results.Identifiers` model for more details.",
     )
     comment: Optional[str] = Field(  # type: ignore
         None,
@@ -177,10 +177,10 @@ class Molecule(ProtoModel):
     masses_: Optional[Array[float]] = Field(  # type: ignore
         None,
         description="The ordered array of atomic masses. Index order "
-        "matches the 0-indexed indices of all other per-atom fields like ``symbols`` and ``real``. If "
+        "matches the 0-indexed indices of all other per-atom fields like :attr:`~qcelemental.models.Molecule.symbols` and :attr:`~qcelemental.models.Molecule.real`. If "
         "this is not provided, the mass of each atom is inferred from its most common isotope. If this "
-        "is provided, it must be the same length as ``symbols`` but can accept ``None`` entries for "
-        "standard masses to infer from the same index in the ``symbols`` field.",
+        "is provided, it must be the same length as :attr:`~qcelemental.models.Molecule.symbols` but can accept ``None`` entries for "
+        "standard masses to infer from the same index in the :attr:`~qcelemental.models.Molecule.symbols` field.",
         shape=["nat"],
         units="u",
     )
@@ -188,8 +188,8 @@ class Molecule(ProtoModel):
         None,
         description="The ordered array indicating if each atom is real (``True``) or "
         "ghost/virtual (``False``). Index "
-        "matches the 0-indexed indices of all other per-atom settings like ``symbols`` and the first "
-        "dimension of ``geometry``. If this is not provided, all atoms are assumed to be real (``True``)."
+        "matches the 0-indexed indices of all other per-atom settings like :attr:`~qcelemental.models.Molecule.symbols` and the first "
+        "dimension of :attr:`~qcelemental.models.Molecule.geometry`. If this is not provided, all atoms are assumed to be real (``True``)."
         "If this is provided, the reality or ghostedness of every atom must be specified.",
         shape=["nat"],
     )
@@ -197,22 +197,22 @@ class Molecule(ProtoModel):
         None,
         description="Additional per-atom labels as an array of strings. Typical use is in "
         "model conversions, such as Elemental <-> Molpro and not typically something which should be user "
-        "assigned. See the ``comments`` field for general human-consumable text to affix to the molecule.",
+        "assigned. See the :attr:`~qcelemental.models.Molecule.comment` field for general human-consumable text to affix to the molecule.",
         shape=["nat"],
     )
     atomic_numbers_: Optional[Array[np.int16]] = Field(  # type: ignore
         None,
         description="An optional ordered 1-D array-like object of atomic numbers of shape (nat,). Index "
-        "matches the 0-indexed indices of all other per-atom settings like ``symbols`` and ``real``. "
-        "Values are inferred from the ``symbols`` list if not explicitly set. "
-        "Ghostedness should be indicated through ``real`` field, not zeros here.",
+        "matches the 0-indexed indices of all other per-atom settings like :attr:`~qcelemental.models.Molecule.symbols` and :attr:`~qcelemental.models.Molecule.real`. "
+        "Values are inferred from the :attr:`~qcelemental.models.Molecule.symbols` list if not explicitly set. "
+        "Ghostedness should be indicated through :attr:`~qcelemental.models.Molecule.real` field, not zeros here.",
         shape=["nat"],
     )
     mass_numbers_: Optional[Array[np.int16]] = Field(  # type: ignore
         None,
         description="An optional ordered 1-D array-like object of atomic *mass* numbers of shape (nat). Index "
-        "matches the 0-indexed indices of all other per-atom settings like ``symbols`` and ``real``. "
-        "Values are inferred from the most common isotopes of the ``symbols`` list if not explicitly set. "
+        "matches the 0-indexed indices of all other per-atom settings like :attr:`~qcelemental.models.Molecule.symbols` and :attr:`~qcelemental.models.Molecule.real`. "
+        "Values are inferred from the most common isotopes of the :attr:`~qcelemental.models.Molecule.symbols` list if not explicitly set. "
         "If single isotope not (yet) known for an atom, -1 is placeholder.",
         shape=["nat"],
     )
@@ -222,15 +222,15 @@ class Molecule(ProtoModel):
         None,
         description="A list of bonds within the molecule. Each entry is a tuple "
         "of ``(atom_index_A, atom_index_B, bond_order)`` where the ``atom_index`` "
-        "matches the 0-indexed indices of all other per-atom settings like ``symbols`` and ``real``. "
+        "matches the 0-indexed indices of all other per-atom settings like :attr:`~qcelemental.models.Molecule.symbols` and :attr:`~qcelemental.models.Molecule.real`. "
         "Bonds may be freely reordered and inverted.",
         min_items=1,
     )
     fragments_: Optional[List[Array[np.int32]]] = Field(  # type: ignore
         None,
         description="List of indices grouping atoms (0-indexed) into molecular fragments within the molecule. "
-        "Each entry in the outer list is a new fragment; index matches the ordering in ``fragment_charges`` and "
-        "``fragment_multiplicities``. Inner lists are 0-indexed atoms which compose the fragment; every atom must "
+        "Each entry in the outer list is a new fragment; index matches the ordering in :attr:`~qcelemental.models.Molecule.fragment_charges` and "
+        ":attr:`~qcelemental.models.Molecule.fragment_multiplicities`. Inner lists are 0-indexed atoms which compose the fragment; every atom must "
         "be in exactly one inner list. Noncontiguous fragments are allowed, though no QM program is known to support them. "
         "Fragment ordering is fixed; that is, a consumer who shuffles fragments must not reattach the input "
         "(pre-shuffling) molecule schema instance to any output (post-shuffling) per-fragment results (e.g., n-body energy arrays).",
@@ -238,16 +238,16 @@ class Molecule(ProtoModel):
     )
     fragment_charges_: Optional[List[float]] = Field(  # type: ignore
         None,
-        description="The total charge of each fragment in the ``fragments`` list. The index of this "
-        "list matches the 0-index indices of ``fragments`` list. Will be filled in based on a set of rules "
-        "if not provided (and ``fragments`` are specified).",
+        description="The total charge of each fragment in the :attr:`~qcelemental.models.Molecule.fragments` list. The index of this "
+        "list matches the 0-index indices of :attr:`~qcelemental.models.Molecule.fragments` list. Will be filled in based on a set of rules "
+        "if not provided (and :attr:`~qcelemental.models.Molecule.fragments` are specified).",
         shape=["nfr"],
     )
     fragment_multiplicities_: Optional[List[int]] = Field(  # type: ignore
         None,
-        description="The multiplicity of each fragment in the ``fragments`` list. The index of this "
-        "list matches the 0-index indices of ``fragments`` list. Will be filled in based on a set of "
-        "rules if not provided (and ``fragments`` are specified).",
+        description="The multiplicity of each fragment in the :attr:`~qcelemental.models.Molecule.fragments` list. The index of this "
+        "list matches the 0-index indices of :attr:`~qcelemental.models.Molecule.fragments` list. Will be filled in based on a set of "
+        "rules if not provided (and :attr:`~qcelemental.models.Molecule.fragments` are specified).",
         shape=["nfr"],
     )
 
@@ -256,7 +256,7 @@ class Molecule(ProtoModel):
         False,
         description="Whether translation of geometry is allowed (fix F) or disallowed (fix T)."
         "When False, QCElemental will pre-process the Molecule object to translate the center of mass "
-        "to (0,0,0) in Euclidean coordinate space, resulting in a different ``geometry`` than the "
+        "to (0,0,0) in Euclidean coordinate space, resulting in a different :attr:`~qcelemental.models.Molecule.geometry` than the "
         "one provided. 'Fix' is used in the sense of 'specify': that is, `fix_com=True` signals that "
         "the origin in `geometry` is a deliberate part of the Molecule spec, whereas `fix_com=False` "
         "(default) allows that the origin is happenstance and may be adjusted. "
@@ -266,14 +266,14 @@ class Molecule(ProtoModel):
         False,
         description="Whether rotation of geometry is allowed (fix F) or disallowed (fix T). "
         "When False, QCElemental will pre-process the Molecule object to orient via the intertial tensor, "
-        "resulting in a different ``geometry`` than the one provided. "
+        "resulting in a different :attr:`~qcelemental.models.Molecule.geometry` than the one provided. "
         "'Fix' is used in the sense of 'specify': that is, `fix_orientation=True` signals that "
         "the frame orientation in `geometry` is a deliberate part of the Molecule spec, whereas "
         "`fix_orientation=False` (default) allows that the frame is happenstance and may be adjusted. "
         "guidance: A consumer who rotates the geometry must not reattach the input (pre-rotation) molecule schema instance to any output (post-rotation) frame-sensitive results (e.g., molecular vibrations).",
     )
     fix_symmetry: Optional[str] = Field(  # type: ignore
-        None, description="Maximal point group symmetry which ``geometry`` should be treated. Lowercase."
+        None, description="Maximal point group symmetry which :attr:`~qcelemental.models.Molecule.geometry` should be treated. Lowercase."
     )
     # Extra
     provenance: Provenance = Field(

--- a/qcelemental/models/procedures.py
+++ b/qcelemental/models/procedures.py
@@ -265,5 +265,7 @@ def Optimization(*args, **kwargs):
     """
     from warnings import warn
 
-    warn("Optimization has been renamed to OptimizationResult and will be removed as soon as v0.13.0", DeprecationWarning)
+    warn(
+        "Optimization has been renamed to OptimizationResult and will be removed as soon as v0.13.0", DeprecationWarning
+    )
     return OptimizationResult(*args, **kwargs)

--- a/qcelemental/models/procedures.py
+++ b/qcelemental/models/procedures.py
@@ -257,7 +257,13 @@ class TorsionDriveResult(TorsionDriveInput):
 
 
 def Optimization(*args, **kwargs):
+    """QC Optimization Results Schema.
+
+    .. deprecated:: 0.12
+       Use :py:func:`qcelemental.models.OptimizationResult` instead.
+
+    """
     from warnings import warn
 
-    warn("Optimization has been renamed to OptimizationResult and will be removed in v0.13.0", DeprecationWarning)
+    warn("Optimization has been renamed to OptimizationResult and will be removed as soon as v0.13.0", DeprecationWarning)
     return OptimizationResult(*args, **kwargs)

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -568,15 +568,16 @@ class AtomicInput(ProtoModel):
             f"The QCSchema specification this model conforms to. Explicitly fixed as {qcschema_input_default}."
         ),
     )
-    schema_version: int = Field(1, description="The version number of :attr:`~qcelemental.models.AtomicInput.schema_name` to which this model conforms.")
+    schema_version: int = Field(
+        1,
+        description="The version number of :attr:`~qcelemental.models.AtomicInput.schema_name` to which this model conforms.",
+    )
 
     molecule: Molecule = Field(..., description="The molecule to use in the computation.")
     driver: DriverEnum = Field(..., description=str(DriverEnum.__doc__))
     model: Model = Field(..., description=str(Model.__doc__))
     keywords: Dict[str, Any] = Field({}, description="The program-specific keywords to be used.")
-    protocols: AtomicResultProtocols = Field(
-        AtomicResultProtocols(), description=str(AtomicResultProtocols.__doc__)
-    )
+    protocols: AtomicResultProtocols = Field(AtomicResultProtocols(), description=str(AtomicResultProtocols.__doc__))
 
     extras: Dict[str, Any] = Field(
         {},
@@ -762,6 +763,7 @@ class ResultProperties(AtomicResultProperties):
        Use :py:func:`qcelemental.models.AtomicResultProperties` instead.
 
     """
+
     def __init__(self, *args, **kwargs):
         from warnings import warn
 
@@ -779,6 +781,7 @@ class ResultProtocols(AtomicResultProtocols):
        Use :py:func:`qcelemental.models.AtomicResultProtocols` instead.
 
     """
+
     def __init__(self, *args, **kwargs):
         from warnings import warn
 
@@ -796,6 +799,7 @@ class ResultInput(AtomicInput):
        Use :py:func:`qcelemental.models.AtomicInput` instead.
 
     """
+
     def __init__(self, *args, **kwargs):
         from warnings import warn
 
@@ -810,6 +814,7 @@ class Result(AtomicResult):
        Use :py:func:`qcelemental.models.AtomicResult` instead.
 
     """
+
     def __init__(self, *args, **kwargs):
         from warnings import warn
 

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -288,7 +288,7 @@ class AtomicResultProperties(ProtoModel):
         try:
             v = np.asarray(v).reshape(shape)
         except (ValueError, AttributeError):
-            raise ValueError(f"Derivative must be castable to shape {shape}! len={np.asarray(v).size()}")
+            raise ValueError(f"Derivative must be castable to shape {shape}!")
         return v
 
     def dict(self, *args, **kwargs):

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -17,12 +17,13 @@ if TYPE_CHECKING:
 
 
 class AtomicResultProperties(ProtoModel):
-    r"""Named properties of quantum chemistry computations following the MolSSI QCSchema.
+    r"""
+    Named properties of quantum chemistry computations following the MolSSI QCSchema.
 
     All arrays are stored flat but must be reshapable into the dimensions in attribute ``shape``, with abbreviations as follows:
 
-      * nao: number of atomic orbitals = calcinfo_nbasis
-      * nmo: number of molecular orbitals
+    * nao: number of atomic orbitals = :attr:`~qcelemental.models.AtomicResultProperties.calcinfo_nbasis`
+    * nmo: number of molecular orbitals = :attr:`~qcelemental.models.AtomicResultProperties.calcinfo_nmo`
     """
 
     # Calcinfo
@@ -36,16 +37,16 @@ class AtomicResultProperties(ProtoModel):
     nuclear_repulsion_energy: Optional[float] = Field(None, description="The nuclear repulsion energy.")
     return_energy: Optional[float] = Field(
         None,
-        description="The energy of the requested method, identical to ``return_result`` for ``driver=energy`` computations.",
+        description="The energy of the requested method, identical to :attr:`~qcelemental.models.AtomicResult.return_result` for :attr:`~qcelemental.models.AtomicInput.driver`\ =\ :attr:`~qcelemental.models.DriverEnum.energy` computations.",
     )
     return_gradient: Optional[Array[float]] = Field(
         None,
-        description="The gradient of the requested method, identical to ``return_result`` for ``driver=gradient`` computations.",
+        description="The gradient of the requested method, identical to :attr:`~qcelemental.models.AtomicResult.return_result` for :attr:`~qcelemental.models.AtomicInput.driver`\ =\ :attr:`~qcelemental.models.DriverEnum.gradient` computations.",
         units="E_h/a0",
     )
     return_hessian: Optional[Array[float]] = Field(
         None,
-        description="The Hessian of the requested method, identical to ``return_result`` for ``driver=hessian`` computations.",
+        description="The Hessian of the requested method, identical to :attr:`~qcelemental.models.AtomicResult.return_result` for :attr:`~qcelemental.models.AtomicInput.driver`\ =\ :attr:`~qcelemental.models.DriverEnum.hessian` computations.",
         units="E_h/a0^2",
     )
 
@@ -287,7 +288,7 @@ class AtomicResultProperties(ProtoModel):
         try:
             v = np.asarray(v).reshape(shape)
         except (ValueError, AttributeError):
-            raise ValueError(f"Derivative must be castable to shape {shape}!")
+            raise ValueError(f"Derivative must be castable to shape {shape}! len={np.asarray(v).size()}")
         return v
 
     def dict(self, *args, **kwargs):
@@ -567,14 +568,14 @@ class AtomicInput(ProtoModel):
             f"The QCSchema specification this model conforms to. Explicitly fixed as {qcschema_input_default}."
         ),
     )
-    schema_version: int = Field(1, description="The version number of ``schema_name`` to which this model conforms.")
+    schema_version: int = Field(1, description="The version number of :attr:`~qcelemental.models.AtomicInput.schema_name` to which this model conforms.")
 
     molecule: Molecule = Field(..., description="The molecule to use in the computation.")
     driver: DriverEnum = Field(..., description=str(DriverEnum.__doc__))
-    model: Model = Field(..., description=str(Model.__base_doc__))
+    model: Model = Field(..., description=str(Model.__doc__))
     keywords: Dict[str, Any] = Field({}, description="The program-specific keywords to be used.")
     protocols: AtomicResultProtocols = Field(
-        AtomicResultProtocols(), description=str(AtomicResultProtocols.__base_doc__)
+        AtomicResultProtocols(), description=str(AtomicResultProtocols.__doc__)
     )
 
     extras: Dict[str, Any] = Field(
@@ -583,7 +584,7 @@ class AtomicInput(ProtoModel):
     )
 
     provenance: Provenance = Field(
-        default_factory=partial(provenance_stamp, __name__), description=str(Provenance.__base_doc__)
+        default_factory=partial(provenance_stamp, __name__), description=str(Provenance.__doc__)
     )
 
     class Config(ProtoModel.Config):
@@ -607,12 +608,12 @@ class AtomicResult(AtomicInput):
             f"The QCSchema specification this model conforms to. Explicitly fixed as {qcschema_output_default}."
         ),
     )
-    properties: AtomicResultProperties = Field(..., description=str(AtomicResultProperties.__base_doc__))
-    wavefunction: Optional[WavefunctionProperties] = Field(None, description=str(WavefunctionProperties.__base_doc__))
+    properties: AtomicResultProperties = Field(..., description=str(AtomicResultProperties.__doc__))
+    wavefunction: Optional[WavefunctionProperties] = Field(None, description=str(WavefunctionProperties.__doc__))
 
     return_result: Union[float, Array[float], Dict[str, Any]] = Field(
         ...,
-        description="The primary return specified by the ``driver`` field. Scalar if energy; array if gradient or hessian; dictionary with property keys if properties.",
+        description="The primary return specified by the :attr:`~qcelemental.models.AtomicInput.driver` field. Scalar if energy; array if gradient or hessian; dictionary with property keys if properties.",
     )  # type: ignore
 
     stdout: Optional[str] = Field(
@@ -623,8 +624,8 @@ class AtomicResult(AtomicInput):
     native_files: Dict[str, Any] = Field({}, description="DSL files.")
 
     success: bool = Field(..., description="The success of program execution. If False, other fields may be blank.")
-    error: Optional[ComputeError] = Field(None, description=str(ComputeError.__base_doc__))
-    provenance: Provenance = Field(..., description=str(Provenance.__base_doc__))
+    error: Optional[ComputeError] = Field(None, description=str(ComputeError.__doc__))
+    provenance: Provenance = Field(..., description=str(Provenance.__doc__))
 
     @validator("schema_name", pre=True)
     def _input_to_output(cls, v):
@@ -755,38 +756,62 @@ class AtomicResult(AtomicInput):
 
 
 class ResultProperties(AtomicResultProperties):
+    """QC Result Properties Schema.
+
+    .. deprecated:: 0.12
+       Use :py:func:`qcelemental.models.AtomicResultProperties` instead.
+
+    """
     def __init__(self, *args, **kwargs):
         from warnings import warn
 
         warn(
-            "ResultProperties has been renamed to AtomicResultProperties and will be removed in v0.13.0",
+            "ResultProperties has been renamed to AtomicResultProperties and will be removed as soon as v0.13.0",
             DeprecationWarning,
         )
         super().__init__(*args, **kwargs)
 
 
 class ResultProtocols(AtomicResultProtocols):
+    """QC Result Protocols Schema.
+
+    .. deprecated:: 0.12
+       Use :py:func:`qcelemental.models.AtomicResultProtocols` instead.
+
+    """
     def __init__(self, *args, **kwargs):
         from warnings import warn
 
         warn(
-            "ResultProtocols has been renamed to AtomicResultProtocols and will be removed in v0.13.0",
+            "ResultProtocols has been renamed to AtomicResultProtocols and will be removed as soon as v0.13.0",
             DeprecationWarning,
         )
         super().__init__(*args, **kwargs)
 
 
 class ResultInput(AtomicInput):
+    """QC Input Schema.
+
+    .. deprecated:: 0.12
+       Use :py:func:`qcelemental.models.AtomicInput` instead.
+
+    """
     def __init__(self, *args, **kwargs):
         from warnings import warn
 
-        warn("ResultInput has been renamed to AtomicInput and will be removed in v0.13.0", DeprecationWarning)
+        warn("ResultInput has been renamed to AtomicInput and will be removed as soon as v0.13.0", DeprecationWarning)
         super().__init__(*args, **kwargs)
 
 
 class Result(AtomicResult):
+    """QC Result Schema.
+
+    .. deprecated:: 0.12
+       Use :py:func:`qcelemental.models.AtomicResult` instead.
+
+    """
     def __init__(self, *args, **kwargs):
         from warnings import warn
 
-        warn("Result has been renamed to AtomicResult and will be removed in v0.13.0", DeprecationWarning)
+        warn("Result has been renamed to AtomicResult and will be removed as soon as v0.13.0", DeprecationWarning)
         super().__init__(*args, **kwargs)

--- a/qcelemental/molutil/align.py
+++ b/qcelemental/molutil/align.py
@@ -556,6 +556,7 @@ def kabsch_quaternion(P, Q):
 
 # TODO: consider `numpy.typing.ArrayLike` in compute_scramble
 
+
 def compute_scramble(
     nat: int,
     do_resort: Union[bool, List, np.ndarray] = True,

--- a/qcelemental/molutil/align.py
+++ b/qcelemental/molutil/align.py
@@ -554,6 +554,8 @@ def kabsch_quaternion(P, Q):
     return U
 
 
+# TODO: consider `numpy.typing.ArrayLike` in compute_scramble
+
 def compute_scramble(
     nat: int,
     do_resort: Union[bool, List, np.ndarray] = True,

--- a/qcelemental/molutil/align.py
+++ b/qcelemental/molutil/align.py
@@ -1,7 +1,7 @@
 import collections
 import itertools
 import time
-from typing import Union
+from typing import List, Optional, Union
 
 import numpy as np
 
@@ -97,7 +97,7 @@ def B787(
 
     Returns
     -------
-    float, tuple
+    float, AlignmentMill
         First item is RMSD [A] between `rgeom` and the optimally aligned
         geometry computed.
         Second item is a AlignmentMill with fields
@@ -431,19 +431,19 @@ def _plausible_atom_orderings(ref, current, rgeom, cgeom, algorithm="hungarian_u
         yield atpat
 
 
-def kabsch_align(rgeom, cgeom, weight=None):
+def kabsch_align(rgeom: np.ndarray, cgeom: np.ndarray, weight: Optional[np.ndarray] = None):
     r"""Finds optimal translation and rotation to align `cgeom` onto `rgeom` via
-    Kabsch algorithm by minimizing the norm of the residual, || R - U * C ||.
+    Kabsch algorithm by minimizing the norm of the residual, :math:`|| R - U * C ||`.
 
     Parameters
     ----------
-    rgeom : ndarray of float
+    rgeom
         (nat, 3) array of reference/target/unchanged geometry. Assumed [a0]
         for RMSD purposes.
-    cgeom : ndarray of float
+    cgeom
         (nat, 3) array of concern/changeable geometry. Assumed [a0] for RMSD
         purposes. Must have same Natom, units, and 1-to-1 atom ordering as rgeom.
-    weight : ndarray of float
+    weight
         (nat,) array of weights applied to `rgeom`. Note that definitions of
         weights (nothing to do with atom masses) are several, and I haven't
         seen one yet that can make centroid the center-of-mass and
@@ -453,19 +453,19 @@ def kabsch_align(rgeom, cgeom, weight=None):
 
     Returns
     -------
-    float, ndarray, ndarray
+    float, ~numpy.ndarray, ~numpy.ndarray
         First item is RMSD [A] between `rgeom` and the optimally aligned
         geometry computed.
         Second item is (3, 3) rotation matrix to optimal alignment.
         Third item is (3,) translation vector [a0] to optimal alignment.
 
-    Sources
-    -------
-    Kabsch: Acta Cryst. (1978). A34, 827-828 http://journals.iucr.org/a/issues/1978/05/00/a15629/a15629.pdf
-    C++ affine code: https://github.com/oleg-alexandrov/projects/blob/master/eigen/Kabsch.cpp
-    weighted RMSD: http://www.amber.utah.edu/AMBER-workshop/London-2015/tutorial1/
-    protein wRMSD code: https://pharmacy.umich.edu/sites/default/files/global_wrmsd_v8.3.py.txt
-    quaternion: https://cnx.org/contents/HV-RsdwL@23/Molecular-Distance-Measures
+    Notes
+    -----
+    * Kabsch: Acta Cryst. (1978). A34, 827-828 http://journals.iucr.org/a/issues/1978/05/00/a15629/a15629.pdf
+    * C++ affine code: https://github.com/oleg-alexandrov/projects/blob/master/eigen/Kabsch.cpp
+    * weighted RMSD: http://www.amber.utah.edu/AMBER-workshop/London-2015/tutorial1/
+    * protein wRMSD code: https://pharmacy.umich.edu/sites/default/files/global_wrmsd_v8.3.py.txt
+    * quaternion: https://cnx.org/contents/HV-RsdwL@23/Molecular-Distance-Measures
 
     Author: dsirianni
 
@@ -554,34 +554,41 @@ def kabsch_quaternion(P, Q):
     return U
 
 
-def compute_scramble(nat, do_resort=True, do_shift=True, do_rotate=True, deflection=1.0, do_mirror=False):
+def compute_scramble(
+    nat: int,
+    do_resort: Union[bool, List, np.ndarray] = True,
+    do_shift: Union[bool, List, np.ndarray] = True,
+    do_rotate: Union[bool, List, np.ndarray] = True,
+    deflection: float = 1.0,
+    do_mirror: bool = False,
+) -> AlignmentMill:
     r"""Generate a random or directed translation, rotation, and atom shuffling.
 
     Parameters
     ----------
-    nat : int
+    nat
         Number of atoms for which to prepare an atom mapping.
-    do_resort : bool or array-like, optional
+    do_resort
         Whether to randomly shuffle atoms (`True`) or leave 1st atom 1st, etc. (`False`)
         or shuffle according to specified (nat, ) indices (e.g., [2, 1, 0])
-    do_shift : bool or array-like, optional
+    do_shift
         Whether to generate a random atom shift on interval [-3, 3) in each
         dimension (`True`) or leave at current origin (`False`) or shift along
         specified (3, ) vector (e.g., np.array([0., 1., -1.])).
-    do_rotate : bool or array-like, optional
+    do_rotate
         Whether to generate a random 3D rotation according to algorithm of Arvo (`True`)
         or leave at current orientation (`False`) or rotate with specified (3, 3) matrix.
-    deflection : float, optional
+    deflection
         If `do_rotate`, how random a rotation: 0.0 is no change, 0.1 is small
         perturbation, 1.0 is completely random.
-    do_mirror : bool, optional
+    do_mirror
         Whether to set mirror reflection instruction. Changes identity of
         molecule so off by default.
 
     Returns
     -------
-    tuple
-        AlignmentMill with fields (shift, rotation, atommap, mirror)
+    AlignmentMill
+        Fields (shift, rotation, atommap, mirror)
         as requested: identity, random, or specified.
 
     """

--- a/qcelemental/molutil/connectivity.py
+++ b/qcelemental/molutil/connectivity.py
@@ -16,18 +16,18 @@ def guess_connectivity(
 
     Parameters
     ----------
-    symbols : np.ndarray
+    symbols
         The molecular symbols (e.g., 'Zr', 'C')
-    geometry : np.ndarray
+    geometry
         The molecular geometry in Bohr
-    threshold : float, optional
+    threshold
         Tunes the covalent radii metric safety factor.
-    default_connectivity : Optional[float], optional
+    default_connectivity
         Provides a default connectivity value
 
     Returns
     -------
-    List[Union[Tuple[int, int], Tuple[int, int, float]]]
+    ~typing.List[~typing.Union[~typing.Tuple[int, int], ~typing.Tuple[int, int, float]]]
         Provides a list of connected atoms, or optionally a list of
         connected atoms and default connectivity if provided.
     """

--- a/qcelemental/molutil/molecular_formula.py
+++ b/qcelemental/molutil/molecular_formula.py
@@ -9,9 +9,9 @@ def order_molecular_formula(formula: str, order: str = "alphabetical") -> str:
 
     Parameters
     ----------
-    formula: str
+    formula
         A molecular formula
-    order: str, optional
+    order
         Sorting order of the formula. Valid choices are "alphabetical" and "hill".
 
     Returns
@@ -42,9 +42,9 @@ def molecular_formula_from_symbols(symbols: List[str], order: str = "alphabetica
 
     Parameters
     ----------
-    symbols: List[str]
+    symbols
         List of chemical symbols
-    order: str, optional
+    order
         Sorting order of the formula. Valid choices are "alphabetical" and "hill".
 
     Returns

--- a/qcelemental/testing.py
+++ b/qcelemental/testing.py
@@ -65,7 +65,7 @@ def compare_values(
     rtol
         Relative tolerance (see formula below). By default set to zero so `atol` dominates.
     equal_nan
-        Passed to np.isclose. Compare NaN's as equal.
+        Passed to :func:`numpy.isclose`. Compare NaN's as equal.
     equal_phase
         Compare computed *or its opposite* as equal.
     passnone
@@ -90,7 +90,7 @@ def compare_values(
 
     Notes
     -----
-    * Akin to np.allclose.
+    * Akin to :func:`numpy.allclose`.
     * For scalar float-comparable types and for arbitrary-dimension, np.ndarray-castable, uniform-type,
       float-comparable types. For mixed types, use :py:func:`compare_recursive`.
     * Sets rtol to zero to match expected Psi4 behaviour, otherwise measured as:
@@ -228,7 +228,7 @@ def compare(
 
     Notes
     -----
-    * Akin to np.array_equal.
+    * Akin to :func:`numpy.array_equal`.
     * For scalar exactly-comparable types and for arbitrary-dimension, np.ndarray-castable, uniform-type,
       exactly-comparable types. For mixed types, use :py:func:`compare_recursive`.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Rework docs (motivation intersphinx from Psi4).

## Changelog description
- [x] Use the excellent https://github.com/mansenfranzen/autodoc_pydantic project to integrate models into sphinx. It looks nice, it is highly configurable, and we can drop the home-grown `AutodocBaseSettings` work that predates this availability (speak up, anyone, if you know reasons to keep it. Here's discussion on docs btwn pydantic and qca folks: https://github.com/samuelcolvin/pydantic/issues/638 .
- [x] More classes/fns documented and API section used as superset, not complement to non-auto docs.
- [x] Fixed a couple things `make linkcheck` didn't like.
- [x] Added links to models.
- [x] Retired the specialized qca sphinx theme in favor of rtd. There was some awkward formatting by qca.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
