### PR TITLE
further which patching for py312

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-.. X.Y.0 / 2023-MM-DD
+.. X.Y.0 / 2023-MM-DD (Unreleased)
 .. -------------------
 ..
 .. Breaking Changes
@@ -18,6 +18,15 @@ Changelog
 ..
 .. Misc.
 .. +++++
+
+
+0.27.1 / 2023-10-26 (Unreleased)
+-------------------
+
+Bug Fixes
++++++++++
+- (:pr:`329`) Continues :pr:`328` adding ``util.which`` workaround for only python v3.12.0 and psi4
+  (can be expanded) to correctly select among cmd, cmd.bat, cmd.exe.
 
 
 0.27.0 / 2023-10-24

--- a/qcelemental/util/importing.py
+++ b/qcelemental/util/importing.py
@@ -104,9 +104,9 @@ def which(
     if sys.platform == "win32" and sys.version_info >= (3, 12, 0) and sys.version_info < (3, 12, 1):
         # https://github.com/python/cpython/issues/109590
         if command == "psi4":
-            ans = shutil.which("psi4.bat", mode=os.F_OK | os.X_OK, path=lenv["PATH"])
+            ans = shutil.which("psi4.exe", mode=os.F_OK | os.X_OK, path=lenv["PATH"])
             if ans is None:
-                ans = shutil.which("psi4.exe", mode=os.F_OK | os.X_OK, path=lenv["PATH"])
+                ans = shutil.which("psi4.bat", mode=os.F_OK | os.X_OK, path=lenv["PATH"])
 
     # secondary check, see https://github.com/MolSSI/QCEngine/issues/292
     local_raise_msg = ""

--- a/qcelemental/util/importing.py
+++ b/qcelemental/util/importing.py
@@ -99,12 +99,14 @@ def which(
         lenv = {"PATH": os.pathsep.join([os.path.abspath(x) for x in env.split(os.pathsep) if x != ""])}
     lenv = {k: v for k, v in lenv.items() if v is not None}
 
+    ans = shutil.which(command, mode=os.F_OK | os.X_OK, path=lenv["PATH"])
+
     if sys.platform == "win32" and sys.version_info >= (3, 12, 0) and sys.version_info < (3, 12, 1):
         # https://github.com/python/cpython/issues/109590
         if command == "psi4":
-            command = "psi4.bat"
-
-    ans = shutil.which(command, mode=os.F_OK | os.X_OK, path=lenv["PATH"])
+            ans = shutil.which("psi4.bat", mode=os.F_OK | os.X_OK, path=lenv["PATH"])
+            if ans is None:
+                ans = shutil.which("psi4.exe", mode=os.F_OK | os.X_OK, path=lenv["PATH"])
 
     # secondary check, see https://github.com/MolSSI/QCEngine/issues/292
     local_raise_msg = ""


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Continues #328 `which`+py312+windows handling, now preferring `.exe` over `.bat`. Tested at qcng.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
