### PR TITLE
Use Pydantic v1 API even with pydantic v2

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.11"]
+        pydantic-version: ["1", "2"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -22,8 +23,12 @@ jobs:
         uses: actions/checkout@v3
       - name: Install poetry
         run: pip install poetry
-      - name: Install repo
+      - name: Install repo with Pydantic v2
         run: poetry install --no-interaction --no-ansi
+        if: ${{ matrix.pydantic-version == 2 }}
+      - name: Install repo with Pydantic v1
+        run: poetry install --no-interaction --no-ansi --without pydantic --with pydanticv1
+        if: ${{ matrix.pydantic-version == 1 }}
       - name: Run tests
         run: poetry run pytest -rws -v --cov=qcelemental --color=yes --cov-report=xml
       - name: Upload coverage to Codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,12 +31,22 @@ numpy = [
 ]
 python = "^3.7"
 pint = ">=0.10.0"
-pydantic = ">=1.8.2"
 nglview = { extras = ["viz"], version = "^3.0.3" }
 ipykernel = { version = "<6.0.0", extras = ["viz"] }
 importlib-metadata = { version = ">=4.8", python = "<3.8" }
 networkx = { version = "<3.0", extras = ["align"] }
 pytest = { extras = ["test"], version = "^7.2.2" }
+
+[tool.poetry.group.pydantic.dependencies]
+pydantic = "^2.0"
+
+[tool.poetry.group.pydanticv1]
+optional = true
+
+[tool.poetry.group.pydanticv1.dependencies]
+pydantic = "^1.8.2"
+
+
 
 
 [tool.poetry.group.dev.dependencies]

--- a/qcelemental/datum.py
+++ b/qcelemental/datum.py
@@ -6,7 +6,10 @@ from decimal import Decimal
 from typing import Any, Dict, Optional
 
 import numpy as np
-from pydantic import BaseModel, validator
+try:
+    from pydantic.v1 import BaseModel, validator
+except ImportError:  # Will also trap ModuleNotFoundError
+    from pydantic import BaseModel, validator
 
 
 class Datum(BaseModel):

--- a/qcelemental/info/cpu_info.py
+++ b/qcelemental/info/cpu_info.py
@@ -8,7 +8,10 @@ from enum import Enum
 from functools import lru_cache
 from typing import List, Optional
 
-from pydantic import Field
+try:
+    from pydantic.v1 import Field
+except ImportError:  # Will also trap ModuleNotFoundError
+    from pydantic import Field
 
 from ..models import ProtoModel
 

--- a/qcelemental/info/dft_info.py
+++ b/qcelemental/info/dft_info.py
@@ -4,7 +4,10 @@ Contains metadata about density functionals
 
 from typing import Dict
 
-from pydantic import Field
+try:
+    from pydantic.v1 import Field
+except ImportError:  # Will also trap ModuleNotFoundError
+    from pydantic import Field
 
 from ..models import ProtoModel
 

--- a/qcelemental/models/align.py
+++ b/qcelemental/models/align.py
@@ -1,7 +1,10 @@
 from typing import Optional
 
 import numpy as np
-from pydantic import Field, validator
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:  # Will also trap ModuleNotFoundError
+    from pydantic import Field, validator
 
 from ..util import blockwise_contract, blockwise_expand
 from .basemodels import ProtoModel

--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -3,8 +3,12 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Set, Union
 
 import numpy as np
-from pydantic import BaseSettings  # remove when QCFractal merges `next`
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+    from pydantic.v1 import BaseSettings  # remove when QCFractal merges `next`
+except ImportError:  # Will also trap ModuleNotFoundError
+    from pydantic import BaseSettings  # remove when QCFractal merges `next`
+    from pydantic import BaseModel
 
 from qcelemental.util import deserialize, serialize
 from qcelemental.util.autodocs import AutoPydanticDocGenerator  # remove when QCFractal merges `next`

--- a/qcelemental/models/basis.py
+++ b/qcelemental/models/basis.py
@@ -1,7 +1,10 @@
 from enum import Enum
 from typing import Dict, List, Optional
 
-from pydantic import ConstrainedInt, Field, constr, validator
+try:
+    from pydantic.v1 import ConstrainedInt, Field, constr, validator
+except ImportError:  # Will also trap ModuleNotFoundError
+    from pydantic import ConstrainedInt, Field, constr, validator
 
 from ..exceptions import ValidationError
 from .basemodels import ProtoModel, qcschema_draft

--- a/qcelemental/models/common_models.py
+++ b/qcelemental/models/common_models.py
@@ -2,13 +2,19 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import numpy as np
-from pydantic import Field
+try:
+    from pydantic.v1 import Field
+except ImportError:  # Will also trap ModuleNotFoundError
+    from pydantic import Field
 
 from .basemodels import ProtoModel, qcschema_draft
 from .basis import BasisSet
 
 if TYPE_CHECKING:
-    from pydantic.typing import ReprArgs
+    try:
+        from pydantic.v1.typing import ReprArgs
+    except ImportError:  # Will also trap ModuleNotFoundError
+        from pydantic.typing import ReprArgs
 
 
 # Encoders, to be deprecated

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -10,7 +10,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union, cast
 
 import numpy as np
-from pydantic import ConstrainedFloat, ConstrainedInt, Field, constr, validator
+try:
+    from pydantic.v1 import ConstrainedFloat, ConstrainedInt, Field, constr, validator
+except ImportError:  # Will also trap ModuleNotFoundError
+    from pydantic import ConstrainedFloat, ConstrainedInt, Field, constr, validator
 
 # molparse imports separated b/c https://github.com/python/mypy/issues/7203
 from ..molparse.from_arrays import from_arrays
@@ -27,7 +30,10 @@ from .common_models import Provenance, qcschema_molecule_default
 from .types import Array
 
 if TYPE_CHECKING:
-    from pydantic.typing import ReprArgs
+    try:
+        from pydantic.v1.typing import ReprArgs
+    except ImportError:  # Will also trap ModuleNotFoundError
+        from pydantic.typing import ReprArgs
 
 # Rounding quantities for hashing
 GEOMETRY_NOISE = 8

--- a/qcelemental/models/procedures.py
+++ b/qcelemental/models/procedures.py
@@ -1,7 +1,10 @@
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-from pydantic import Field, conlist, constr, validator
+try:
+    from pydantic.v1 import Field, conlist, constr, validator
+except ImportError:  # Will also trap ModuleNotFoundError
+    from pydantic import Field, conlist, constr, validator
 
 from ..util import provenance_stamp
 from .basemodels import ProtoModel
@@ -20,7 +23,10 @@ from .molecule import Molecule
 from .results import AtomicResult
 
 if TYPE_CHECKING:
-    from pydantic.typing import ReprArgs
+    try:
+        from pydantic.v1.typing import ReprArgs
+    except ImportError:  # Will also trap ModuleNotFoundError
+        from pydantic.typing import ReprArgs
 
 
 class TrajectoryProtocolEnum(str, Enum):

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -3,7 +3,10 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Union
 
 import numpy as np
-from pydantic import Field, constr, validator
+try:
+    from pydantic.v1 import Field, constr, validator
+except ImportError:  # Will also trap ModuleNotFoundError
+    from pydantic import Field, constr, validator
 
 from ..util import provenance_stamp
 from .basemodels import ProtoModel, qcschema_draft
@@ -13,7 +16,10 @@ from .molecule import Molecule
 from .types import Array
 
 if TYPE_CHECKING:
-    from pydantic.typing import ReprArgs
+    try:
+        from pydantic.v1.typing import ReprArgs
+    except ImportError:  # Will also trap ModuleNotFoundError
+        from pydantic.typing import ReprArgs
 
 
 class AtomicResultProperties(ProtoModel):

--- a/qcelemental/molutil/test_molutil.py
+++ b/qcelemental/molutil/test_molutil.py
@@ -2,7 +2,10 @@ import math
 import pprint
 
 import numpy as np
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:  # Will also trap ModuleNotFoundError
+    import pydantic
 import pytest
 
 import qcelemental as qcel

--- a/qcelemental/testing.py
+++ b/qcelemental/testing.py
@@ -5,7 +5,10 @@ import sys
 from typing import Callable, Dict, List, Tuple, Union
 
 import numpy as np
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:  # Will also trap ModuleNotFoundError
+    from pydantic import BaseModel
 
 from qcelemental.models.basemodels import ProtoModel
 

--- a/qcelemental/tests/test_datum.py
+++ b/qcelemental/tests/test_datum.py
@@ -1,7 +1,10 @@
 from decimal import Decimal
 
 import numpy as np
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:  # Will also trap ModuleNotFoundError
+    import pydantic
 import pytest
 
 import qcelemental as qcel

--- a/qcelemental/tests/test_molutil.py
+++ b/qcelemental/tests/test_molutil.py
@@ -2,7 +2,10 @@ import math
 import pprint
 
 import numpy as np
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:  # Will also trap ModuleNotFoundError
+    import pydantic
 import pytest
 
 import qcelemental as qcel

--- a/qcelemental/tests/test_utils.py
+++ b/qcelemental/tests/test_utils.py
@@ -2,7 +2,10 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pytest
-from pydantic import BaseModel, Field
+try:
+    from pydantic.v1 import BaseModel, Field
+except ImportError:  # Will also trap ModuleNotFoundError
+    from pydantic import BaseModel, Field
 
 import qcelemental as qcel
 from qcelemental.testing import compare_recursive, compare_values

--- a/qcelemental/util/autodocs.py
+++ b/qcelemental/util/autodocs.py
@@ -3,7 +3,10 @@ from enum import Enum, EnumMeta
 from textwrap import dedent, indent
 from typing import Any
 
-from pydantic import BaseModel, BaseSettings
+try:
+    from pydantic.v1 import BaseModel, BaseSettings
+except ImportError:  # Will also trap ModuleNotFoundError
+    from pydantic import BaseModel, BaseSettings
 
 __all__ = ["auto_gen_docs_on_demand", "get_base_docs", "AutoPydanticDocGenerator"]
 
@@ -36,7 +39,11 @@ def is_pydantic(test_object):
 
 
 def parse_type_str(prop) -> str:
-    from pydantic import fields  # Import here to minimize issues
+    # Import here to minimize issues
+    try:
+        from pydantic.v1 import fields
+    except ImportError:  # Will also trap ModuleNotFoundError
+        from pydantic import fields
 
     typing_map = {
         fields.SHAPE_TUPLE: "Tuple",

--- a/qcelemental/util/serialization.py
+++ b/qcelemental/util/serialization.py
@@ -2,7 +2,10 @@ import json
 from typing import Any, Union
 
 import numpy as np
-from pydantic.json import pydantic_encoder
+try:
+    from pydantic.v1.json import pydantic_encoder
+except ImportError:  # Will also trap ModuleNotFoundError
+    from pydantic.json import pydantic_encoder
 
 from .importing import which_import
 


### PR DESCRIPTION
## Description
This PR changes all imports to test against Pydantic v2 and then uses the v1 api if found. Precursor to future v2 migration.

Also updates the CI to test against both versions. Hopefully I figured out Poetry correctly.

## Changelog description
Compatibility with Pydantic v2 but use the v1 API as a stopgap for the version pin.

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
