### PR TITLE
Added empty dictionary for ComputeError extras default instead of None

### DIFF
--- a/qcelemental/models/common_models.py
+++ b/qcelemental/models/common_models.py
@@ -83,7 +83,7 @@ class ComputeError(ProtoModel):
         "information as well.",
     )
     extras: Optional[Dict[str, Any]] = Field(  # type: ignore
-        None,
+        {},
         description="Additional information to bundle with the error.",
     )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
As per previous discussion about `native_files` when we have empty fields that are `dict` objects we want their default value to be `{}` not `None`. `{}` evaluates falsey in python so it can still be treated as a "null object" and we remove needing to check the case of `None` for `.extras`. This makes coding easier because we can always do:

```python
compute_error.extras['hi'] = 'new value'
```

Instead of having to always check this first:

```python
if compute_error.extras is None:
    compute_error.extras = {"hi': 'new value}
else:
    compute_error.extras["hi'] =  'new value
```

## Changelog description
Change default value for `ComputeError.extra` from `None` to `{}`

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [ x] Code base linted
- [ x] Ready to go
