### PR TITLE
Csse pyd2 model convert classes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,8 +35,9 @@ New Features
 
 Enhancements
 ++++++++++++
+* ``v2.FailedOperation`` field `id` is becoming `Optional[str]` instead of plain `str` so that the default validates.
 * v1.ProtoModel learned `model_copy`, `model_dump`, `model_dump_json` methods (all w/o warnings) so downstream can unify on newer syntax. Levi's work alternately/additionally taught v2 `copy`, `dict`, `json` (all w/warning) but dict has an alternate use in Pydantic v2.
-* ``AtomicInput`` and ``AtomicResult`` ``OptimizationInput``, ``OptimizationResult``, ``TorsionDriveInput``, ``TorsionDriveResult`` (both versions) learned a ``.convert_v(ver)`` function that returns self or the other version.
+* ``AtomicInput`` and ``AtomicResult`` ``OptimizationInput``, ``OptimizationResult``, ``TorsionDriveInput``, ``TorsionDriveResult``, ``FailedOperation`` (both versions) learned a ``.convert_v(ver)`` function that returns self or the other version.
 * The ``models.v2`` ``AtomicInput``, ``AtomicResult``, ``AtomicResultProperties`` ``OptimizationInput``, ``OptimizationResult``, ``TorsionDriveInput``, ``TorsionDriveResult`` had their `schema_version` changed to a Literal[2] and validated so new instances will be 2, even if another value passed in.
 * The ``models.v1`` ``AtomicInput``, ``AtomicResult``, ``OptimizationInput``, ``OptimizationResult``, ``TorsionDriveInput``, ``TorsionDriveResult`` had their `schema_version` changed to a Literal[1] and validated so new instances will be 1, even if another value passed in.
 * The ``models.v1`` and ``models.v2`` ``OptimizationResult`` given schema_version for the first time.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,10 @@ New Features
 
 Enhancements
 ++++++++++++
+* ``AtomicInput`` and ``AtomicResult`` ``OptimizationInput``, ``OptimizationResult``, ``TorsionDriveInput``, ``TorsionDriveResult`` (both versions) learned a ``.convert_v(ver)`` function that returns self or the other version.
+* The ``models.v2`` ``AtomicInput``, ``AtomicResult``, ``AtomicResultProperties`` ``OptimizationInput``, ``OptimizationResult``, ``TorsionDriveInput``, ``TorsionDriveResult`` had their `schema_version` changed to a Literal[2] and validated so new instances will be 2, even if another value passed in.
+* The ``models.v1`` ``AtomicInput``, ``AtomicResult``, ``OptimizationInput``, ``OptimizationResult``, ``TorsionDriveInput``, ``TorsionDriveResult`` had their `schema_version` changed to a Literal[1] and validated so new instances will be 1, even if another value passed in.
+* The ``models.v1`` and ``models.v2`` ``OptimizationResult`` given schema_version for the first time.
 * The ``models.v2`` have had their `schema_version` bumped for ``BasisSet``, ``AtomicInput``, ``OptimizationInput`` (implicit for ``AtomicResult`` and ``OptimizationResult``), ``TorsionDriveInput`` , and ``TorsionDriveResult``.
 * The ``models.v2`` ``AtomicResultProperties`` has been given a ``schema_name`` and ``schema_version`` (2) for the first time.
 * Note that ``models.v2`` ``QCInputSpecification`` and ``OptimizationSpecification`` have *not* had schema_version bumped.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,7 @@ New Features
 
 Enhancements
 ++++++++++++
+* v1.ProtoModel learned `model_copy`, `model_dump`, `model_dump_json` methods (all w/o warnings) so downstream can unify on newer syntax. Levi's work alternately/additionally taught v2 `copy`, `dict`, `json` (all w/warning) but dict has an alternate use in Pydantic v2.
 * ``AtomicInput`` and ``AtomicResult`` ``OptimizationInput``, ``OptimizationResult``, ``TorsionDriveInput``, ``TorsionDriveResult`` (both versions) learned a ``.convert_v(ver)`` function that returns self or the other version.
 * The ``models.v2`` ``AtomicInput``, ``AtomicResult``, ``AtomicResultProperties`` ``OptimizationInput``, ``OptimizationResult``, ``TorsionDriveInput``, ``TorsionDriveResult`` had their `schema_version` changed to a Literal[2] and validated so new instances will be 2, even if another value passed in.
 * The ``models.v1`` ``AtomicInput``, ``AtomicResult``, ``OptimizationInput``, ``OptimizationResult``, ``TorsionDriveInput``, ``TorsionDriveResult`` had their `schema_version` changed to a Literal[1] and validated so new instances will be 1, even if another value passed in.

--- a/qcelemental/datum.py
+++ b/qcelemental/datum.py
@@ -163,7 +163,7 @@ class Datum(BaseModel):
 
     def json(self, *args, **kwargs):
         """
-        Passthrough to model_dump_sjon without deprecation warning
+        Passthrough to model_dump_json without deprecation warning
         exclude_unset is forced through the model_serializer
         """
         return super().model_dump_json(*args, **kwargs)

--- a/qcelemental/models/align.py
+++ b/qcelemental/models/align.py
@@ -2,11 +2,12 @@ from warnings import warn
 
 import qcelemental
 
+from .common_models import _qcsk_v2_default_v1_importpathschange
+
 _nonapi_file = "align"
-_shim_classes_removed_version = "0.40.0"
 
 warn(
-    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_shim_classes_removed_version}",
+    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_qcsk_v2_default_v1_importpathschange}.",
     DeprecationWarning,
 )
 

--- a/qcelemental/models/basemodels.py
+++ b/qcelemental/models/basemodels.py
@@ -2,11 +2,12 @@ from warnings import warn
 
 import qcelemental
 
+from .common_models import _qcsk_v2_default_v1_importpathschange
+
 _nonapi_file = "basemodels"
-_shim_classes_removed_version = "0.40.0"
 
 warn(
-    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_shim_classes_removed_version}",
+    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_qcsk_v2_default_v1_importpathschange}.",
     DeprecationWarning,
 )
 

--- a/qcelemental/models/basis.py
+++ b/qcelemental/models/basis.py
@@ -2,11 +2,12 @@ from warnings import warn
 
 import qcelemental
 
+from .common_models import _qcsk_v2_default_v1_importpathschange
+
 _nonapi_file = "basis"
-_shim_classes_removed_version = "0.40.0"
 
 warn(
-    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_shim_classes_removed_version}",
+    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_qcsk_v2_default_v1_importpathschange}.",
     DeprecationWarning,
 )
 

--- a/qcelemental/models/common_models.py
+++ b/qcelemental/models/common_models.py
@@ -2,11 +2,14 @@ from warnings import warn
 
 import qcelemental
 
+_qcsk_v2_available_v1_nochange = "0.50.0"
+_qcsk_v2_default_v1_importpathschange = "0.70.0"
+_qcsk_v2_nochange_v1_dropped = "1.0.0"
+
 _nonapi_file = "common_models"
-_shim_classes_removed_version = "0.40.0"
 
 warn(
-    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_shim_classes_removed_version}",
+    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_qcsk_v2_default_v1_importpathschange}.",
     DeprecationWarning,
 )
 

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -3,10 +3,10 @@ from warnings import warn
 import qcelemental
 
 _nonapi_file = "molecule"
-_shim_classes_removed_version = "0.40.0"
+from .common_models import _qcsk_v2_default_v1_importpathschange
 
 warn(
-    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_shim_classes_removed_version}",
+    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_qcsk_v2_default_v1_importpathschange}.",
     DeprecationWarning,
 )
 

--- a/qcelemental/models/procedures.py
+++ b/qcelemental/models/procedures.py
@@ -3,10 +3,10 @@ from warnings import warn
 import qcelemental
 
 _nonapi_file = "procedures"
-_shim_classes_removed_version = "0.40.0"
+from .common_models import _qcsk_v2_default_v1_importpathschange
 
 warn(
-    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_shim_classes_removed_version}",
+    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_qcsk_v2_default_v1_importpathschange}.",
     DeprecationWarning,
 )
 

--- a/qcelemental/models/results.py
+++ b/qcelemental/models/results.py
@@ -2,11 +2,12 @@ from warnings import warn
 
 import qcelemental
 
+from .common_models import _qcsk_v2_default_v1_importpathschange
+
 _nonapi_file = "results"
-_shim_classes_removed_version = "0.40.0"
 
 warn(
-    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_shim_classes_removed_version}",
+    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_qcsk_v2_default_v1_importpathschange}.",
     DeprecationWarning,
 )
 

--- a/qcelemental/models/types.py
+++ b/qcelemental/models/types.py
@@ -3,10 +3,10 @@ from warnings import warn
 import qcelemental
 
 _nonapi_file = "types"
-_shim_classes_removed_version = "0.40.0"
+from .common_models import _qcsk_v2_default_v1_importpathschange
 
 warn(
-    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_shim_classes_removed_version}",
+    f"qcelemental.models.{_nonapi_file} should be accessed through qcelemental.models (or qcelemental.models.v1 or .v2 for fixed QCSchema version). The 'models.{_nonapi_file}' route will be removed as soon as v{_qcsk_v2_default_v1_importpathschange}.",
     DeprecationWarning,
 )
 

--- a/qcelemental/models/v1/basemodels.py
+++ b/qcelemental/models/v1/basemodels.py
@@ -118,6 +118,18 @@ class ProtoModel(BaseModel):
         else:
             raise KeyError(f"Unknown encoding type '{encoding}', valid encoding types: 'json'.")
 
+    def model_dump(self, **kwargs):
+        # forwarding pydantic v2 API function to pydantic v1 API so downstream can unify on new syntax
+        return self.dict(**kwargs)
+
+    def model_dump_json(self, **kwargs):
+        # forwarding pydantic v2 API function to pydantic v1 API so downstream can unify on new syntax
+        return self.json(**kwargs)
+
+    def model_copy(self, **kwargs):
+        # forwarding pydantic v2 API function to pydantic v1 API so downstream can unify on new syntax
+        return self.copy(**kwargs)
+
     def serialize(
         self,
         encoding: str,

--- a/qcelemental/models/v1/common_models.py
+++ b/qcelemental/models/v1/common_models.py
@@ -128,6 +128,21 @@ class FailedOperation(ProtoModel):
     def __repr_args__(self) -> "ReprArgs":
         return [("error", self.error)]
 
+    def convert_v(
+        self, version: int
+    ) -> Union["qcelemental.models.v1.FailedOperation", "qcelemental.models.v2.FailedOperation"]:
+        """Convert to instance of particular QCSchema version."""
+        import qcelemental as qcel
+
+        if check_convertible_version(version, error="FailedOperation") == "self":
+            return self
+
+        dself = self.dict()
+        if version == 2:
+            self_vN = qcel.models.v2.FailedOperation(**dself)
+
+        return self_vN
+
 
 def check_convertible_version(ver: int, error: str):
     if ver == 1:

--- a/qcelemental/models/v1/common_models.py
+++ b/qcelemental/models/v1/common_models.py
@@ -129,6 +129,15 @@ class FailedOperation(ProtoModel):
         return [("error", self.error)]
 
 
+def check_convertible_version(ver: int, error: str):
+    if ver == 1:
+        return "self"
+    elif ver == 2:
+        return True
+    else:
+        raise ValueError(f"QCSchema {error} version={version} does not exist for conversion.")
+
+
 qcschema_input_default = "qcschema_input"
 qcschema_output_default = "qcschema_output"
 qcschema_optimization_input_default = "qcschema_optimization_input"

--- a/qcelemental/models/v1/procedures.py
+++ b/qcelemental/models/v1/procedures.py
@@ -1,5 +1,11 @@
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    # remove when minimum py38
+    from typing_extensions import Literal
 
 from pydantic.v1 import Field, conlist, constr, validator
 
@@ -10,6 +16,7 @@ from .common_models import (
     DriverEnum,
     Model,
     Provenance,
+    check_convertible_version,
     qcschema_input_default,
     qcschema_optimization_input_default,
     qcschema_optimization_output_default,
@@ -53,7 +60,7 @@ class QCInputSpecification(ProtoModel):
     """
 
     schema_name: constr(strip_whitespace=True, regex=qcschema_input_default) = qcschema_input_default  # type: ignore
-    schema_version: int = 1
+    schema_version: int = 1  # TODO
 
     driver: DriverEnum = Field(DriverEnum.gradient, description=str(DriverEnum.__doc__))
     model: Model = Field(..., description=str(Model.__doc__))
@@ -71,7 +78,7 @@ class OptimizationInput(ProtoModel):
     schema_name: constr(  # type: ignore
         strip_whitespace=True, regex=qcschema_optimization_input_default
     ) = qcschema_optimization_input_default
-    schema_version: int = 1
+    schema_version: Literal[1] = 1
 
     keywords: Dict[str, Any] = Field({}, description="The optimization specific keywords to be used.")
     extras: Dict[str, Any] = Field({}, description="Extra fields that are not part of the schema.")
@@ -88,11 +95,31 @@ class OptimizationInput(ProtoModel):
             ("molecule_hash", self.initial_molecule.get_hash()[:7]),
         ]
 
+    @validator("schema_version", pre=True)
+    def _version_stamp(cls, v):
+        return 1
+
+    def convert_v(
+        self, version: int
+    ) -> Union["qcelemental.models.v1.OptimizationInput", "qcelemental.models.v2.OptimizationInput"]:
+        """Convert to instance of particular QCSchema version."""
+        import qcelemental as qcel
+
+        if check_convertible_version(version, error="OptimizationInput") == "self":
+            return self
+
+        dself = self.dict()
+        if version == 2:
+            self_vN = qcel.models.v2.OptimizationInput(**dself)
+
+        return self_vN
+
 
 class OptimizationResult(OptimizationInput):
     schema_name: constr(  # type: ignore
         strip_whitespace=True, regex=qcschema_optimization_output_default
     ) = qcschema_optimization_output_default
+    schema_version: Literal[1] = 1
 
     final_molecule: Optional[Molecule] = Field(..., description="The final molecule of the geometry optimization.")
     trajectory: List[AtomicResult] = Field(
@@ -131,6 +158,25 @@ class OptimizationResult(OptimizationInput):
 
         return v
 
+    @validator("schema_version", pre=True)
+    def _version_stamp(cls, v):
+        return 1
+
+    def convert_v(
+        self, version: int
+    ) -> Union["qcelemental.models.v1.OptimizationResult", "qcelemental.models.v2.OptimizationResult"]:
+        """Convert to instance of particular QCSchema version."""
+        import qcelemental as qcel
+
+        if check_convertible_version(version, error="OptimizationResult") == "self":
+            return self
+
+        dself = self.dict()
+        if version == 2:
+            self_vN = qcel.models.v2.OptimizationResult(**dself)
+
+        return self_vN
+
 
 class OptimizationSpecification(ProtoModel):
     """
@@ -143,7 +189,7 @@ class OptimizationSpecification(ProtoModel):
     """
 
     schema_name: constr(strip_whitespace=True, regex="qcschema_optimization_specification") = "qcschema_optimization_specification"  # type: ignore
-    schema_version: int = 1
+    schema_version: int = 1  # TODO
 
     procedure: str = Field(..., description="Optimization procedure to run the optimization with.")
     keywords: Dict[str, Any] = Field({}, description="The optimization specific keywords to be used.")
@@ -200,7 +246,7 @@ class TorsionDriveInput(ProtoModel):
     """
 
     schema_name: constr(strip_whitespace=True, regex=qcschema_torsion_drive_input_default) = qcschema_torsion_drive_input_default  # type: ignore
-    schema_version: int = 1
+    schema_version: Literal[1] = 1
 
     keywords: TDKeywords = Field(..., description="The torsion drive specific keywords to be used.")
     extras: Dict[str, Any] = Field({}, description="Extra fields that are not part of the schema.")
@@ -221,6 +267,25 @@ class TorsionDriveInput(ProtoModel):
         assert value.driver == DriverEnum.gradient, "driver must be set to gradient"
         return value
 
+    @validator("schema_version", pre=True)
+    def _version_stamp(cls, v):
+        return 1
+
+    def convert_v(
+        self, version: int
+    ) -> Union["qcelemental.models.v1.TorsionDriveInput", "qcelemental.models.v2.TorsionDriveInput"]:
+        """Convert to instance of particular QCSchema version."""
+        import qcelemental as qcel
+
+        if check_convertible_version(version, error="TorsionDriveInput") == "self":
+            return self
+
+        dself = self.dict()
+        if version == 2:
+            self_vN = qcel.models.v2.TorsionDriveInput(**dself)
+
+        return self_vN
+
 
 class TorsionDriveResult(TorsionDriveInput):
     """Results from running a torsion drive.
@@ -231,7 +296,7 @@ class TorsionDriveResult(TorsionDriveInput):
     """
 
     schema_name: constr(strip_whitespace=True, regex=qcschema_torsion_drive_output_default) = qcschema_torsion_drive_output_default  # type: ignore
-    schema_version: int = 1
+    schema_version: Literal[1] = 1
 
     final_energies: Dict[str, float] = Field(
         ..., description="The final energy at each angle of the TorsionDrive scan."
@@ -253,6 +318,25 @@ class TorsionDriveResult(TorsionDriveInput):
     )
     error: Optional[ComputeError] = Field(None, description=str(ComputeError.__doc__))
     provenance: Provenance = Field(..., description=str(Provenance.__doc__))
+
+    @validator("schema_version", pre=True)
+    def _version_stamp(cls, v):
+        return 1
+
+    def convert_v(
+        self, version: int
+    ) -> Union["qcelemental.models.v1.TorsionDriveResult", "qcelemental.models.v2.TorsionDriveResult"]:
+        """Convert to instance of particular QCSchema version."""
+        import qcelemental as qcel
+
+        if check_convertible_version(version, error="TorsionDriveResult") == "self":
+            return self
+
+        dself = self.dict()
+        if version == 2:
+            self_vN = qcel.models.v2.TorsionDriveResult(**dself)
+
+        return self_vN
 
 
 def Optimization(*args, **kwargs):

--- a/qcelemental/models/v2/common_models.py
+++ b/qcelemental/models/v2/common_models.py
@@ -95,7 +95,7 @@ class FailedOperation(ProtoModel):
     and containing the reason and input data which generated the failure.
     """
 
-    id: str = Field(  # type: ignore
+    id: Optional[str] = Field(  # type: ignore
         None,
         description="A unique identifier which links this FailedOperation, often of the same Id of the operation "
         "should it have been successful. This will often be set programmatically by a database such as "
@@ -125,6 +125,21 @@ class FailedOperation(ProtoModel):
 
     def __repr_args__(self) -> "ReprArgs":
         return [("error", self.error)]
+
+    def convert_v(
+        self, version: int
+    ) -> Union["qcelemental.models.v1.FailedOperation", "qcelemental.models.v2.FailedOperation"]:
+        """Convert to instance of particular QCSchema version."""
+        import qcelemental as qcel
+
+        if check_convertible_version(version, error="FailedOperation") == "self":
+            return self
+
+        dself = self.model_dump()
+        if version == 1:
+            self_vN = qcel.models.v1.FailedOperation(**dself)
+
+        return self_vN
 
 
 def check_convertible_version(ver: int, error: str):

--- a/qcelemental/models/v2/common_models.py
+++ b/qcelemental/models/v2/common_models.py
@@ -127,6 +127,15 @@ class FailedOperation(ProtoModel):
         return [("error", self.error)]
 
 
+def check_convertible_version(ver: int, error: str):
+    if ver == 1:
+        return True
+    elif ver == 2:
+        return "self"
+    else:
+        raise ValueError(f"QCSchema {error} version={version} does not exist for conversion.")
+
+
 qcschema_input_default = "qcschema_input"
 qcschema_output_default = "qcschema_output"
 qcschema_optimization_input_default = "qcschema_optimization_input"

--- a/qcelemental/models/v2/types.py
+++ b/qcelemental/models/v2/types.py
@@ -11,6 +11,17 @@ from typing_extensions import Annotated, get_args
 
 def generate_caster(dtype):
     def cast_to_np(v):
+        # for driver=properties
+        if isinstance(v, dict):
+            vv = {}
+            for key, val in v.items():
+                try:
+                    val = np.asarray(val, dtype=dtype)
+                except ValueError:
+                    raise ValueError(f"Could not cast {val} to NumPy Array!")
+                vv[key] = val
+            return vv
+
         try:
             v = np.asarray(v, dtype=dtype)
         except ValueError:

--- a/qcelemental/models/v2/types.py
+++ b/qcelemental/models/v2/types.py
@@ -11,16 +11,10 @@ from typing_extensions import Annotated, get_args
 
 def generate_caster(dtype):
     def cast_to_np(v):
-        # for driver=properties
-        if isinstance(v, dict):
-            vv = {}
-            for key, val in v.items():
-                try:
-                    val = np.asarray(val, dtype=dtype)
-                except ValueError:
-                    raise ValueError(f"Could not cast {val} to NumPy Array!")
-                vv[key] = val
-            return vv
+        if isinstance(v, (float, dict)):
+            return v
+        elif isinstance(v, int):
+            return float(v)
 
         try:
             v = np.asarray(v, dtype=dtype)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
~currently atop #349~
- [x] main Input/Result classes and FailedOperation gained a `convert_v(<ver>)` function to transform to other version. transformation trivial at this point b/c this is pydantic's purpose, but functions will differentiate at the rearrangement milestone. Needed to actually validate `schema_version` field so it would overwrite at conversion.
- [x] added `model_dump`, `model_dump_json`, `copy_model` to v1 so easier to write code that can take both model types. Levi had done the reverse and added `dict`, `json`, `copy` to v2, but I'm thinking this is the better way. Haven't removed Levi's fns.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
