### PR TITLE
Use newer pint version for Python >=3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ numpy = [
     { version = ">=1.26.1", python = ">=3.9,<3.13" },
 ]
 python = "^3.7"
-pint =[
-    { version = ">=0.10", python = "3.8" },
+pint = [
+    { version = ">=0.10", python = ">=3.7,<3.9" },
     { version = ">=0.21", python = ">=3.9,<3.13" },
 ]
 pydantic = ">=1.8.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,10 @@ numpy = [
     { version = ">=1.26.1", python = ">=3.9,<3.13" },
 ]
 python = "^3.7"
-pint = ">=0.10.0"
+pint =[
+    { version = ">=0.10", python = "3.8" },
+    { version = ">=0.21", python = ">=3.9,<3.13" },
+]
 pydantic = ">=1.8.2"
 nglview = { version = "^3.0.3", optional = true }
 ipykernel = { version = "<6.0.0", optional = true }


### PR DESCRIPTION
Pint  >= 0.10 fails for newer numpy versions, in particular >= 1.25.

This change bumps up the version requirements for Pint in cases where we are using newer numpy.

## Description
See https://github.com/MolSSI/QCElemental/issues/334 

## Changelog description
Use newer pint version for Python >=3.9

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
