### PR TITLE
poetry to setuptools; min py38

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,6 @@
 <!-- Provide a brief single sentence for the changelog. -->
 
 ## Status
-<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
+<!-- Please `bash scripts/format.sh` in the base folder or use pre-commit. -->
 - [ ] Code base linted
 - [ ] Ready to go

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
       - name: Install QCElemental (full deps)
-        if: (!(matrix.python-version == '3.8' || matrix.python-version == '3.10'))
+        if: matrix.python-version != '3.8' && matrix.python-version != '3.10'
         run: pip install '.[test,viz,align,standard]'
       - name: Install QCElemental (min deps)
         if: matrix.python-version == '3.8' || matrix.python-version == '3.10'

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -31,10 +31,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
       - name: Install repo with poetry (full deps)
-        if: matrix.python-version != '3.9'
+        if: (!(matrix.python-version == '3.8' || matrix.python-version == '3.10'))
         run: pip install '.[test,viz,align]'
       - name: Install repo with poetry (min deps)
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.8' || matrix.python-version == '3.10'
         run: pip install '.[test]'
       - name: Run tests
         run: pytest -rws -v --cov=qcelemental --color=yes --cov-report=xml  #-k "not pubchem_multiout_g"

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -19,7 +19,8 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         pydantic-version: ["2"]
-        runs-on: [ubuntu-latest, windows-latest]
+        #runs-on: [ubuntu-latest, windows-latest]
+        runs-on: [ubuntu-latest]
     name: "🐍 ${{ matrix.python-version }} • ${{ matrix.pydantic-version }} • ${{ matrix.runs-on }}"
     runs-on: ${{ matrix.runs-on }}
 
@@ -30,10 +31,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Checkout Code
         uses: actions/checkout@v3
-      - name: Install repo with poetry (full deps)
+      - name: Install QCElemental (full deps)
         if: (!(matrix.python-version == '3.8' || matrix.python-version == '3.10'))
         run: pip install '.[test,viz,align]'
-      - name: Install repo with poetry (min deps)
+      - name: Install QCElemental (min deps)
         if: matrix.python-version == '3.8' || matrix.python-version == '3.10'
         run: pip install '.[test]'
       - name: Run tests
@@ -62,12 +63,10 @@ jobs:
           python-version: "3.10"
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2
-      - name: Install poetry
-        run: pip install poetry
       - name: Install repo
-        run: poetry install --no-interaction --no-ansi
+        run: pip install '.[docs]'
       - name: Build Documentation
-        run: bash scripts/build_docs.sh
+        run: sphinx-build docs/ build/docs
       - name: GitHub Pages Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.1
         if: github.event_name == 'push' && github.repository == 'MolSSI/QCElemental' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/master' )

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         pydantic-version: ["2"]
         runs-on: [ubuntu-latest, windows-latest]
     name: "🐍 ${{ matrix.python-version }} • ${{ matrix.pydantic-version }} • ${{ matrix.runs-on }}"
@@ -30,16 +30,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Checkout Code
         uses: actions/checkout@v3
-      - name: Install poetry
-        run: pip install poetry
       - name: Install repo with poetry (full deps)
         if: matrix.python-version != '3.9'
-        run: poetry install --no-interaction --no-ansi --all-extras
+        run: pip install '.[test,viz,align]'
       - name: Install repo with poetry (min deps)
         if: matrix.python-version == '3.9'
-        run: poetry install --no-interaction --no-ansi --extras test
+        run: pip install '.[test]'
       - name: Run tests
-        run: poetry run pytest -rws -v --cov=qcelemental --color=yes --cov-report=xml  #-k "not pubchem_multiout_g"
+        run: pytest -rws -v --cov=qcelemental --color=yes --cov-report=xml  #-k "not pubchem_multiout_g"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3 # NEEDS UPDATE TO v3 https://github.com/codecov/codecov-action
       - name: QCSchema Examples Deploy

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -19,8 +19,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         pydantic-version: ["2"]
-        #runs-on: [ubuntu-latest, windows-latest]
-        runs-on: [ubuntu-latest]
+        runs-on: [ubuntu-latest, windows-latest]
     name: "🐍 ${{ matrix.python-version }} • ${{ matrix.pydantic-version }} • ${{ matrix.runs-on }}"
     runs-on: ${{ matrix.runs-on }}
 
@@ -33,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install QCElemental (full deps)
         if: (!(matrix.python-version == '3.8' || matrix.python-version == '3.10'))
-        run: pip install '.[test,viz,align]'
+        run: pip install '.[test,viz,align,standard]'
       - name: Install QCElemental (min deps)
         if: matrix.python-version == '3.8' || matrix.python-version == '3.10'
         run: pip install '.[test]'

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -10,11 +10,11 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Install black
         run: pip install "black>=22.1.0,<23.0a0"
       - name: Check code formatting with black
@@ -23,26 +23,24 @@ jobs:
   isort:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
-      - name: Install poetry
-        run: pip install poetry
+          python-version: "3.8"
       - name: Install repo
-        run: poetry install --no-interaction --no-ansi
+        run: pip install '.[lint]'
       - name: Check import formatting with isort
-        run: poetry run isort --check-only --diff .
+        run: isort --check-only --diff .
 # TODO: Support flake8 when the repo is ready :)
 # flake8:
 #   runs-on: ubuntu-latest
 #   steps:
-#     - uses: actions/checkout@v3
+#     - uses: actions/checkout@v4
 #     - name: Set up Python
 #       uses: actions/setup-python@v4
 #       with:
-#         python-version: "3.7"
+#         python-version: "3.8"
 #     - name: Install flake8
 #       run: pip install flake8
 #     - name: Flake8
@@ -52,7 +50,7 @@ jobs:
 # mypy:
 #   runs-on: ubuntu-latest
 #   steps:
-#     - uses: actions/checkout@v3
+#     - uses: actions/checkout@v4
 #     - name: Set up Python
 #       uses: actions/setup-python@v4
 #       with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,21 +16,25 @@ We welcome contributions from external contributors, and this document describes
   git clone https://github.com/{YOUR-GITHUB-USERNAME}/QCElemental.git
   cd QCElemental
   ```
+<!--
 - Install [poetry](https://python-poetry.org/) if you do not have it on your system. Poetry will manage package dependencies and virtual environments for you.
   ```sh
   curl -sSL https://install.python-poetry.org | python3 -
   ```
+-->
 - Install QCElemental.
 
   ```sh
-  poetry install
+  pip install .
   ```
 
+<!--
 - Activate your new virtual environment. Many editors--like VS Code--will do this for you automatically when you open a directory that has been installed with `poetry`.
 
   ```sh
   poetry shell
   ```
+-->
 
 - Check your installation by running the tests.
 
@@ -84,12 +88,12 @@ We welcome contributions from external contributors, and this document describes
 - Build packages for distribution. Build artifacts will be in `dist/`:
 
   ```sh
-  poetry build
+  python -m build
   ```
 
 - Distribute built packages to PyPi:
   ```sh
-  poetry publish --username {pypi_username} --password {pypi_password}
+  python -m twine upload dist/*
   ```
 
 ## Additional Resources

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://img.shields.io/codecov/c/github/MolSSI/QCElemental.svg?logo=Codecov&logoColor=white)](https://codecov.io/gh/MolSSI/QCElemental)
 [![Documentation Status](https://img.shields.io/github/actions/workflow/status/MolSSI/QCElemental/CI.yaml?label=docs&logo=readthedocs&logoColor=white)](https://molssi.github.io/QCElemental/)
 [![Chat on Slack](https://img.shields.io/badge/chat-on_slack-green.svg?longCache=true&style=flat&logo=slack)](https://join.slack.com/t/qcarchive/shared_invite/enQtNDIzNTQ2OTExODk0LTE3MWI0YzBjNzVhNzczNDM0ZTA5MmQ1ODcxYTc0YTA1ZDQ2MTk1NDhlMjhjMmQ0YWYwOGMzYzJkZTM2NDlmOGM)
-![python](https://img.shields.io/badge/python-3.7+-blue.svg)
+![python](https://img.shields.io/badge/python-3.8+-blue.svg)
 
 **Documentation:** [GitHub Pages](https://molssi.github.io/QCElemental/)
 
@@ -16,7 +16,7 @@ This project also contains a generator, validator, and translator for [Molecule 
 
 ## ✨ Getting Started
 
-- Installation. QCElemental supports Python 3.7+. We reserve the right to move to Python 3.9+ at no notice for new releases.
+- Installation. QCElemental supports Python 3.8+. We reserve the right to move to Python 3.9+ at no notice for new releases.
 
   ```sh
   python -m pip install qcelemental

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,7 @@ New Features
 ++++++++++++
 * Downstream code should ``from qcelemental.models.v1 import Molecule, AtomicResult`` etc. to assure medium-term availability of existing models.
 * New pydantic v2 models available as ``from qcelemental.models.v2 import Molecule, AtomicResult`` etc.
+- (:pr:`361`) Switch from poetry to setuptools build backend. 
 
 Enhancements
 ++++++++++++

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ classifiers = [
     "Framework :: Pydantic :: 2",
 ]
 dependencies = [
-    "numpy >=1.26.1",
+    "numpy >=1.12.0; python_version=='3.8'",
+    "numpy >=1.26.1; python_version>3.8'",
     "pint >=0.24",
     "pydantic >=2.0",
 ]
@@ -42,6 +43,7 @@ dependencies = [
 [project.optional-dependencies]
 viz = [
     "nglview", 
+    "setuptools; python_version>='3.12'",  # nglview needs pkg_resources
     "ipykernel <6.0",
 ]
 align = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+standard = [
+    "msgpack",
+    "jsonschema",
+]
 viz = [
     "nglview",  # !py38  # insufficient on pypi as also need `dot`. python-graphviz sufficient in conda.
     "setuptools; python_version>='3.12'",  # nglview needs pkg_resources
@@ -60,6 +64,9 @@ lint = [
     "pre-commit",
     "black >=22.1.0,<23.0a0",  # if running outside of pre-commit
     "isort ==5.11.5",  # if running outside of pre-commit
+    # "mypy",
+    # "autoflake",
+    # "flake8",
 ]
 docs = [  # probably >=py39
     "numpydoc",
@@ -79,11 +86,6 @@ docs = [  # probably >=py39
 #pytest = { version = "^7.2.2", optional = true }
 
 #[tool.poetry.group.dev.dependencies]
-#mypy = "^1.1.1"
-#flake8 = "6.0.0"
-#pytest-cov = "^4.0.0"
-#autoflake = "^2.0.2"
-#jsonschema = "^4.23.0"
 #msgpack = "^1.0.8"
 #    { version = "^1.22", python = "<3.10" },
 #    { version = "^2.3", python = ">=3.10,<4.0.0" }
@@ -91,11 +93,11 @@ docs = [  # probably >=py39
 
 [tool.black]
 line-length = 120
+target-version = ['py38']
 
 [tool.isort]
 profile = "black"
 line_length = 120
-target-version = ['py38']
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy >=1.12.0; python_version=='3.8'",
-    "numpy >=1.26.1; python_version>3.8'",
+    "numpy >=1.26.1; python_version>'3.8'",
     "pint >=0.24",
     "pydantic >=2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,9 @@ classifiers = [
 ]
 dependencies = [
     "numpy >=1.12.0; python_version=='3.8'",
-    "numpy >=1.26.1; python_version>'3.8'",
-    "pint >=0.24",
+    "numpy >=1.26.1; python_version>='3.9'",
+    "pint >=0.10; python_version=='3.8'",
+    "pint >=0.24; python_version>='3.9'",
     "pydantic >=2.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 
 [project.optional-dependencies]
 viz = [
-    "nglview",  # !py38
+    "nglview",  # !py38  # insufficient on pypi as also need `dot`. python-graphviz sufficient in conda.
     "setuptools; python_version>='3.12'",  # nglview needs pkg_resources
     "ipykernel <6.0",
 ]
@@ -61,7 +61,7 @@ dev = [
     "black >=22.1.0,<23.0a0",  # if running outside of pre-commit
     "isort",  # if running outside of pre-commit
 ]
-docs = [
+docs = [  # probably >=py39
     "numpydoc",
     "docutils",
     "sphinx >=7.0.0",
@@ -70,7 +70,6 @@ docs = [
     "autodoc-pydantic",
     "sphinx-automodapi",
     "sphinx-autodoc-typehints",
-    "python >=3.9",
     "pydantic ==2.5.0",  # for now
     "pydantic-settings ==2.2.0",  # for now
 ]
@@ -89,7 +88,6 @@ docs = [
 #    { version = "^1.22", python = "<3.10" },
 #    { version = "^2.3", python = ">=3.10,<4.0.0" }
 #]
-#graphviz = "^0.20.0"  # insufficient on pypi as also need `dot`. python-graphviz sufficient in conda.
 
 [tool.black]
 profile = "black"
@@ -100,26 +98,22 @@ target-version = ['py38']
 branch = true
 omit = ["*/tests/*", "*/migrations/*", "*site-packages*", "*__init__.py"]
 
-#[tool.mypy]
-#plugins = "pydantic.mypy"
-#ignore_missing_imports = true
-#
-#[tool.pydantic-mypy]
-#init_forbid_extra = true
-#init_typed = true
-#warn_required_dynamic_aliases = true
-#warn_untyped_fields = true
+[tool.mypy]
+plugins = "pydantic.mypy"
+ignore_missing_imports = true
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
+warn_untyped_fields = true
 
 [tool.setuptools]
 packages = ["qcelemental"]
 
-# QCMayBody
-
 [tool.setuptools.package-data]
 
-
 [tool.setuptools_scm]
-
 
 [tool.versioningit.vcs]
 default-tag = "0.0.99" # useful for CI/shallow clones

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 
 [project.optional-dependencies]
 viz = [
-    "nglview", 
+    "nglview",  # !py38
     "setuptools; python_version>='3.12'",  # nglview needs pkg_resources
     "ipykernel <6.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,137 +1,120 @@
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
+build-backend = "setuptools.build_meta"
 
-
-[tool.poetry]
-name = "qcelemental"
-version = "0.28.0"
-description = "Core data structures for Quantum Chemistry."
-authors = ["The QCArchive Development Team <qcarchive@molssi.org>"]
-license = "BSD-3-Clause"
-readme = "README.md"
+[project.urls]
 homepage = "https://github.com/MolSSI/QCElemental"
+changelog = "https://github.com/MolSSI/QCElemental/docs/changelog.rst"
 documentation = "http://docs.qcarchive.molssi.org/projects/qcelemental/en/latest/"
+issues = "https://github.com/MolSSI/QCElemental/issues"
+
+[project]
+name = "qcelemental"
+#version = "0.28.0"
+dynamic = ["version"]
+requires-python = ">=3.8"
+description = "Core data structures for Quantum Chemistry."
+authors = [
+  { name="The QCArchive Development Team", email="qcarchive@molssi.org" },
+]
+license = { file="LICENSE" }
+readme = "README.md"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Framework :: Pydantic",
     "Framework :: Pydantic :: 2",
 ]
+dependencies = [
+    "numpy >=1.26.1",
+    "pint >=0.24",
+    "pydantic >=2.0",
+]
 
-[tool.poetry.dependencies]
-numpy = [
-    { version = ">=1.12.0", python = "3.8" },
-    { version = ">=1.26.1,<2.0", python = ">=3.9,<3.10" },
-    { version = ">=1.26.1", python = ">=3.9,<3.13" },
+[project.optional-dependencies]
+viz = [
+    "nglview", 
+    "ipykernel <6.0",
 ]
-packaging = [
-    { version = ">=24.0", python = ">=3.7,<3.8" },
-    { version = ">=24.1", python = ">=3.8" },
+align = [
+    "networkx <3.0", 
+    "scipy",
 ]
-# qcel is compatible with most any numpy, v1 or v2, but numpy v2 only works with pint >=0.24, which is only available for py >=3.10
-python = "^3.7.1"
-pint = [
-    { version = ">=0.10", python = ">=3.7,<3.9" },
-    { version = ">=0.23", python = ">=3.9,<3.10" },
-    { version = ">=0.24", python = ">=3.10,<3.13" },
+test = [
+    "pytest",
 ]
-pydantic = ">=2.0"
-nglview = { version = "^3.0.3", optional = true }
-ipykernel = { version = "<6.0.0", optional = true }
-importlib-metadata = { version = ">=4.8", python = "<3.8" }
-networkx = { version = "<3.0", optional = true }
-scipy = [
-    { version = ">=1.6.0", python = "<3.9", optional = true },
-    { version = ">=1.9.0", python = ">=3.9,<3.13", optional = true },
+dev = [
+    "pre-commit",
+    "black >=22.1.0,<23.0a0",  # if running outside of pre-commit
+    "isort",  # if running outside of pre-commit
 ]
-pytest = { version = "^7.2.2", optional = true }
+docs = [
+    "numpydoc",
+    "docutils",
+    "sphinx >=7.0.0",
+    "sphinxcontrib-napoleon",
+    "sphinx-rtd-theme",
+    "autodoc-pydantic",
+    "sphinx-automodapi",
+    "sphinx-autodoc-typehints",
+    "python >=3.9",
+    "pydantic ==2.5.0",  # for now
+    "pydantic-settings ==2.2.0",  # for now
+]
 
-[tool.poetry.extras]
-viz = ["nglview", "ipykernel"]
-align = ["networkx", "scipy"]
-test = ["pytest"]
+#[tool.poetry.dependencies]
+#packaging = ">=24.1"
+#pytest = { version = "^7.2.2", optional = true }
 
-# Note that all the versions below are a farce for poetry's benefit.
-#   One needs a fairly recent sphinx, pydantic, and autodoc-pydantic for a
-#   successful docs build, and that likely requires py 3.9."
-
-[tool.poetry.group.dev.dependencies]
-black = ">=22.1.0,<23.0a0"
-mypy = "^1.1.1"
-isort = "5.11.5"
-flake8 = [
-    { version = "<6.0.0", python = "<3.8.1" },
-    { version = "6.0.0", python = ">=3.8.1,<4.0.0" }
-]
-pre-commit = [
-    { version = "<3.2.0", python = "<3.9" },
-    { version = "^3.8.0", python = ">=3.9,<4.0.0" }
-]
-pytest-cov = "^4.0.0"
-autoflake = "^2.0.2"
-jsonschema = { version = "^4.23.0", python = ">=3.8,<4.0.0" }
-msgpack = { version = "^1.0.8", python = ">=3.8,<4.0.0" }
-numpydoc = [
-    { version = "^1.5.0", python = "<3.9" },
-    { version = "^1.8.0", python = ">=3.9,<4.0.0" }
-]
-docutils = [
-    { version = "<0.19", python = "<3.9" },
-    { version = "0.20.1", python = ">=3.9,<4.0.0" }
-]
-sphinx = [
-    { version = "<6.0.0", python = "<3.9" },
-    { version = "^7.0.0", python = ">=3.9,<4.0.0" }
-]
-sphinxcontrib-napoleon = "^0.7"
-sphinx-rtd-theme = [
-    { version = "^1.2.0", python = "<3.9" },
-    { version = "^2.0.0", python = ">=3.9,<4.0.0" }
-]
-autodoc-pydantic = [
-    { version = "^2.0.0", python = "<3.8" },
-    { version = "^2.1.0", python = ">=3.8,<4.0" }
-]
-sphinx-automodapi = [
-    { version = "^0.15.0", python = "<3.8" },
-    { version = "^0.17.0", python = ">=3.8,<4.0.0" }
-]
-sphinx-autodoc-typehints = [
-    { version = "^1.22", python = "<3.10" },
-    { version = "^2.3", python = ">=3.10,<4.0.0" }
-]
-graphviz = "^0.20.0"  # insufficient on pypi as also need `dot`. python-graphviz sufficient in conda.
+#[tool.poetry.group.dev.dependencies]
+#mypy = "^1.1.1"
+#flake8 = "6.0.0"
+#pytest-cov = "^4.0.0"
+#autoflake = "^2.0.2"
+#jsonschema = "^4.23.0"
+#msgpack = "^1.0.8"
+#    { version = "^1.22", python = "<3.10" },
+#    { version = "^2.3", python = ">=3.10,<4.0.0" }
+#]
+#graphviz = "^0.20.0"  # insufficient on pypi as also need `dot`. python-graphviz sufficient in conda.
 
 [tool.black]
+profile = "black"
 line-length = 120
-target-version = ['py37']
-
-[tool.isort]
-force_grid_wrap = 0
-include_trailing_comma = true
-line_length = 120
-multi_line_output = 3
-use_parentheses = true
+target-version = ['py38']
 
 [tool.coverage.run]
 branch = true
 omit = ["*/tests/*", "*/migrations/*", "*site-packages*", "*__init__.py"]
 
-[tool.mypy]
-plugins = "pydantic.mypy"
-ignore_missing_imports = true
+#[tool.mypy]
+#plugins = "pydantic.mypy"
+#ignore_missing_imports = true
+#
+#[tool.pydantic-mypy]
+#init_forbid_extra = true
+#init_typed = true
+#warn_required_dynamic_aliases = true
+#warn_untyped_fields = true
 
-[tool.pydantic-mypy]
-init_forbid_extra = true
-init_typed = true
-warn_required_dynamic_aliases = true
-warn_untyped_fields = true
+[tool.setuptools]
+packages = ["qcelemental"]
+
+# QCMayBody
+
+[tool.setuptools.package-data]
+
+
+[tool.setuptools_scm]
+
+
+[tool.versioningit.vcs]
+default-tag = "0.0.99" # useful for CI/shallow clones

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ test = [
 lint = [
     "pre-commit",
     "black >=22.1.0,<23.0a0",  # if running outside of pre-commit
-    "isort",  # if running outside of pre-commit
+    "isort ==5.11.5",  # if running outside of pre-commit
 ]
 docs = [  # probably >=py39
     "numpydoc",
@@ -90,8 +90,11 @@ docs = [  # probably >=py39
 #]
 
 [tool.black]
-profile = "black"
 line-length = 120
+
+[tool.isort]
+profile = "black"
+line_length = 120
 target-version = ['py38']
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ test = [
     "pytest-cov",
     "codecov",
 ]
-dev = [
+lint = [
     "pre-commit",
     "black >=22.1.0,<23.0a0",  # if running outside of pre-commit
     "isort",  # if running outside of pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ align = [
 ]
 test = [
     "pytest",
+    "pytest-cov",
+    "codecov",
 ]
 dev = [
     "pre-commit",

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -1,3 +1,3 @@
 set -xe
 # Run tests
-poetry run sphinx-build docs/ build/docs
+sphinx-build docs/ build/docs

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -2,6 +2,6 @@
 
 set -x
 
-poetry run autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place . --exclude=__init__.py
-poetry run black .
-poetry run isort .
+autoflake --remove-all-unused-imports --recursive --remove-unused-variables --in-place . --exclude=__init__.py
+black .
+isort .

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,3 +1,3 @@
 set -xe
 # Run tests
-poetry run pytest --cov-report html:htmlcov --cov
+pytest --cov-report html:htmlcov --cov


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
- [x] After all-but-py37 builds spontaneously broke in the last few days, it's easier to move the build backend back in line with other QCA projects (QCFractal and QCManyBody) rather than find the issue with poetry's solve-all-at-once and highly-version-specified format.
- [x] This should hit most poetry uses and examples. I've already confirmed that new builds on `master` didn't break, so fine targeting this to `next2024`.
- [x] Dialed back the pydantic versions for docs build. There's some errors with latest pydantic, so that pin needs investigating and releasing.
- [x] Also bump the min python to 3.8+. Even that is end-of-life but QCEngine test lanes still use it.
- There will likely be refinements and corrections to this switchover, but this is a largely working start.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
