### PR TITLE
Update for Pint 0.20 API breaks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         cfg:
           - conda-env: minimal
-            python-version: 3.6
+            python-version: 3.8
             label: mindep
           - conda-env: base
-            python-version: 3.6
+            python-version: 3.8
             label: minpy
           - conda-env: base-cf
             python-version: "3.10"

--- a/devtools/conda-envs/base-cf.yaml
+++ b/devtools/conda-envs/base-cf.yaml
@@ -6,7 +6,7 @@ dependencies:
   - numpy>=1.12.0
   - nomkl
   - python
-  - pint>=0.20.1
+  - pint>=0.20
   - pydantic>=1.8.2
 
     # Optional depends

--- a/devtools/conda-envs/base-cf.yaml
+++ b/devtools/conda-envs/base-cf.yaml
@@ -6,7 +6,7 @@ dependencies:
   - numpy>=1.12.0
   - nomkl
   - python
-  - pint>=0.10.0
+  - pint>=0.20.1
   - pydantic>=1.8.2
 
     # Optional depends

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -7,7 +7,7 @@ dependencies:
   - numpy>=1.12.0
   - nomkl
   - python
-  - pint>=0.10.0
+  - pint>=0.20.1
   - pydantic>=1.8.2
   - dataclasses  # only for py36 and only b/c default channel pydantic missing the conditional dep
 

--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -7,7 +7,7 @@ dependencies:
   - numpy>=1.12.0
   - nomkl
   - python
-  - pint>=0.20.1
+  - pint>=0.20
   - pydantic>=1.8.2
   - dataclasses  # only for py36 and only b/c default channel pydantic missing the conditional dep
 

--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -7,7 +7,7 @@ dependencies:
   - networkx
   - pydantic
   - numpy
-  - pint
+  - pint>=0.20.1
   - pip
 
     # qc

--- a/devtools/conda-envs/docs-cf.yaml
+++ b/devtools/conda-envs/docs-cf.yaml
@@ -7,7 +7,7 @@ dependencies:
   - networkx
   - pydantic
   - numpy
-  - pint>=0.20.1
+  - pint>=0.20
   - pip
 
     # qc

--- a/devtools/conda-envs/minimal.yaml
+++ b/devtools/conda-envs/minimal.yaml
@@ -7,7 +7,7 @@ dependencies:
   - numpy=1.14  # technically, pint has an optional >=1.12.0 numpy dep but c-f doesn't have py38 builds for it
   - nomkl
   - python
-  - pint=0.10.0  # technically, qcel has no lower bound for pint version for py36,37 but needs 0.10 for 38
+  - pint>=0.20.1
   - pydantic=1.8.2
   - dataclasses  # until drop py36
 

--- a/devtools/conda-envs/minimal.yaml
+++ b/devtools/conda-envs/minimal.yaml
@@ -7,7 +7,7 @@ dependencies:
   - numpy=1.14  # technically, pint has an optional >=1.12.0 numpy dep but c-f doesn't have py38 builds for it
   - nomkl
   - python
-  - pint>=0.20.1
+  - pint>=0.20
   - pydantic=1.8.2
   - dataclasses  # until drop py36
 

--- a/qcelemental/physical_constants/context.py
+++ b/qcelemental/physical_constants/context.py
@@ -309,8 +309,6 @@ class PhysicalConstantsContext:
 
         # Add a little magic in case the incoming values have scalars
 
-        from pint import quantity
-
         factor = 1.0
 
         # First make sure we either have Units or Quantities
@@ -321,11 +319,11 @@ class PhysicalConstantsContext:
             conv_unit = self.ureg.parse_expression(conv_unit)
 
         # Need to play with prevector if we have Quantities
-        if isinstance(base_unit, quantity._Quantity):
+        if isinstance(base_unit, self.ureg.Quantity):
             factor *= base_unit.magnitude
             base_unit = base_unit.units
 
-        if isinstance(conv_unit, quantity._Quantity):
+        if isinstance(conv_unit, self.ureg.Quantity):
             factor /= conv_unit.magnitude
             conv_unit = conv_unit.units
 

--- a/qcelemental/physical_constants/context.py
+++ b/qcelemental/physical_constants/context.py
@@ -11,7 +11,8 @@ from ..datum import Datum, print_variables
 from .ureg import build_units_registry
 
 if TYPE_CHECKING:
-    from pint import UnitRegistry, quantity  # lgtm: [py/unused-import]
+    from pint import Quantity as _Quantity  # lgtm: [py/unused-import]
+    from pint import UnitRegistry
 
 
 class PhysicalConstantsContext:
@@ -269,15 +270,13 @@ class PhysicalConstantsContext:
     #       na                        'Avogadro constant'                         = 6.02214179E23        # Avogadro's number
     #       me                        'electron mass'                             = 9.10938215E-31       # Electron rest mass (in kg)
 
-    def Quantity(self, data: str) -> "quantity._Quantity":
+    def Quantity(self, data: str) -> "_Quantity":
         """Returns a Pint Quantity."""
 
         return self.ureg.Quantity(data)
 
     @lru_cache()
-    def conversion_factor(
-        self, base_unit: Union[str, "quantity._Quantity"], conv_unit: Union[str, "quantity._Quantity"]
-    ) -> float:
+    def conversion_factor(self, base_unit: Union[str, "_Quantity"], conv_unit: Union[str, "_Quantity"]) -> float:
         r"""Provides the conversion factor from one unit to another.
 
         The conversion factor is based on the current contexts CODATA.
@@ -309,6 +308,8 @@ class PhysicalConstantsContext:
 
         # Add a little magic in case the incoming values have scalars
 
+        from pint import Quantity as _Quantity
+
         factor = 1.0
 
         # First make sure we either have Units or Quantities
@@ -319,11 +320,11 @@ class PhysicalConstantsContext:
             conv_unit = self.ureg.parse_expression(conv_unit)
 
         # Need to play with prevector if we have Quantities
-        if isinstance(base_unit, self.ureg.Quantity):
+        if isinstance(base_unit, _Quantity):
             factor *= base_unit.magnitude
             base_unit = base_unit.units
 
-        if isinstance(conv_unit, self.ureg.Quantity):
+        if isinstance(conv_unit, _Quantity):
             factor /= conv_unit.magnitude
             conv_unit = conv_unit.units
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR attempts to update QCElemental to work with the newest version of Pint. Version 0.20.0 moved around a ton of stuff internally, although the only breakage here was the disappearance of an easily accessible `Quantity` class. Somewhat confusingly `type(Quantity)` returns something that does not obviously exist, but importing directly from the top-level namespace does work.

```python3
>>> import pint
>>> ureg = pint.UnitRegistry()
>>> type(ureg.Quantity("1 angstrom"))
<class 'pint.util.Quantity'>
>>> from pint.util import Quantity
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'Quantity' from 'pint.util' (/Users/mattthompson/mambaforge/envs/test/lib/python3.11/site-packages/pint/util.py)
>>> from pint import Quantity
>>> isinstance(ureg.Quantity("1 angstrom"), Quantity)
True
```

Prior to seeing a similar attempt from @loriab, I had this to say, which is not quite correct:
> I believe this comes from the code around [here](https://github.com/hgrecco/pint/blob/0.20/pint/util.py#L1024) - in any case one cannot simply import any sort of `Quantity` as it is no longer a standalone class but something that dangles off of the registry. Fortunately the change here appears to be simple - the internals were not reached into too deeply and the change to one bit of input sanitization didn't need information it didn't already have in scope.~~

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Update for compatibility with Pint 0.20.

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted - I'd be happy to move this to use https://pre-commit.ci/ so users never need to lint themselves
- [x] Ready to go
