### PR TITLE
Add eigenvalues_and_occupations to wavefunction protocols

### DIFF
--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -507,6 +507,7 @@ class WavefunctionProtocolEnum(str, Enum):
 
     all = "all"
     orbitals_and_eigenvalues = "orbitals_and_eigenvalues"
+    eigenvalues_and_occupations = "eigenvalues_and_occupations"
     return_results = "return_results"
     none = "none"
 
@@ -702,6 +703,8 @@ class AtomicResult(AtomicInput):
             ]
         elif wfnp == "orbitals_and_eigenvalues":
             return_keep = ["orbitals_a", "orbitals_b", "eigenvalues_a", "eigenvalues_b"]
+        elif wfnp == "eigenvalues_and_occupations":
+            return_keep = ["eigenvalues_a", "eigenvalues_b", "occupations_a", "occupations_b"]
         else:
             raise ValueError(f"Protocol `wavefunction:{wfnp}` is not understood.")
 

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -307,6 +307,18 @@ def test_wavefunction_return_result_pointer(wavefunction_data_fixture):
             ["orbitals_a", "eigenvalues_a"],
         ),
         ("return_results", True, ["orbitals_a", "fock_a", "fock_b"], ["orbitals_a", "fock_a"]),
+        (
+            "eigenvalues_and_occupations",
+            True,
+            ["orbitals_a", "orbitals_b", "occupations_a", "occupations_b", "eigenvalues_a", "eigenvalues_b"],
+            ["occupations_a", "eigenvalues_a"],
+        ),
+        (
+            "eigenvalues_and_occupations",
+            False,
+            ["orbitals_a", "orbitals_b", "occupations_a", "occupations_b", "eigenvalues_a", "eigenvalues_b"],
+            ["occupations_a", "occupations_b", "eigenvalues_a", "eigenvalues_b"],
+        ),
     ],
 )
 def test_wavefunction_protocols(protocol, restricted, provided, expected, wavefunction_data_fixture, request):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
Adds the ability to save only eigenvalues and occupations. Tests have been added.

Background: We need to obtain/store orbital energies for millions of molecules, and we can't afford to also store orbitals for all of them :)

No need to modify QCEngine as the stripping of fields is done in QCElemental.

## Changelog description
Add `eigenvalues_and_occupations` as an option to WavefunctionProtocols

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
