### PR TITLE
undo overzealous autodocs removal

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -30,7 +30,7 @@ Enhancements
 ++++++++++++
 - (:pr:`285`) Standardized default on ``AtomicResult.native_files`` to ``{}``
   from ``None``.
-- (:pr:`289`) Transition from some early documentation tools (class
+- (:pr:`289`, :pr:`290`) Transition from some early documentation tools (class
   ``AutodocBaseSettings`` and ``qcarchive_sphinx_theme``) to externally
   maintained ones (project https://github.com/mansenfranzen/autodoc_pydantic
   and ``sphinx_rtd_theme``). Expand API docs.

--- a/qcelemental/models/__init__.py
+++ b/qcelemental/models/__init__.py
@@ -8,6 +8,7 @@ except ImportError:  # pragma: no cover
 
 from . import types
 from .align import AlignmentMill
+from .basemodels import AutodocBaseSettings  # remove when QCFractal merges `next`
 from .basemodels import ProtoModel
 from .basis import BasisSet
 from .common_models import ComputeError, DriverEnum, FailedOperation, Provenance

--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -3,9 +3,11 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Set, Union
 
 import numpy as np
-from pydantic import BaseModel, BaseSettings
+from pydantic import BaseSettings  # remove when QCFractal merges `next`
+from pydantic import BaseModel
 
 from qcelemental.util import deserialize, serialize
+from qcelemental.util.autodocs import AutoPydanticDocGenerator  # remove when QCFractal merges `next`
 
 
 def _repr(self) -> str:
@@ -23,6 +25,7 @@ class ProtoModel(BaseModel):
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
+        cls.__base_doc__ = ""  # remove when QCFractal merges `next`
 
         if "pydantic" in cls.__repr__.__module__:
             cls.__repr__ = _repr
@@ -186,6 +189,12 @@ class ProtoModel(BaseModel):
         from ..testing import compare_recursive
 
         return compare_recursive(self, other, **kwargs)
+
+
+# remove when QCFractal merges `next`
+class AutodocBaseSettings(BaseSettings):
+    def __init_subclass__(cls) -> None:
+        cls.__doc__ = AutoPydanticDocGenerator(cls, always_apply=True)
 
 
 qcschema_draft = "http://json-schema.org/draft-04/schema#"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Removal of home-grown autodoc in #289, while good, threatened to break `qcportal`/`qcfractal` import. Presence restored, though not functionality (which interfered with autodoc-pydantic).

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
