### PR TITLE
Allow floating point numbers for multiplicities

### DIFF
--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -179,7 +179,7 @@ class Molecule(ProtoModel):
         description="Additional comments for this molecule. Intended for pure human/user consumption and clarity.",
     )
     molecular_charge: float = Field(0.0, description="The net electrostatic charge of the molecule.")  # type: ignore
-    molecular_multiplicity: int = Field(1, description="The total multiplicity of the molecule.")  # type: ignore
+    molecular_multiplicity: Union[int, float] = Field(1, description="The total multiplicity of the molecule.")  # type: ignore
 
     # Atom data
     masses_: Optional[Array[float]] = Field(  # type: ignore
@@ -251,7 +251,7 @@ class Molecule(ProtoModel):
         "if not provided (and :attr:`~qcelemental.models.Molecule.fragments` are specified).",
         shape=["nfr"],
     )
-    fragment_multiplicities_: Optional[List[int]] = Field(  # type: ignore
+    fragment_multiplicities_: Optional[List[Union[int, float]]] = Field(  # type: ignore
         None,
         description="The multiplicity of each fragment in the :attr:`~qcelemental.models.Molecule.fragments` list. The index of this "
         "list matches the 0-index indices of :attr:`~qcelemental.models.Molecule.fragments` list. Will be filled in based on a set of "
@@ -784,6 +784,12 @@ class Molecule(ProtoModel):
                 data = float_prep(data, CHARGE_NOISE)
             elif field == "molecular_charge":
                 data = float_prep(data, CHARGE_NOISE)
+            elif field == "fragment_multiplicities":
+                if any(isinstance(value, float) for value in data):
+                    data = float_prep(data, CHARGE_NOISE)
+            elif field == "molecular_multiplicity":
+                if isinstance(data, float):
+                    data = float_prep(data, CHARGE_NOISE)
             elif field == "masses":
                 data = float_prep(data, MASS_NOISE)
 

--- a/qcelemental/molparse/chgmult.py
+++ b/qcelemental/molparse/chgmult.py
@@ -101,6 +101,8 @@ def validate_and_fill_chgmult(
     ------
     qcelemental.ValidationError
         When no solution to input arguments subject to the constraints below can be found.
+    TypeError
+        When fractional multiplicity is provided.
 
     Notes
     -----
@@ -299,6 +301,19 @@ def validate_and_fill_chgmult(
     log_full = verbose >= 2
     log_brief = verbose >= 2  # TODO: Move back to 1
     text = []
+
+    def int_if_possible(val):
+        if isinstance(val, float) and val.is_integer():
+            return int(val)
+        else:
+            return val
+
+    molecular_multiplicity = int_if_possible(molecular_multiplicity)
+    fragment_multiplicities = [int_if_possible(m) for m in fragment_multiplicities]
+    if isinstance(molecular_multiplicity, float) or any(isinstance(m, float) for m in fragment_multiplicities):
+        raise TypeError(
+            f"validate_and_fill_chgmult() cannot handle fractional multiplicity. m: {molecular_multiplicity}, fm: {fragment_multiplicities}"
+        )
 
     felez = np.split(zeff, fragment_separators)
     nfr = len(felez)

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -734,3 +734,35 @@ def test_extras():
 
     mol = qcel.models.Molecule(symbols=["He"], geometry=[0, 0, 0], extras={"foo": "bar"})
     assert mol.extras["foo"] == "bar"
+
+
+@pytest.mark.parametrize(
+    "mult_in,mult_store,validate",
+    [
+        pytest.param(3, 3, False),
+        pytest.param(3, 3, True),
+        pytest.param(3.1, 3.1, False),
+        pytest.param(3.00001, 3.00001, False),
+        pytest.param(3.0, 3, False),
+        pytest.param(3.0, 3, True),
+        pytest.param(1, 1, False),
+        pytest.param(1, 1, True),
+        pytest.param(1.000000000000000000002, 1, False),
+        pytest.param(1.000000000000000000002, 1, True),
+        pytest.param(1.000000000000002, 1.000000000000002, False),
+        pytest.param(None, 1, False),
+        pytest.param(None, 1, True),
+    ],
+)
+def test_mol_multiplicity_types(mult_in, mult_store, validate):
+    # validate=False passes through pydantic validators. =True passes through molparse.
+    # fractional can only use =False route b/c molparse can't check the physics of chg/mult for float multiplicity.
+    if mult_in is None:
+        mol = qcel.models.Molecule(symbols=["He"], geometry=[0, 0, 0], validate=validate)
+    else:
+        mol = qcel.models.Molecule(
+            symbols=["He"], geometry=[0, 0, 0], validate=validate, molecular_multiplicity=mult_in
+        )
+
+    assert mult_store == mol.molecular_multiplicity
+    assert type(mult_store) is type(mol.molecular_multiplicity)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
Closes #317 

## Description
<!-- Provide a brief description of the PR's purpose here. -->
- make behavior consistent between molecular / fragment charges and molecular / fragment multiplicities

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
- allow floating point numbers for multiplicities

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
