### PR TITLE
noncontig passthrough

### DIFF
--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -341,14 +341,22 @@ class Molecule(ProtoModel):
             # original_keys = set(kwargs.keys())  # revive when ready to revisit sparsity
 
             nonphysical = kwargs.pop("nonphysical", False)
+            throw_reorder = not (kwargs.pop("allow_noncontiguous_but_reorder", False))  # experimental
             schema = to_schema(
-                from_schema(kwargs, nonphysical=nonphysical), dtype=kwargs["schema_version"], copy=False, np_out=True
+                from_schema(kwargs, nonphysical=nonphysical, throw_reorder=throw_reorder),
+                dtype=kwargs["schema_version"],
+                copy=False,
+                np_out=True,
             )
             schema = _filter_defaults(schema)
 
             kwargs["validated"] = True
             kwargs = {**kwargs, **schema}  # Allow any extra fields
             validate = True
+        else:
+            # these kwargs only relevant for validation
+            kwargs.pop("nonphysical", None)
+            kwargs.pop("allow_noncontiguous_but_reorder", None)
 
         super().__init__(**kwargs)
 

--- a/qcelemental/molparse/from_schema.py
+++ b/qcelemental/molparse/from_schema.py
@@ -7,7 +7,7 @@ from ..util import provenance_stamp
 from .from_arrays import from_arrays
 
 
-def from_schema(molschema: Dict, *, nonphysical: bool = False, verbose: int = 1) -> Dict:
+def from_schema(molschema: Dict, *, nonphysical: bool = False, throw_reorder: bool = True, verbose: int = 1) -> Dict:
     r"""Construct molecule dictionary representation from non-Psi4 schema.
 
     Parameters
@@ -16,6 +16,10 @@ def from_schema(molschema: Dict, *, nonphysical: bool = False, verbose: int = 1)
         Dictionary form of Molecule following known schema.
     nonphysical
         Do allow masses outside an element's natural range to pass validation?
+    throw_reorder
+        Do, when non-contiguous fragments detected, raise
+        ValidationError (``True``) or to proceed to reorder atoms to
+        contiguize fragments (``False``).
     verbose
         Amount of printing.
 
@@ -54,7 +58,7 @@ def from_schema(molschema: Dict, *, nonphysical: bool = False, verbose: int = 1)
         mass=ms.get("masses", None),
         real=ms.get("real", None),
         elbl=ms.get("atom_labels", None),
-        throw_reorder=True,
+        throw_reorder=throw_reorder,
     )
 
     molrec = from_arrays(

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -436,6 +436,38 @@ def test_charged_fragment():
 #    })
 
 
+@pytest.mark.parametrize(
+    "validate, allow_noncontiguous_but_reorder", [(True, True), (True, False), (False, True), (False, False)]
+)
+def test_noncontig(validate, allow_noncontiguous_but_reorder):
+    mol = {
+        "fragments": [[2, 0], [1]],
+        "geometry": np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 0.0]]),
+        "symbols": np.array(["Li", "H", "He"]),
+        "fragment_multiplicities": [4, 2],
+    }
+
+    if validate:
+        if allow_noncontiguous_but_reorder:
+            mol = Molecule(**mol, validate=validate, allow_noncontiguous_but_reorder=allow_noncontiguous_but_reorder)
+            assert compare(["He", "Li", "H"], mol.symbols)
+            assert compare([2, 3, 1], mol.atomic_numbers)
+            assert compare_values([[0, 0, 0], [0, 0, 1], [0, 0, 2]], mol.geometry)
+            assert compare([4, 2], mol.fragment_multiplicities)
+
+        else:
+            with pytest.raises(qcel.ValidationError) as e:
+                Molecule(**mol, validate=validate, allow_noncontiguous_but_reorder=allow_noncontiguous_but_reorder)
+                assert "QCElemental would need to reorder atoms to accommodate non-contiguous fragments" in str(e.value)
+
+    else:
+        mol = Molecule(**mol, validate=validate, allow_noncontiguous_but_reorder=allow_noncontiguous_but_reorder)
+        assert compare(["Li", "H", "He"], mol.symbols)
+        assert compare([3, 1, 2], mol.atomic_numbers)
+        assert compare_values([[0, 0, 1], [0, 0, 2], [0, 0, 0]], mol.geometry)
+        assert compare([4, 2], mol.fragment_multiplicities)
+
+
 @pytest.mark.parametrize("group_fragments, orient", [(True, True), (False, False)])  # original  # Psi4-like
 def test_get_fragment(group_fragments, orient):
     mol = Molecule(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Tentative allowing noncontiguous fragment _input_ in Molecule _with_ validation. Partially fixes #298.

Background is that Mol can store noncontig fragments. However, the internals that the validation step uses can't store them; it can either balk or reorder the atoms so the fragments are contiguous. This PR makes the latter option accessible through the Mol constructor.

This option should be used tentatively and with results checking at first. Note that identical atom ordering is not assured with `allow_noncontiguous_but_reorder=T` between `validate=T/F`. Those wanting validation _and_ atom order presevation may want to `Molecule(..., allow_noncontiguous_but_reorder=True)`, and if that passes, use the results from `mol = Molecule(..., validate=False)`.

This is not a permanent solution, and a future solution with some sort of `fix_order` (like `fix_com`; remember, "affix", not "correct") will use a different option, since reordering that is unnecessary for the schema spec is not good.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [ ] Ready to go
