### PR TITLE
add hashes and rearrange mult handling

### DIFF
--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -419,6 +419,8 @@ class Molecule(ProtoModel):
                 raise ValueError(
                     "Fragment Multiplicities must be same number of entries as Fragments"
                 )
+        if any([m<1.0 for m in v]):
+            raise ValueError(f"Fragment Multiplicity must be positive: {v}")
         return v
 
     @validator("molecular_multiplicity")

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -401,14 +401,32 @@ class Molecule(ProtoModel):
             v = np.array([True for _ in range(n)])
         return v
 
-    @validator("fragment_charges_", "fragment_multiplicities_")
+    @validator("fragment_charges_")
     def _must_be_n_frag(cls, v, values, **kwargs):
         if "fragments_" in values and values["fragments_"] is not None:
             n = len(values["fragments_"])
             if len(v) != n:
                 raise ValueError(
-                    "Fragment Charges and Fragment Multiplicities must be same number of entries as Fragments"
+                    "Fragment Charges must be same number of entries as Fragments"
                 )
+        return v
+
+    @validator("fragment_multiplicities_")
+    def _must_be_n_frag_mult(cls, v, values, **kwargs):
+        if "fragments_" in values and values["fragments_"] is not None:
+            n = len(values["fragments_"])
+            if len(v) != n:
+                raise ValueError(
+                    "Fragment Multiplicities must be same number of entries as Fragments"
+                )
+        return v
+
+    @validator("molecular_multiplicity")
+    def _int_if_possible(cls, v, values, **kwargs):
+        if v < 1.0:
+            raise ValueError(
+                "Molecular Multiplicity must be positive"
+            )
         return v
 
     @property

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -406,9 +406,7 @@ class Molecule(ProtoModel):
         if "fragments_" in values and values["fragments_"] is not None:
             n = len(values["fragments_"])
             if len(v) != n:
-                raise ValueError(
-                    "Fragment Charges must be same number of entries as Fragments"
-                )
+                raise ValueError("Fragment Charges must be same number of entries as Fragments")
         return v
 
     @validator("fragment_multiplicities_")
@@ -416,19 +414,15 @@ class Molecule(ProtoModel):
         if "fragments_" in values and values["fragments_"] is not None:
             n = len(values["fragments_"])
             if len(v) != n:
-                raise ValueError(
-                    "Fragment Multiplicities must be same number of entries as Fragments"
-                )
-        if any([m<1.0 for m in v]):
+                raise ValueError("Fragment Multiplicities must be same number of entries as Fragments")
+        if any([m < 1.0 for m in v]):
             raise ValueError(f"Fragment Multiplicity must be positive: {v}")
         return v
 
     @validator("molecular_multiplicity")
     def _int_if_possible(cls, v, values, **kwargs):
         if v < 1.0:
-            raise ValueError(
-                "Molecular Multiplicity must be positive"
-            )
+            raise ValueError("Molecular Multiplicity must be positive")
         return v
 
     @property

--- a/qcelemental/molparse/chgmult.py
+++ b/qcelemental/molparse/chgmult.py
@@ -300,6 +300,19 @@ def validate_and_fill_chgmult(
     log_brief = verbose >= 2  # TODO: Move back to 1
     text = []
 
+    def int_if_possible(val):
+        if isinstance(val, float) and val.is_integer():
+            return int(val)
+        else:
+            return val
+
+    molecular_multiplicity = int_if_possible(molecular_multiplicity)
+    fragment_multiplicities = [int_if_possible(m) for m in fragment_multiplicities]
+    if (molecular_multiplicity and molecular_multiplicity < 1.0) or any(m < 1.0 for m in fragment_multiplicities if m):
+        raise ValidationError(
+            f"validate_and_fill_chgmult(): Multiplicity must be positive. m: {molecular_multiplicity}, fm: {fragment_multiplicities}"
+        )
+
     felez = np.split(zeff, fragment_separators)
     nfr = len(felez)
     if log_full:

--- a/qcelemental/molparse/from_arrays.py
+++ b/qcelemental/molparse/from_arrays.py
@@ -759,7 +759,9 @@ def validate_and_fill_fragments(nat, fragment_separators=None, fragment_charges=
             try:
                 frm = [(f if f is None else float(f)) for f in fragment_multiplicities]
             except TypeError:
-                raise ValidationError("""fragment_multiplicities not among None or float: {}""".format(fragment_charges))
+                raise ValidationError(
+                    """fragment_multiplicities not among None or float: {}""".format(fragment_charges)
+                )
 
     if not (len(frc) == len(frm) == len(frs) + 1):
         raise ValidationError(

--- a/qcelemental/molparse/from_arrays.py
+++ b/qcelemental/molparse/from_arrays.py
@@ -753,12 +753,13 @@ def validate_and_fill_fragments(nat, fragment_separators=None, fragment_charges=
 
         if fragment_multiplicities is None:
             frm = [None] * nfr
-        elif all(f is None or (isinstance(f, (int, np.integer)) and f >= 1) for f in fragment_multiplicities):
-            frm = fragment_multiplicities
         else:
-            raise ValidationError(
-                """fragment_multiplicities not among None or positive integer: {}""".format(fragment_multiplicities)
-            )
+            # positive-ness checks and integer-if-possible casting now deferred to validate_and_fill_chgmult()
+            #   to match molecular_multiplicities handling
+            try:
+                frm = [(f if f is None else float(f)) for f in fragment_multiplicities]
+            except TypeError:
+                raise ValidationError("""fragment_multiplicities not among None or float: {}""".format(fragment_charges))
 
     if not (len(frc) == len(frm) == len(frs) + 1):
         raise ValidationError(

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -771,14 +771,16 @@ _ref_mol_multiplicity_hash = {
         pytest.param(1, 1, True, "singlet"),
         pytest.param(None, 1, False, "singlet"),
         pytest.param(None, 1, True, "singlet"),
+        # fmt: off
         pytest.param(3., 3, False, "triplet"),
         pytest.param(3., 3, True, "triplet"),
+        # fmt: on
     ],
 )
 def test_mol_multiplicity_types(mult_in, mult_store, validate, exp_hash):
     # validate=False passes through pydantic validators. =True passes through molparse.
 
-    mol_args = {"symbols":["He"], "geometry":[0, 0, 0], "validate":validate}
+    mol_args = {"symbols": ["He"], "geometry": [0, 0, 0], "validate": validate}
     if mult_in is not None:
         mol_args["molecular_multiplicity"] = mult_in
 
@@ -797,7 +799,7 @@ def test_mol_multiplicity_types(mult_in, mult_store, validate, exp_hash):
     ],
 )
 def test_mol_multiplicity_types_errors(mult_in, validate, error):
-    mol_args = {"symbols":["He"], "geometry":[0, 0, 0], "validate":validate}
+    mol_args = {"symbols": ["He"], "geometry": [0, 0, 0], "validate": validate}
     if mult_in is not None:
         mol_args["molecular_multiplicity"] = mult_in
 
@@ -816,8 +818,10 @@ def test_mol_multiplicity_types_errors(mult_in, validate, error):
         #   simply gets cast to int with no error. This will change soon. The validate=True throws a
         #   irreconcilable error.
         pytest.param(5, [3.1, 3.4], [3, 3], False, "ditriplet"),
+        # fmt: off
         pytest.param(5, [3.0, 3.], [3, 3], False, "ditriplet"),
         pytest.param(5, [3.0, 3.], [3, 3], True, "ditriplet"),
+        # fmt: on
         pytest.param(1, [1, 1], [1, 1], False, "disinglet"),
         pytest.param(1, [1, 1], [1, 1], True, "disinglet"),
         # None in frag_mult not allowed for validate=False
@@ -827,10 +831,17 @@ def test_mol_multiplicity_types_errors(mult_in, validate, error):
 def test_frag_multiplicity_types(mol_mult_in, mult_in, mult_store, validate, exp_hash):
     # validate=False passes through pydantic validators. =True passes through molparse.
 
-    mol_args = {"symbols":["He", "Ne"], "geometry":[0, 0, 0, 2, 0, 0], "fragments":[[0], [1]], "validate":validate,
+    mol_args = {
+        "symbols": ["He", "Ne"],
+        "geometry": [0, 0, 0, 2, 0, 0],
+        "fragments": [[0], [1]],
+        "validate": validate,
         # below three passed in so hashes match btwn validate=T/F. otherwise, validate=False never
         #   populates these fields
-        "molecular_charge": 0, "fragment_charges": [0,0], "molecular_multiplicity": mol_mult_in}
+        "molecular_charge": 0,
+        "fragment_charges": [0, 0],
+        "molecular_multiplicity": mol_mult_in,
+    }
     if mult_in is not None:
         mol_args["fragment_multiplicities"] = mult_in
 
@@ -849,7 +860,7 @@ def test_frag_multiplicity_types(mol_mult_in, mult_in, mult_store, validate, exp
     ],
 )
 def test_frag_multiplicity_types_errors(mult_in, validate, error):
-    mol_args = {"symbols":["He", "Ne"], "geometry":[0, 0, 0, 2, 0, 0], "fragments":[[0], [1]], "validate":validate}
+    mol_args = {"symbols": ["He", "Ne"], "geometry": [0, 0, 0, 2, 0, 0], "fragments": [[0], [1]], "validate": validate}
     if mult_in is not None:
         mol_args["fragment_multiplicities"] = mult_in
 

--- a/qcelemental/tests/test_molparse_from_string.py
+++ b/qcelemental/tests/test_molparse_from_string.py
@@ -1666,7 +1666,8 @@ def test_badmult_error():
             variables=[("bond", "3")],
         )
 
-    assert "fragment_multiplicities not among None or positive integer" in str(e.value)
+    # formerly: assert "fragment_multiplicities not among None or positive integer" in str(e.value)
+    assert "Multiplicity must be positive" in str(e.value)
 
 
 def test_badchg_error():

--- a/qcelemental/tests/test_molparse_validate_and_fill_chgmult.py
+++ b/qcelemental/tests/test_molparse_validate_and_fill_chgmult.py
@@ -8,85 +8,85 @@ from qcelemental.testing import compare
 
 
 working_chgmults = [
-        (("He", 0, [0], 1, [1]), (0, [0], 1, [1]), "b3855c64"),  # 1
-        (("He", None, [None], None, [None]), (0, [0], 1, [1]), "b3855c64"),  # 2
-        (("He/He", None, [None, None], None, [None, None]), (0, [0, 0], 1, [1, 1]), "ad36285a"),  # 3
-        (("He/He", 2, [None, None], None, [None, None]), (2, [2, 0], 1, [1, 1]), "bfdcbd63"),  # 4
-        (("He/He", None, [2, None], None, [None, None]), (2, [2, 0], 1, [1, 1]), "bfdcbd63"),  # 5
-        (("He/He", 0, [2, None], None, [None, None]), (0, [2, -2], 1, [1, 1]), "e7141038"),  # 6
-        (("Ne/He/He", -2, [None, 2, None], None, [None, None, None]), (-2, [-4, 2, 0], 1, [1, 1, 1]), "35a61864"),  # 7
-        (("Ne/He/He", 2, [None, -2, None], None, [None, None, None]), (2, [4, -2, 0], 1, [1, 1, 1]), "cd3a0ecd"),  # 8
-        (("He/He/Ne", 2, [None, -2, None], None, [None, None, None]), (2, [0, -2, 4], 1, [1, 1, 1]), "e3ca63c8"),  # 9
-        (("He/He/Ne", 2, [2, -2, None], None, [None, None, None]), (2, [2, -2, 2], 1, [1, 1, 1]), "8d70c7ec"),  # 11
-        (("He/He", None, [-2, 2], None, [None, None]), (0, [-2, 2], 1, [1, 1]), "cf3e8c41"),  # 12
-        (("He/He", None, [None, -2], None, [None, None]), (-2, [0, -2], 1, [1, 1]), "9cd54b37"),  # 13
-        (("Ne/Ne", 0, [None, 4], None, [None, None]), (0, [-4, 4], 1, [1, 1]), "752ec2fe"),  # 14
-        (("He/He/He", 4, [2, None, None], None, [None, None, None]), (4, [2, 2, 0], 1, [1, 1, 1]), "cc52833f"),  # 15
-        (("He/He", 0, [-2, 2], None, [None, None]), (0, [-2, 2], 1, [1, 1]), "cf3e8c41"),  # 16
-        (("He", None, [None], None, [1]), (0, [0], 1, [1]), "b3855c64"),  # 19
-        (("He", None, [None], None, [3]), (0, [0], 3, [3]), "7caca87a"),  # 21
-        (("He", None, [-1], None, [2]), (-1, [-1], 2, [2]), "e5f7b504"),  # 23
-        (("He/He", None, [None, None], None, [1, 1]), (0, [0, 0], 1, [1, 1]), "ad36285a"),  # 25
-        (("He/He", None, [None, None], None, [3, 1]), (0, [0, 0], 3, [3, 1]), "3fa264e9"),  # 26
-        (("He/He", None, [None, None], None, [1, 3]), (0, [0, 0], 3, [1, 3]), "516f623a"),  # 27
-        (("He/He", None, [None, None], None, [3, 3]), (0, [0, 0], 5, [3, 3]), "0f1a1ffc"),  # 28
-        (("He/He", None, [None, None], 3, [3, 3]), (0, [0, 0], 3, [3, 3]), "9eb13213"),  # 29
-        (("H", None, [None], None, [None]), (0, [0], 2, [2]), "512c204f"),  # 31
-        (("H", 1, [None], None, [None]), (1, [1], 1, [1]), "74aba942"),  # 32
-        (("H", None, [-1], None, [None]), (-1, [-1], 1, [1]), "809afce3"),  # 33
-        (("funnyH", None, [None], None, [None]), (0, [0], 1, [1]), "f91e3c77"),  # 34
-        (("H/H", None, [None, None], None, [None, None]), (0, [0, 0], 3, [2, 2]), "dc9720af"),  # 36
-        (("H/He", None, [None, None], None, [None, None]), (0, [0, 0], 2, [2, 1]), "9445d8b9"),  # 37
-        (("H/He", None, [1, 1], None, [None, None]), (2, [1, 1], 2, [1, 2]), "dfcb8940"),  # 38
-        (("H/He", -2, [-1, None], None, [None, None]), (-2, [-1, -1], 2, [1, 2]), "e9b8fe09"),  # 39
-        (
-            ("H/He/Na/Ne", None, [1, None, 1, None], None, [None, None, None, None]),
-            (2, [1, 0, 1, 0], 1, [1, 1, 1, 1]),
-"59c6613a",
-        ),  # 40
-        (
-            ("H/He/Na/Ne", None, [-1, None, 1, None], None, [None, None, None, None]),
-            (0, [-1, 0, 1, 0], 1, [1, 1, 1, 1]),
-"ccd5e698",
-        ),  # 41
-        (
-            ("H/He/Na/Ne", 2, [None, None, 1, None], None, [None, None, None, None]),
-            (2, [1, 0, 1, 0], 1, [1, 1, 1, 1]),
-"59c6613a",
-        ),  # 42
-        (
-            ("H/He/Na/Ne", 3, [None, None, 1, None], None, [None, None, None, None]),
-            (3, [0, 2, 1, 0], 2, [2, 1, 1, 1]),
-"ac9200ac",
-        ),  # 43
-        (
-            ("H/He/Na/Ne", None, [None, 1, 0, 1], None, [None, None, None, None]),
-            (2, [0, 1, 0, 1], 5, [2, 2, 2, 2]),
-"3a2ba1ea",
-        ),  # 47
-        (
-            ("H/He/Na/Ne", None, [None, 1, 0, None], None, [None, None, None, None]),
-            (1, [0, 1, 0, 0], 4, [2, 2, 2, 1]),
-"f4a99eac",
-        ),  # 48
-        (
-            ("H/He/Na/Ne", None, [None, 1, 0, None], None, [None, None, 4, None]),
-            (1, [0, 1, 0, 0], 6, [2, 2, 4, 1]),
-"cb147b67",
-        ),  # 49
-        (("He/He/He", 0, [None, None, 1], None, [1, None, 2]), (0, [0, -1, 1], 3, [1, 2, 2]), "7140d169"),  # 50
-        (("N/N/N", None, [1, 1, 1], 3, [None, 3, None]), (3, [1, 1, 1], 3, [1, 3, 1]), "b381f350"),  # 51
-        (("N/N/N", None, [1, 1, 1], 3, [None, None, None]), (3, [1, 1, 1], 3, [3, 1, 1]), "2d17a8fd"),  # 52
-        (("N/N/N", 1, [None, -1, None], 3, [None, None, 2]), (1, [2, -1, 0], 3, [2, 1, 2]), "b3e87763"),  # 54
-        (("N/Ne/N", 1, [None, None, None], 4, [None, 3, None]), (1, [1, 0, 0], 4, [1, 3, 2]), "38a20a23"),  # 55
-        (("N/Ne/N", 1, [None, None, None], 4.0, [None, 3.0, None]), (1, [1, 0, 0], 4, [1, 3, 2]), "38a20a23"),  # 55b
-        (("N/Ne/N", None, [None, None, 1], 4, [None, 3, None]), (1, [0, 0, 1], 4, [2, 3, 1]), "28064e3e"),  # 56
-        (("He/He", None, [-1, 1], None, [None, None]), (0, [-1, 1], 3, [2, 2]), "83330b29"),  # 57
-        (("He/Gh", None, [2, None], None, [None, None], {"verbose": 2}), (2, [2, 0], 1, [1, 1]), "dfc621eb"),  # 61
-        (("Gh/He/Ne", 2, [None, -2, None], None, [None, None, None]), (2, [0, -2, 4], 1, [1, 1, 1]), "c828e6fd"),  # 63
-        (("Gh/He/Gh", 1, [None, None, None], None, [None, None, None]), (1, [0, 1, 0], 2, [1, 2, 1]), "54238534"),  # 64
-        (("Ne/Ne", 2, [-2, None], None, [None, None]), (2, [-2, 4], 1, [1, 1]), "ffe022cd"),  # 65a
-        (("Gh/Ne", 2, [-2, None], None, [None, None], {"zero_ghost_fragments": True}), (0, [0, 0], 1, [1, 1]), ""),  # 65c
+    (("He", 0, [0], 1, [1]), (0, [0], 1, [1]), "b3855c64"),  # 1
+    (("He", None, [None], None, [None]), (0, [0], 1, [1]), "b3855c64"),  # 2
+    (("He/He", None, [None, None], None, [None, None]), (0, [0, 0], 1, [1, 1]), "ad36285a"),  # 3
+    (("He/He", 2, [None, None], None, [None, None]), (2, [2, 0], 1, [1, 1]), "bfdcbd63"),  # 4
+    (("He/He", None, [2, None], None, [None, None]), (2, [2, 0], 1, [1, 1]), "bfdcbd63"),  # 5
+    (("He/He", 0, [2, None], None, [None, None]), (0, [2, -2], 1, [1, 1]), "e7141038"),  # 6
+    (("Ne/He/He", -2, [None, 2, None], None, [None, None, None]), (-2, [-4, 2, 0], 1, [1, 1, 1]), "35a61864"),  # 7
+    (("Ne/He/He", 2, [None, -2, None], None, [None, None, None]), (2, [4, -2, 0], 1, [1, 1, 1]), "cd3a0ecd"),  # 8
+    (("He/He/Ne", 2, [None, -2, None], None, [None, None, None]), (2, [0, -2, 4], 1, [1, 1, 1]), "e3ca63c8"),  # 9
+    (("He/He/Ne", 2, [2, -2, None], None, [None, None, None]), (2, [2, -2, 2], 1, [1, 1, 1]), "8d70c7ec"),  # 11
+    (("He/He", None, [-2, 2], None, [None, None]), (0, [-2, 2], 1, [1, 1]), "cf3e8c41"),  # 12
+    (("He/He", None, [None, -2], None, [None, None]), (-2, [0, -2], 1, [1, 1]), "9cd54b37"),  # 13
+    (("Ne/Ne", 0, [None, 4], None, [None, None]), (0, [-4, 4], 1, [1, 1]), "752ec2fe"),  # 14
+    (("He/He/He", 4, [2, None, None], None, [None, None, None]), (4, [2, 2, 0], 1, [1, 1, 1]), "cc52833f"),  # 15
+    (("He/He", 0, [-2, 2], None, [None, None]), (0, [-2, 2], 1, [1, 1]), "cf3e8c41"),  # 16
+    (("He", None, [None], None, [1]), (0, [0], 1, [1]), "b3855c64"),  # 19
+    (("He", None, [None], None, [3]), (0, [0], 3, [3]), "7caca87a"),  # 21
+    (("He", None, [-1], None, [2]), (-1, [-1], 2, [2]), "e5f7b504"),  # 23
+    (("He/He", None, [None, None], None, [1, 1]), (0, [0, 0], 1, [1, 1]), "ad36285a"),  # 25
+    (("He/He", None, [None, None], None, [3, 1]), (0, [0, 0], 3, [3, 1]), "3fa264e9"),  # 26
+    (("He/He", None, [None, None], None, [1, 3]), (0, [0, 0], 3, [1, 3]), "516f623a"),  # 27
+    (("He/He", None, [None, None], None, [3, 3]), (0, [0, 0], 5, [3, 3]), "0f1a1ffc"),  # 28
+    (("He/He", None, [None, None], 3, [3, 3]), (0, [0, 0], 3, [3, 3]), "9eb13213"),  # 29
+    (("H", None, [None], None, [None]), (0, [0], 2, [2]), "512c204f"),  # 31
+    (("H", 1, [None], None, [None]), (1, [1], 1, [1]), "74aba942"),  # 32
+    (("H", None, [-1], None, [None]), (-1, [-1], 1, [1]), "809afce3"),  # 33
+    (("funnyH", None, [None], None, [None]), (0, [0], 1, [1]), "f91e3c77"),  # 34
+    (("H/H", None, [None, None], None, [None, None]), (0, [0, 0], 3, [2, 2]), "dc9720af"),  # 36
+    (("H/He", None, [None, None], None, [None, None]), (0, [0, 0], 2, [2, 1]), "9445d8b9"),  # 37
+    (("H/He", None, [1, 1], None, [None, None]), (2, [1, 1], 2, [1, 2]), "dfcb8940"),  # 38
+    (("H/He", -2, [-1, None], None, [None, None]), (-2, [-1, -1], 2, [1, 2]), "e9b8fe09"),  # 39
+    (
+        ("H/He/Na/Ne", None, [1, None, 1, None], None, [None, None, None, None]),
+        (2, [1, 0, 1, 0], 1, [1, 1, 1, 1]),
+        "59c6613a",
+    ),  # 40
+    (
+        ("H/He/Na/Ne", None, [-1, None, 1, None], None, [None, None, None, None]),
+        (0, [-1, 0, 1, 0], 1, [1, 1, 1, 1]),
+        "ccd5e698",
+    ),  # 41
+    (
+        ("H/He/Na/Ne", 2, [None, None, 1, None], None, [None, None, None, None]),
+        (2, [1, 0, 1, 0], 1, [1, 1, 1, 1]),
+        "59c6613a",
+    ),  # 42
+    (
+        ("H/He/Na/Ne", 3, [None, None, 1, None], None, [None, None, None, None]),
+        (3, [0, 2, 1, 0], 2, [2, 1, 1, 1]),
+        "ac9200ac",
+    ),  # 43
+    (
+        ("H/He/Na/Ne", None, [None, 1, 0, 1], None, [None, None, None, None]),
+        (2, [0, 1, 0, 1], 5, [2, 2, 2, 2]),
+        "3a2ba1ea",
+    ),  # 47
+    (
+        ("H/He/Na/Ne", None, [None, 1, 0, None], None, [None, None, None, None]),
+        (1, [0, 1, 0, 0], 4, [2, 2, 2, 1]),
+        "f4a99eac",
+    ),  # 48
+    (
+        ("H/He/Na/Ne", None, [None, 1, 0, None], None, [None, None, 4, None]),
+        (1, [0, 1, 0, 0], 6, [2, 2, 4, 1]),
+        "cb147b67",
+    ),  # 49
+    (("He/He/He", 0, [None, None, 1], None, [1, None, 2]), (0, [0, -1, 1], 3, [1, 2, 2]), "7140d169"),  # 50
+    (("N/N/N", None, [1, 1, 1], 3, [None, 3, None]), (3, [1, 1, 1], 3, [1, 3, 1]), "b381f350"),  # 51
+    (("N/N/N", None, [1, 1, 1], 3, [None, None, None]), (3, [1, 1, 1], 3, [3, 1, 1]), "2d17a8fd"),  # 52
+    (("N/N/N", 1, [None, -1, None], 3, [None, None, 2]), (1, [2, -1, 0], 3, [2, 1, 2]), "b3e87763"),  # 54
+    (("N/Ne/N", 1, [None, None, None], 4, [None, 3, None]), (1, [1, 0, 0], 4, [1, 3, 2]), "38a20a23"),  # 55
+    (("N/Ne/N", 1, [None, None, None], 4.0, [None, 3.0, None]), (1, [1, 0, 0], 4, [1, 3, 2]), "38a20a23"),  # 55b
+    (("N/Ne/N", None, [None, None, 1], 4, [None, 3, None]), (1, [0, 0, 1], 4, [2, 3, 1]), "28064e3e"),  # 56
+    (("He/He", None, [-1, 1], None, [None, None]), (0, [-1, 1], 3, [2, 2]), "83330b29"),  # 57
+    (("He/Gh", None, [2, None], None, [None, None], {"verbose": 2}), (2, [2, 0], 1, [1, 1]), "dfc621eb"),  # 61
+    (("Gh/He/Ne", 2, [None, -2, None], None, [None, None, None]), (2, [0, -2, 4], 1, [1, 1, 1]), "c828e6fd"),  # 63
+    (("Gh/He/Gh", 1, [None, None, None], None, [None, None, None]), (1, [0, 1, 0], 2, [1, 2, 1]), "54238534"),  # 64
+    (("Ne/Ne", 2, [-2, None], None, [None, None]), (2, [-2, 4], 1, [1, 1]), "ffe022cd"),  # 65a
+    (("Gh/Ne", 2, [-2, None], None, [None, None], {"zero_ghost_fragments": True}), (0, [0, 0], 1, [1, 1]), ""),  # 65c
 ]
 
 
@@ -166,6 +166,7 @@ def test_validate_and_fill_chgmult_irreconcilable(systemtranslator, inp):
 # 35 - insufficient electrons
 # 55 - both (1, (1, 0.0, 0.0), 4, (1, 3, 2)) and (1, (0.0, 0.0, 1), 4, (2, 3, 1)) plausible
 # 65 - non-0/1 on Gh fragment errors normally but reset by zero_ghost_fragments
+
 
 @pytest.fixture
 def systemtranslator():

--- a/qcelemental/tests/test_molparse_validate_and_fill_chgmult.py
+++ b/qcelemental/tests/test_molparse_validate_and_fill_chgmult.py
@@ -7,88 +7,123 @@ from qcelemental.testing import compare
 # (system-shorthand, tot-chg, frag-chg, tot-mult, frag-mult), (expected_final_tot-chg, frag-chg, tot-mult, frag-mult)
 
 
-@pytest.mark.parametrize(
-    "inp,expected",
-    [
-        (("He", 0, [0], 1, [1]), (0, [0], 1, [1])),  # 1
-        (("He", None, [None], None, [None]), (0, [0], 1, [1])),  # 2
-        (("He/He", None, [None, None], None, [None, None]), (0, [0, 0], 1, [1, 1])),  # 3
-        (("He/He", 2, [None, None], None, [None, None]), (2, [2, 0], 1, [1, 1])),  # 4
-        (("He/He", None, [2, None], None, [None, None]), (2, [2, 0], 1, [1, 1])),  # 5
-        (("He/He", 0, [2, None], None, [None, None]), (0, [2, -2], 1, [1, 1])),  # 6
-        (("Ne/He/He", -2, [None, 2, None], None, [None, None, None]), (-2, [-4, 2, 0], 1, [1, 1, 1])),  # 7
-        (("Ne/He/He", 2, [None, -2, None], None, [None, None, None]), (2, [4, -2, 0], 1, [1, 1, 1])),  # 8
-        (("He/He/Ne", 2, [None, -2, None], None, [None, None, None]), (2, [0, -2, 4], 1, [1, 1, 1])),  # 9
-        (("He/He/Ne", 2, [2, -2, None], None, [None, None, None]), (2, [2, -2, 2], 1, [1, 1, 1])),  # 11
-        (("He/He", None, [-2, 2], None, [None, None]), (0, [-2, 2], 1, [1, 1])),  # 12
-        (("He/He", None, [None, -2], None, [None, None]), (-2, [0, -2], 1, [1, 1])),  # 13
-        (("Ne/Ne", 0, [None, 4], None, [None, None]), (0, [-4, 4], 1, [1, 1])),  # 14
-        (("He/He/He", 4, [2, None, None], None, [None, None, None]), (4, [2, 2, 0], 1, [1, 1, 1])),  # 15
-        (("He/He", 0, [-2, 2], None, [None, None]), (0, [-2, 2], 1, [1, 1])),  # 16
-        (("He", None, [None], None, [1]), (0, [0], 1, [1])),  # 19
-        (("He", None, [None], None, [3]), (0, [0], 3, [3])),  # 21
-        (("He", None, [-1], None, [2]), (-1, [-1], 2, [2])),  # 23
-        (("He/He", None, [None, None], None, [1, 1]), (0, [0, 0], 1, [1, 1])),  # 25
-        (("He/He", None, [None, None], None, [3, 1]), (0, [0, 0], 3, [3, 1])),  # 26
-        (("He/He", None, [None, None], None, [1, 3]), (0, [0, 0], 3, [1, 3])),  # 27
-        (("He/He", None, [None, None], None, [3, 3]), (0, [0, 0], 5, [3, 3])),  # 28
-        (("He/He", None, [None, None], 3, [3, 3]), (0, [0, 0], 3, [3, 3])),  # 29
-        (("H", None, [None], None, [None]), (0, [0], 2, [2])),  # 31
-        (("H", 1, [None], None, [None]), (1, [1], 1, [1])),  # 32
-        (("H", None, [-1], None, [None]), (-1, [-1], 1, [1])),  # 33
-        (("funnyH", None, [None], None, [None]), (0, [0], 1, [1])),  # 34
-        (("H/H", None, [None, None], None, [None, None]), (0, [0, 0], 3, [2, 2])),  # 36
-        (("H/He", None, [None, None], None, [None, None]), (0, [0, 0], 2, [2, 1])),  # 37
-        (("H/He", None, [1, 1], None, [None, None]), (2, [1, 1], 2, [1, 2])),  # 38
-        (("H/He", -2, [-1, None], None, [None, None]), (-2, [-1, -1], 2, [1, 2])),  # 39
+working_chgmults = [
+        (("He", 0, [0], 1, [1]), (0, [0], 1, [1]), "b3855c64"),  # 1
+        (("He", None, [None], None, [None]), (0, [0], 1, [1]), "b3855c64"),  # 2
+        (("He/He", None, [None, None], None, [None, None]), (0, [0, 0], 1, [1, 1]), "ad36285a"),  # 3
+        (("He/He", 2, [None, None], None, [None, None]), (2, [2, 0], 1, [1, 1]), "bfdcbd63"),  # 4
+        (("He/He", None, [2, None], None, [None, None]), (2, [2, 0], 1, [1, 1]), "bfdcbd63"),  # 5
+        (("He/He", 0, [2, None], None, [None, None]), (0, [2, -2], 1, [1, 1]), "e7141038"),  # 6
+        (("Ne/He/He", -2, [None, 2, None], None, [None, None, None]), (-2, [-4, 2, 0], 1, [1, 1, 1]), "35a61864"),  # 7
+        (("Ne/He/He", 2, [None, -2, None], None, [None, None, None]), (2, [4, -2, 0], 1, [1, 1, 1]), "cd3a0ecd"),  # 8
+        (("He/He/Ne", 2, [None, -2, None], None, [None, None, None]), (2, [0, -2, 4], 1, [1, 1, 1]), "e3ca63c8"),  # 9
+        (("He/He/Ne", 2, [2, -2, None], None, [None, None, None]), (2, [2, -2, 2], 1, [1, 1, 1]), "8d70c7ec"),  # 11
+        (("He/He", None, [-2, 2], None, [None, None]), (0, [-2, 2], 1, [1, 1]), "cf3e8c41"),  # 12
+        (("He/He", None, [None, -2], None, [None, None]), (-2, [0, -2], 1, [1, 1]), "9cd54b37"),  # 13
+        (("Ne/Ne", 0, [None, 4], None, [None, None]), (0, [-4, 4], 1, [1, 1]), "752ec2fe"),  # 14
+        (("He/He/He", 4, [2, None, None], None, [None, None, None]), (4, [2, 2, 0], 1, [1, 1, 1]), "cc52833f"),  # 15
+        (("He/He", 0, [-2, 2], None, [None, None]), (0, [-2, 2], 1, [1, 1]), "cf3e8c41"),  # 16
+        (("He", None, [None], None, [1]), (0, [0], 1, [1]), "b3855c64"),  # 19
+        (("He", None, [None], None, [3]), (0, [0], 3, [3]), "7caca87a"),  # 21
+        (("He", None, [-1], None, [2]), (-1, [-1], 2, [2]), "e5f7b504"),  # 23
+        (("He/He", None, [None, None], None, [1, 1]), (0, [0, 0], 1, [1, 1]), "ad36285a"),  # 25
+        (("He/He", None, [None, None], None, [3, 1]), (0, [0, 0], 3, [3, 1]), "3fa264e9"),  # 26
+        (("He/He", None, [None, None], None, [1, 3]), (0, [0, 0], 3, [1, 3]), "516f623a"),  # 27
+        (("He/He", None, [None, None], None, [3, 3]), (0, [0, 0], 5, [3, 3]), "0f1a1ffc"),  # 28
+        (("He/He", None, [None, None], 3, [3, 3]), (0, [0, 0], 3, [3, 3]), "9eb13213"),  # 29
+        (("H", None, [None], None, [None]), (0, [0], 2, [2]), "512c204f"),  # 31
+        (("H", 1, [None], None, [None]), (1, [1], 1, [1]), "74aba942"),  # 32
+        (("H", None, [-1], None, [None]), (-1, [-1], 1, [1]), "809afce3"),  # 33
+        (("funnyH", None, [None], None, [None]), (0, [0], 1, [1]), "f91e3c77"),  # 34
+        (("H/H", None, [None, None], None, [None, None]), (0, [0, 0], 3, [2, 2]), "dc9720af"),  # 36
+        (("H/He", None, [None, None], None, [None, None]), (0, [0, 0], 2, [2, 1]), "9445d8b9"),  # 37
+        (("H/He", None, [1, 1], None, [None, None]), (2, [1, 1], 2, [1, 2]), "dfcb8940"),  # 38
+        (("H/He", -2, [-1, None], None, [None, None]), (-2, [-1, -1], 2, [1, 2]), "e9b8fe09"),  # 39
         (
             ("H/He/Na/Ne", None, [1, None, 1, None], None, [None, None, None, None]),
             (2, [1, 0, 1, 0], 1, [1, 1, 1, 1]),
+"59c6613a",
         ),  # 40
         (
             ("H/He/Na/Ne", None, [-1, None, 1, None], None, [None, None, None, None]),
             (0, [-1, 0, 1, 0], 1, [1, 1, 1, 1]),
+"ccd5e698",
         ),  # 41
         (
             ("H/He/Na/Ne", 2, [None, None, 1, None], None, [None, None, None, None]),
             (2, [1, 0, 1, 0], 1, [1, 1, 1, 1]),
+"59c6613a",
         ),  # 42
         (
             ("H/He/Na/Ne", 3, [None, None, 1, None], None, [None, None, None, None]),
             (3, [0, 2, 1, 0], 2, [2, 1, 1, 1]),
+"ac9200ac",
         ),  # 43
         (
             ("H/He/Na/Ne", None, [None, 1, 0, 1], None, [None, None, None, None]),
             (2, [0, 1, 0, 1], 5, [2, 2, 2, 2]),
+"3a2ba1ea",
         ),  # 47
         (
             ("H/He/Na/Ne", None, [None, 1, 0, None], None, [None, None, None, None]),
             (1, [0, 1, 0, 0], 4, [2, 2, 2, 1]),
+"f4a99eac",
         ),  # 48
         (
             ("H/He/Na/Ne", None, [None, 1, 0, None], None, [None, None, 4, None]),
             (1, [0, 1, 0, 0], 6, [2, 2, 4, 1]),
+"cb147b67",
         ),  # 49
-        (("He/He/He", 0, [None, None, 1], None, [1, None, 2]), (0, [0, -1, 1], 3, [1, 2, 2])),  # 50
-        (("N/N/N", None, [1, 1, 1], 3, [None, 3, None]), (3, [1, 1, 1], 3, [1, 3, 1])),  # 51
-        (("N/N/N", None, [1, 1, 1], 3, [None, None, None]), (3, [1, 1, 1], 3, [3, 1, 1])),  # 52
-        (("N/N/N", 1, [None, -1, None], 3, [None, None, 2]), (1, [2, -1, 0], 3, [2, 1, 2])),  # 54
-        (("N/Ne/N", 1, [None, None, None], 4, [None, 3, None]), (1, [1, 0, 0], 4, [1, 3, 2])),  # 55
-        (("N/Ne/N", None, [None, None, 1], 4, [None, 3, None]), (1, [0, 0, 1], 4, [2, 3, 1])),  # 56
-        (("He/He", None, [-1, 1], None, [None, None]), (0, [-1, 1], 3, [2, 2])),  # 57
-        (("He/Gh", None, [2, None], None, [None, None], {"verbose": 2}), (2, [2, 0], 1, [1, 1])),  # 61
-        (("Gh/He/Ne", 2, [None, -2, None], None, [None, None, None]), (2, [0, -2, 4], 1, [1, 1, 1])),  # 63
-        (("Gh/He/Gh", 1, [None, None, None], None, [None, None, None]), (1, [0, 1, 0], 2, [1, 2, 1])),  # 64
-        (("Ne/Ne", 2, [-2, None], None, [None, None]), (2, [-2, 4], 1, [1, 1])),  # 65a
-        (("Gh/Ne", 2, [-2, None], None, [None, None], {"zero_ghost_fragments": True}), (0, [0, 0], 1, [1, 1])),  # 65c
-    ],
-)
-def test_validate_and_fill_chgmult(inp, expected):
-    system = _systemtranslator[inp[0]]
+        (("He/He/He", 0, [None, None, 1], None, [1, None, 2]), (0, [0, -1, 1], 3, [1, 2, 2]), "7140d169"),  # 50
+        (("N/N/N", None, [1, 1, 1], 3, [None, 3, None]), (3, [1, 1, 1], 3, [1, 3, 1]), "b381f350"),  # 51
+        (("N/N/N", None, [1, 1, 1], 3, [None, None, None]), (3, [1, 1, 1], 3, [3, 1, 1]), "2d17a8fd"),  # 52
+        (("N/N/N", 1, [None, -1, None], 3, [None, None, 2]), (1, [2, -1, 0], 3, [2, 1, 2]), "b3e87763"),  # 54
+        (("N/Ne/N", 1, [None, None, None], 4, [None, 3, None]), (1, [1, 0, 0], 4, [1, 3, 2]), "38a20a23"),  # 55
+        (("N/Ne/N", 1, [None, None, None], 4.0, [None, 3.0, None]), (1, [1, 0, 0], 4, [1, 3, 2]), "38a20a23"),  # 55b
+        (("N/Ne/N", None, [None, None, 1], 4, [None, 3, None]), (1, [0, 0, 1], 4, [2, 3, 1]), "28064e3e"),  # 56
+        (("He/He", None, [-1, 1], None, [None, None]), (0, [-1, 1], 3, [2, 2]), "83330b29"),  # 57
+        (("He/Gh", None, [2, None], None, [None, None], {"verbose": 2}), (2, [2, 0], 1, [1, 1]), "dfc621eb"),  # 61
+        (("Gh/He/Ne", 2, [None, -2, None], None, [None, None, None]), (2, [0, -2, 4], 1, [1, 1, 1]), "c828e6fd"),  # 63
+        (("Gh/He/Gh", 1, [None, None, None], None, [None, None, None]), (1, [0, 1, 0], 2, [1, 2, 1]), "54238534"),  # 64
+        (("Ne/Ne", 2, [-2, None], None, [None, None]), (2, [-2, 4], 1, [1, 1]), "ffe022cd"),  # 65a
+        (("Gh/Ne", 2, [-2, None], None, [None, None], {"zero_ghost_fragments": True}), (0, [0, 0], 1, [1, 1]), ""),  # 65c
+]
+
+
+@pytest.mark.parametrize("inp,expected,exp_hash", working_chgmults)
+def test_validate_and_fill_chgmult(systemtranslator, inp, expected, exp_hash):
+    system = systemtranslator[inp[0]]
     kwargs = inp[5] if len(inp) > 5 else {}
+    _keys = ["molecular_charge", "fragment_charges", "molecular_multiplicity", "fragment_multiplicities"]
 
     ans = qcelemental.molparse.validate_and_fill_chgmult(system[0], system[1], inp[1], inp[2], inp[3], inp[4], **kwargs)
     assert compare(1, ans == dict(zip(_keys, expected)), """{}: {}, {}, {}, {} --> {}""".format(*inp, expected))
+
+
+@pytest.mark.parametrize("inp,expected,exp_hash", working_chgmults)
+def test_validate_and_fill_chgmult_mol_model(systemtranslator, inp, expected, exp_hash):
+    symbols, sep = systemtranslator[inp[0]]
+    kwargs = inp[5] if len(inp) > 5 else {}
+    if "zero_ghost_fragments" in kwargs:
+        pytest.skip()
+
+    def none_y(inp):
+        return (inp is None) or (isinstance(inp, list) and (all(x is None for x in inp)))
+
+    _keys = ["molecular_charge", "fragment_charges", "molecular_multiplicity", "fragment_multiplicities"]
+    input_chgmults = {k: v for k, v in zip(_keys, inp[1:]) if not none_y(v)}
+    nat = len(symbols)
+    geometry = [[iat * 2.0, 0.0, 0.0] for iat in range(nat)]
+    fidx = np.split(np.arange(nat), sep)
+    fragments = [fr.tolist() for fr in fidx]
+
+    mol = qcelemental.models.Molecule(symbols=symbols, geometry=geometry, fragments=fragments, **input_chgmults)
+
+    assert mol.molecular_charge == expected[0]
+    assert mol.fragment_charges == expected[1]
+    assert mol.molecular_multiplicity == expected[2]
+    assert mol.fragment_multiplicities == expected[3]
+    assert mol.get_hash()[:8] == exp_hash
 
 
 @pytest.mark.parametrize(
@@ -113,8 +148,8 @@ def test_validate_and_fill_chgmult(inp, expected):
         ("Gh/Ne", 2, [-2, None], None, [None, None]),  # 65b
     ],
 )
-def test_validate_and_fill_chgmult_irreconcilable(inp):
-    system = _systemtranslator[inp[0]]
+def test_validate_and_fill_chgmult_irreconcilable(systemtranslator, inp):
+    system = systemtranslator[inp[0]]
 
     with pytest.raises(qcelemental.ValidationError):
         qcelemental.molparse.validate_and_fill_chgmult(system[0], system[1], inp[1], inp[2], inp[3], inp[4], verbose=0)
@@ -132,26 +167,27 @@ def test_validate_and_fill_chgmult_irreconcilable(inp):
 # 55 - both (1, (1, 0.0, 0.0), 4, (1, 3, 2)) and (1, (0.0, 0.0, 1), 4, (2, 3, 1)) plausible
 # 65 - non-0/1 on Gh fragment errors normally but reset by zero_ghost_fragments
 
-_keys = ["molecular_charge", "fragment_charges", "molecular_multiplicity", "fragment_multiplicities"]
-_systemtranslator = {
-    "He": (np.array([2]), np.array([])),
-    "He/He": (np.array([2, 2]), np.array([1])),
-    "Ne/He/He": (np.array([10, 2, 2]), np.array([1, 2])),
-    "He/He/Ne": (np.array([2, 2, 10]), np.array([1, 2])),
-    "Ne/Ne": (np.array([10, 10]), np.array([1])),
-    "He/He/He": (np.array([2, 2, 2]), np.array([1, 2])),
-    "H": (np.array([1]), np.array([])),
-    "funnyH": (np.array([0]), np.array([])),  # has no electrons
-    "funnierH": (np.array([-1]), np.array([])),  # has positron
-    "H/H": (np.array([1, 1]), np.array([1])),
-    "H/He": (np.array([1, 2]), np.array([1])),
-    "H/He/Na/Ne": (np.array([1, 2, 11, 10]), np.array([1, 2, 3])),
-    "N/N/N": (np.array([7, 7, 7]), np.array([1, 2])),
-    "N/Ne/N": (np.array([7, 10, 7]), np.array([1, 2])),
-    "He/Gh": (np.array([2, 0]), np.array([1])),
-    "Gh/He": (np.array([0, 2]), np.array([1])),
-    "Gh": (np.array([0, 0]), np.array([])),
-    "Gh/He/Ne": (np.array([0, 0, 2, 10]), np.array([2, 3])),
-    "Gh/He/Gh": (np.array([0, 2, 0]), np.array([1, 2])),
-    "Gh/Ne": (np.array([0, 10]), np.array([1])),
-}
+@pytest.fixture
+def systemtranslator():
+    return {
+        "He": (np.array([2]), np.array([])),
+        "He/He": (np.array([2, 2]), np.array([1])),
+        "Ne/He/He": (np.array([10, 2, 2]), np.array([1, 2])),
+        "He/He/Ne": (np.array([2, 2, 10]), np.array([1, 2])),
+        "Ne/Ne": (np.array([10, 10]), np.array([1])),
+        "He/He/He": (np.array([2, 2, 2]), np.array([1, 2])),
+        "H": (np.array([1]), np.array([])),
+        "funnyH": (np.array([0]), np.array([])),  # has no electrons
+        "funnierH": (np.array([-1]), np.array([])),  # has positron
+        "H/H": (np.array([1, 1]), np.array([1])),
+        "H/He": (np.array([1, 2]), np.array([1])),
+        "H/He/Na/Ne": (np.array([1, 2, 11, 10]), np.array([1, 2, 3])),
+        "N/N/N": (np.array([7, 7, 7]), np.array([1, 2])),
+        "N/Ne/N": (np.array([7, 10, 7]), np.array([1, 2])),
+        "He/Gh": (np.array([2, 0]), np.array([1])),
+        "Gh/He": (np.array([0, 2]), np.array([1])),
+        "Gh": (np.array([0, 0]), np.array([])),
+        "Gh/He/Ne": (np.array([0, 0, 2, 10]), np.array([2, 3])),
+        "Gh/He/Gh": (np.array([0, 2, 0]), np.array([1, 2])),
+        "Gh/Ne": (np.array([0, 10]), np.array([1])),
+    }

--- a/qcelemental/tests/test_molparse_validate_and_fill_chgmult.py
+++ b/qcelemental/tests/test_molparse_validate_and_fill_chgmult.py
@@ -87,6 +87,13 @@ working_chgmults = [
     (("Gh/He/Gh", 1, [None, None, None], None, [None, None, None]), (1, [0, 1, 0], 2, [1, 2, 1]), "54238534"),  # 64
     (("Ne/Ne", 2, [-2, None], None, [None, None]), (2, [-2, 4], 1, [1, 1]), "ffe022cd"),  # 65a
     (("Gh/Ne", 2, [-2, None], None, [None, None], {"zero_ghost_fragments": True}), (0, [0, 0], 1, [1, 1]), ""),  # 65c
+    (("Ne/Ne", None, [-2.1, 2.1], None, [None, None]), (0, [-2.1, 2.1], 1, [1, 1]), "684cec20"),  # 112
+    (("N/N/N", 3.3, [1, None, 1], 3, [None, 3, None]), (3.3, [1, 3.3 - 2, 1], 3, [1, 3, 1]), "7a5fd2d3"),  # 151
+    (
+        ("N/N/N", -2.4, [None, None, None], None, [None, None, None], {"verbose": 2}),
+        (-2.4, [-2.4, 0, 0], 3, [1, 2, 2]),
+        "a83a3356",
+    ),  # 166
 ]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
This PR is preparatory to #318.

- [x] NEW: adds a check to the basic Molecule pydantic model so multiplicities <1 get caught. This route is accessed when `Molecule(..., validate=False)`. I believe this is a universally good check, but it is a new restriction. Any weird positron, fractional electron, etc. reason to not catch less-than-one mult?
- [x] add many hash checks (incl. all the chgmult variations in `validate_and_fill_chgmult` testing) to molecules, so we'll know if code starts changing the hash and thereby disrupting the QCA server.
- [x] `qcel.molparse` has a different error message for less-than-one `fragment_multiplicities` you try to put through it. `qcel.molparse` is accessed whenever `Molecule(...)` or `Molecule(..., validate=True)` is called.
- [x] `qcel.molparse` newly allows floats that are ints (e.g., `1.0`) for multiplicity. previously it would raise an error about not being an int.
- [x] `qcel.molparse` newly has a dedicated error for any less-than-one `molecular_multiplicity` you try to put through it. Previously it raised the usual "Inconsistent" error.
- [x] more tests that chgmult are processing as expected, including some with fractional _charges_ (https://github.com/MolSSI/QCElemental/pull/343/files#diff-29ef453faf072f4ee853122f0f64f6ba594c00dc44599a1f5138946619d9951fR90-R96) for the first time.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
