### PR TITLE
Fix floating-point bug in `compute_angle`

### DIFF
--- a/qcelemental/util/misc.py
+++ b/qcelemental/util/misc.py
@@ -249,7 +249,7 @@ def compute_angle(points1, points2, points3, *, degrees: bool = False) -> np.nda
     v23 = points2 - points3
 
     denom = _norm(v12) * _norm(v23)
-    cosine_angle = np.einsum("ij,ij->i", v12, v23) / denom
+    cosine_angle = np.clip(np.einsum("ij,ij->i", v12, v23) / denom, -1, 1)
 
     angle = np.pi - np.arccos(cosine_angle)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Fixes the bug described in #324 by ensuring that the calculated cosine has a valid value between [-1, 1].

## Changelog description
Fixed a bug causing `qcel.util.measure_coordinates` to return `nan` values.

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [ ] Code base linted
- [x] Ready to go
