### PR TITLE
literal schema_name

### DIFF
--- a/qcelemental/models/procedures.py
+++ b/qcelemental/models/procedures.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
 
 try:
     from pydantic.v1 import Field, conlist, constr, validator
@@ -58,7 +58,7 @@ class QCInputSpecification(ProtoModel):
     A compute description for energy, gradient, and Hessian computations used in a geometry optimization.
     """
 
-    schema_name: constr(strip_whitespace=True, regex=qcschema_input_default) = qcschema_input_default  # type: ignore
+    schema_name: Literal["qcschema_input"] = Field(qcschema_input_default)
     schema_version: int = 1
 
     driver: DriverEnum = Field(DriverEnum.gradient, description=str(DriverEnum.__doc__))

--- a/qcelemental/models/procedures.py
+++ b/qcelemental/models/procedures.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
 try:
     from typing import Literal
 except ImportError:

--- a/qcelemental/models/procedures.py
+++ b/qcelemental/models/procedures.py
@@ -1,5 +1,10 @@
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+try:
+    from typing import Literal
+except ImportError:
+    # remove when minimum py38
+    from typing_extensions import Literal
 
 try:
     from pydantic.v1 import Field, conlist, constr, validator

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from functools import partial
-from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Set, Union
 
 import numpy as np
 
@@ -609,7 +609,7 @@ class AtomicInput(ProtoModel):
 class AtomicResult(AtomicInput):
     r"""Results from a CMS program execution."""
 
-    schema_name: constr(strip_whitespace=True, regex="^(qc_?schema_output)$") = Field(  # type: ignore
+    schema_name: Literal["qcschema_output"] = Field(
         qcschema_output_default,
         description=(
             f"The QCSchema specification this model conforms to. Explicitly fixed as {qcschema_output_default}."

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -1,6 +1,11 @@
 from enum import Enum
 from functools import partial
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Union
+try:
+    from typing import Literal
+except ImportError:
+    # remove when minimum py38
+    from typing_extensions import Literal
 
 import numpy as np
 

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Union
+
 try:
     from typing import Literal
 except ImportError:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Changelog description
* Solidifies the `schema_name`s for `QCInputSpecification` and `AtomicResult` into `Literal`s where previously they had been regex strings coerced into a single name (name unchanged). The literals are for the benefit of `GeneralizedOptimizationInput`/`Result` in QCManyBody, which is a generalization of Opt so that it can hold either a single-point gradient or a more complicated gradient specification. To discriminate between the two types, pydantic needs a `Literal`.

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
