### PR TITLE
Add dependency on `packaging` for version parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ numpy = [
     { version = ">=1.26.1,<2.0", python = ">=3.9,<3.10" },
     { version = ">=1.26.1", python = ">=3.9,<3.13" },
 ]
+packaging = [
+    { version = ">=24.0", python = ">=3.7,<3.8" },
+    { version = ">=24.1", python = ">=3.8" },
+]
 # qcel is compatible with most any numpy, v1 or v2, but numpy v2 only works with pint >=0.24, which is only available for py >=3.10
 python = "^3.7"
 pint = [

--- a/qcelemental/tests/test_importing.py
+++ b/qcelemental/tests/test_importing.py
@@ -147,3 +147,13 @@ def test_which_f_raisemsg():
         qcel.util.which("evills", raise_error=True, raise_msg="Install `evills`.")
 
     assert str(e.value).endswith("Command 'evills' not found in envvar PATH. Install `evills`.")
+
+
+def test_parse_version():
+    v = qcel.util.parse_version("5.3.1")
+    assert str(v) == "5.3.1"
+
+
+def test_safe_version():
+    v = qcel.util.safe_version("5.3.1")
+    assert v == "5.3.1"

--- a/qcelemental/util/importing.py
+++ b/qcelemental/util/importing.py
@@ -1,7 +1,10 @@
 import os
 import shutil
 import sys
-from typing import List, Union
+from typing import TYPE_CHECKING, List, Union
+
+if TYPE_CHECKING:
+    from packaging.version import Version
 
 
 def which_import(
@@ -127,20 +130,17 @@ def which(
         return ans
 
 
-def safe_version(*args, **kwargs) -> str:
+def safe_version(version) -> str:
     """
     Package resources is a very slow load
     """
-    import pkg_resources
-
-    version = pkg_resources.safe_version(*args, **kwargs)
-    return version
+    return str(parse_version(version))
 
 
-def parse_version(*args, **kwargs):
+def parse_version(version) -> "Version":
     """
     Package resources is a very slow load
     """
-    import pkg_resources
+    from packaging.version import parse
 
-    return pkg_resources.parse_version(*args, **kwargs)
+    return parse(version)


### PR DESCRIPTION
## Description
Running
```bash
python -m venv ./venv
source ./venv/bin/activate
python -m pip install -e .
```
inside of QCEngine, followed by
```python
"""qcengine_example.py: Example of running a Q-Chem calculation through QCEngine."""

import qcengine as qcng
import qcelemental as qcel

mol = qcel.models.Molecule.from_data("""
O  0.0  0.000  -0.129
H  0.0 -1.494  1.027
H  0.0  1.494  1.027
""")

inp = qcel.models.AtomicInput(
    molecule=mol,
    driver="energy",
    model={"method": "hf", "basis": "sto-3g"},
)
ret = qcng.compute(
    inp,
    "qchem",
    local_options={"ncores": 1},
)

with open("qcengine_example.json", "w", encoding="utf-8") as handle:
    handle.write(ret.json())
```
produces an output with the error
```
QCEngine Execution Error:
Traceback (most recent call last):
  File "/home/eric/development/forks/MolSSI/QCEngine/qcengine/util.py", line 117, in compute_wrapper
    yield metadata
  File "/home/eric/development/forks/MolSSI/QCEngine/qcengine/compute.py", line 108, in compute
    output_data = executor.compute(input_data, config)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/eric/development/forks/MolSSI/QCEngine/qcen
gine/programs/qchem.py", line 106, in compute
    if parse_version(self.get_version()) < parse_version(qceng_ver):
                     ^^^^^^^^^^^^^^^^^^
  File "/home/eric/development/forks/MolSSI/QCEngine/qcengine/programs/qchem.py", line 89, in get_version
    self.version_cache[which_prog] = safe_version(mobj.group(1))
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/eric/development/forks/MolSSI/QCEngine/venv/lib/python3.12/site
-packages/qcelemental/util/importing.py", line 134, in safe_version
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```
which means setuptools needs to be a runtime dependency.  This bit of setuptools has been transitioned to `packaging` long ago and isn't even the build backend for qcel.

QCEngine tests against NWChem look clean.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Use `packaging` instead of `setuptools` to provide version parsing

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
