### PR TITLE
Csse layout opt/td

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -37,7 +37,7 @@ jobs:
         if: matrix.python-version == '3.8' || matrix.python-version == '3.10'
         run: pip install '.[test]'
       - name: Run tests
-        run: pytest -rws -v --cov=qcelemental --color=yes --cov-report=xml  -k "not TD and not Torsion"  #-k "not pubchem_multiout_g"
+        run: pytest -rws -v --cov=qcelemental --color=yes --cov-report=xml  #-k "not pubchem_multiout_g"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
       - name: QCSchema Examples Deploy

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -37,7 +37,7 @@ jobs:
         if: matrix.python-version == '3.8' || matrix.python-version == '3.10'
         run: pip install '.[test]'
       - name: Run tests
-        run: pytest -rws -v --cov=qcelemental --color=yes --cov-report=xml  #-k "not pubchem_multiout_g"
+        run: pytest -rws -v --cov=qcelemental --color=yes --cov-report=xml  -k "not TD and not Torsion"  #-k "not pubchem_multiout_g"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
       - name: QCSchema Examples Deploy

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: "3.8"
       - name: Install black
         run: pip install "black>=22.1.0,<23.0a0"
-      - name: Print code formatting with black
+      - name: Print code formatting with black (hints here if next step errors)
         run: black --diff .
       - name: Check code formatting with black
         run: black --check .

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -39,10 +39,12 @@ Enhancements
 ++++++++++++
 - (:pr:`363`) 
 - (:pr:`363`) 
-- (:pr:`363`) 
-- (:pr:`363`) allow nwchemdriver w/o driver=energy. provenance now nwchemdriver not nwchemrelax
+- (:pr:`363`) ``v2.TorsionDriveResult`` no longer inherits from Input and now has indep id and extras and new native_files.
+- (:pr:`363`) ``v2.TorsionDriveInput.initial_molecule`` now ``initial_molecules`` as it's a list of >=1 molecules. keep change?
+- (:pr:`363`) ``v2. TorsionDriveSpecification`` is a new model. instead of ``v2.TorsionDriveInput`` having a ``input_specification`` and an ``optimization_spec`` fields, it has a ``specification`` field that is a ``TorsionDriveSpecification`` which in turn hold opt info and in turn gradient/atomic info. 
+- (:pr:`363`) ``v2.TDKeywords`` got a ``schema_name`` field.
+- (:pr:`363`) ``native_files`` field added to ``v2.OptimizationResult`` and ``v2.TorsionDriveResult`` gained a ``native_files`` field, though not protocols for user control.
 - (:pr:`363`) ``v2.AtomicResult.convert_v()`` learned external_protocols option to inject that field if known from OptIn
-- (:pr:`363`) Optking now fills in ``v2.OptimizationResult.stdout``. Through v2, once can alter gradient protocols in an optimization.
 - (:pr:`363`) OptimizationSpecification learned a ``convert_v`` function to interconvert.
 - (:pr:`363`) all the v2 models of ptcl/kw/spec/in/prop/res type have ``schema_name``.  ``qcschema_input`` and ``qcschema_output`` now are ``qcschema_atomic_input`` and ``qcschema_atomic_output``
 - (:pr:`363`) whereas ``v1.AtomicInput`` and ``v1.QCInputSpecification`` shared the same schema_name, ``v2.AtomicInput`` and ``v2.AtomicSpecification`` do not. This is a step towards more explicit schema names.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,6 +37,26 @@ New Features
 
 Enhancements
 ++++++++++++
+- (:pr:`363`) 
+- (:pr:`363`) 
+- (:pr:`363`) 
+- (:pr:`363`) allow nwchemdriver w/o driver=energy. provenance now nwchemdriver not nwchemrelax
+- (:pr:`363`) ``v2.AtomicResult.convert_v()`` learned external_protocols option to inject that field if known from OptIn
+- (:pr:`363`) Optking now fills in ``v2.OptimizationResult.stdout``. Through v2, once can alter gradient protocols in an optimization.
+- (:pr:`363`) OptimizationSpecification learned a ``convert_v`` function to interconvert.
+- (:pr:`363`) all the v2 models of ptcl/kw/spec/in/prop/res type have ``schema_name``.  ``qcschema_input`` and ``qcschema_output`` now are ``qcschema_atomic_input`` and ``qcschema_atomic_output``
+- (:pr:`363`) whereas ``v1.AtomicInput`` and ``v1.QCInputSpecification`` shared the same schema_name, ``v2.AtomicInput`` and ``v2.AtomicSpecification`` do not. This is a step towards more explicit schema names.
+- (:pr:`363`) ``v2.AtomicResult`` gets a literal schema_name and it no longer accepts the qc_schema*
+- (:pr:`363`) ``v2.OptimizatonResult.energies`` becomes ``v2.OptimizationResult.trajectory_properties`` and ManyBody allowed as well as atomic. Much expands information returned
+- (:pr:`363`) ``v2.OptimizatonResult.trajectory`` becomes ``v2.OptimizationResult.trajectory_results`` and ManyBody allowed as well as atomic.
+- (:pr:`363`) a new basic ``v2.OptimizationProperties`` for expansion later. for now has number of opt iter. help by `OptimizationResult.properties`
+- (:pr:`363`) ``v2.OptimizationResult`` gained a ``input_data`` field for the corresponding ``OptimizationInput`` and independent ``id`` and ``extras``. No longer inherits from ``OptimizationInput``.
+                 Literal schema_name. Added ``native_files`` field.
+- (:pr:`363`) ``v2.OptimizationInput`` got a Literal schema_name now. field ``specification`` now takes an ``OptimizationSpecification`` that itself takes an ``AtomicSpecification`` replaces field ``input_specification`` that took a ``QCInputSpecification``. ``v2.OptimizationInput`` gained a ``protocols`` field.
+              fields ``keywords``, ``extras``, and ``protocols`` from Input are now in ``OptimizationSpecification``
+- (:pr:`363`) ``v2.OptimizationSpecification`` now is used every optimization as ``v2.OptimizationInput.specification`` = ``OptimizationSpecification`` rather than only in torsion drives. No longer has schema_name and schema_version.
+              Its. ``procedures`` field is now ``program``. Gains new field ``specification`` that is most commonly ``AtomicSpecification`` but could be ``ManyBodySpecification`` or any other E/G/H producer.
+- (:pr:`363`) ``v2.OptimizationInput`` now takes consolidated ``AtomicSpecification`` rather than ``QCInputSpecification`` (now deleted)
 - (:pr:`359`) ``v2.AtomicInput`` lost extras so extras belong unambiguously to the specification.
 - (:pr:`359`) ``v2.AtomicSpecification``, unlike ``v1.QCInputSpecification``, doesn't have schema_name and schema version.
 - (:pr:`359`) misc -- ``isort`` version bumped to 5.13 and imports and syntax take advantage of python 3.8+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "pint >=0.10; python_version=='3.8'",
     "pint >=0.24; python_version>='3.9'",
     "pydantic >=2.0",
+    "typing_extensions; python_version<'3.9'",
 ]
 
 [project.optional-dependencies]

--- a/qcelemental/models/v1/common_models.py
+++ b/qcelemental/models/v1/common_models.py
@@ -129,18 +129,20 @@ class FailedOperation(ProtoModel):
         return [("error", self.error)]
 
     def convert_v(
-        self, version: int
+        self, target_version: int, /
     ) -> Union["qcelemental.models.v1.FailedOperation", "qcelemental.models.v2.FailedOperation"]:
         """Convert to instance of particular QCSchema version."""
         import qcelemental as qcel
 
-        if check_convertible_version(version, error="FailedOperation") == "self":
+        if check_convertible_version(target_version, error="FailedOperation") == "self":
             return self
 
         dself = self.dict()
-        if version == 2:
+        if target_version == 2:
             # TODO if FailedOp gets a schema_version, add a validator
             self_vN = qcel.models.v2.FailedOperation(**dself)
+        else:
+            assert False, target_version
 
         return self_vN
 

--- a/qcelemental/models/v1/procedures.py
+++ b/qcelemental/models/v1/procedures.py
@@ -70,20 +70,22 @@ class QCInputSpecification(ProtoModel):
         return 1
 
     def convert_v(
-        self, version: int
+        self, target_version: int, /
     ) -> Union["qcelemental.models.v1.QCInputSpecification", "qcelemental.models.v2.AtomicSpecification"]:
         """Convert to instance of particular QCSchema version."""
         import qcelemental as qcel
 
-        if check_convertible_version(version, error="QCInputSpecification") == "self":
+        if check_convertible_version(target_version, error="QCInputSpecification") == "self":
             return self
 
         dself = self.dict()
-        if version == 2:
+        if target_version == 2:
             dself.pop("schema_name")
             dself.pop("schema_version")
 
             self_vN = qcel.models.v2.AtomicSpecification(**dself)
+        else:
+            assert False, target_version
 
         return self_vN
 
@@ -116,18 +118,20 @@ class OptimizationInput(ProtoModel):
         return 1
 
     def convert_v(
-        self, version: int
+        self, target_version: int, /
     ) -> Union["qcelemental.models.v1.OptimizationInput", "qcelemental.models.v2.OptimizationInput"]:
         """Convert to instance of particular QCSchema version."""
         import qcelemental as qcel
 
-        if check_convertible_version(version, error="OptimizationInput") == "self":
+        if check_convertible_version(target_version, error="OptimizationInput") == "self":
             return self
 
         dself = self.dict()
-        if version == 2:
+        if target_version == 2:
             dself["input_specification"].pop("schema_version", None)
             self_vN = qcel.models.v2.OptimizationInput(**dself)
+        else:
+            assert False, target_version
 
         return self_vN
 
@@ -180,25 +184,27 @@ class OptimizationResult(OptimizationInput):
         return 1
 
     def convert_v(
-        self, version: int
+        self, target_version: int, /
     ) -> Union["qcelemental.models.v1.OptimizationResult", "qcelemental.models.v2.OptimizationResult"]:
         """Convert to instance of particular QCSchema version."""
         import qcelemental as qcel
 
-        if check_convertible_version(version, error="OptimizationResult") == "self":
+        if check_convertible_version(target_version, error="OptimizationResult") == "self":
             return self
 
         trajectory_class = self.trajectory[0].__class__
         dself = self.dict()
-        if version == 2:
+        if target_version == 2:
             # remove harmless empty error field that v2 won't accept. if populated, pydantic will catch it.
             if not dself.get("error", True):
                 dself.pop("error")
 
-            dself["trajectory"] = [trajectory_class(**atres).convert_v(version) for atres in dself["trajectory"]]
+            dself["trajectory"] = [trajectory_class(**atres).convert_v(target_version) for atres in dself["trajectory"]]
             dself["input_specification"].pop("schema_version", None)
 
             self_vN = qcel.models.v2.OptimizationResult(**dself)
+        else:
+            assert False, target_version
 
         return self_vN
 
@@ -301,21 +307,23 @@ class TorsionDriveInput(ProtoModel):
         return 1
 
     def convert_v(
-        self, version: int
+        self, target_version: int, /
     ) -> Union["qcelemental.models.v1.TorsionDriveInput", "qcelemental.models.v2.TorsionDriveInput"]:
         """Convert to instance of particular QCSchema version."""
         import qcelemental as qcel
 
-        if check_convertible_version(version, error="TorsionDriveInput") == "self":
+        if check_convertible_version(target_version, error="TorsionDriveInput") == "self":
             return self
 
         dself = self.dict()
         # dself = self.model_dump(exclude_unset=True, exclude_none=True)
-        if version == 2:
+        if target_version == 2:
             dself["input_specification"].pop("schema_version", None)
             dself["optimization_spec"].pop("schema_version", None)
 
             self_vN = qcel.models.v2.TorsionDriveInput(**dself)
+        else:
+            assert False, target_version
 
         return self_vN
 
@@ -357,17 +365,17 @@ class TorsionDriveResult(TorsionDriveInput):
         return 1
 
     def convert_v(
-        self, version: int
+        self, target_version: int, /
     ) -> Union["qcelemental.models.v1.TorsionDriveResult", "qcelemental.models.v2.TorsionDriveResult"]:
         """Convert to instance of particular QCSchema version."""
         import qcelemental as qcel
 
-        if check_convertible_version(version, error="TorsionDriveResult") == "self":
+        if check_convertible_version(target_version, error="TorsionDriveResult") == "self":
             return self
 
         opthist_class = next(iter(self.optimization_history.values()))[0].__class__
         dself = self.dict()
-        if version == 2:
+        if target_version == 2:
             # remove harmless empty error field that v2 won't accept. if populated, pydantic will catch it.
             if not dself.get("error", True):
                 dself.pop("error")
@@ -375,13 +383,15 @@ class TorsionDriveResult(TorsionDriveInput):
             dself["input_specification"].pop("schema_version", None)
             dself["optimization_spec"].pop("schema_version", None)
             dself["optimization_history"] = {
-                k: [opthist_class(**res).convert_v(version) for res in lst]
+                k: [opthist_class(**res).convert_v(target_version) for res in lst]
                 for k, lst in dself["optimization_history"].items()
             }
             # if dself["optimization_spec"].pop("extras", None):
             #    pass
 
             self_vN = qcel.models.v2.TorsionDriveResult(**dself)
+        else:
+            assert False, target_version
 
         return self_vN
 

--- a/qcelemental/models/v1/results.py
+++ b/qcelemental/models/v1/results.py
@@ -622,10 +622,10 @@ class AtomicInput(ProtoModel):
             return self
 
         dself = self.dict()
-        spec = {}
         if target_version == 2:
             dself.pop("schema_name")  # changes in v2
 
+            spec = {}
             spec["driver"] = dself.pop("driver")
             spec["model"] = dself.pop("model")
             spec["keywords"] = dself.pop("keywords", None)
@@ -633,6 +633,8 @@ class AtomicInput(ProtoModel):
             spec["extras"] = dself.pop("extras", None)
             dself["specification"] = spec
             self_vN = qcel.models.v2.AtomicInput(**dself)
+        else:
+            assert False, target_version
 
         return self_vN
 
@@ -865,6 +867,8 @@ class AtomicResult(AtomicInput):
                 dself["input_data"] = input_data
 
             self_vN = qcel.models.v2.AtomicResult(**dself)
+        else:
+            assert False, target_version
 
         return self_vN
 

--- a/qcelemental/models/v2/__init__.py
+++ b/qcelemental/models/v2/__init__.py
@@ -6,6 +6,7 @@ from .common_models import ComputeError, DriverEnum, FailedOperation, Model, Pro
 from .molecule import Molecule
 from .procedures import (
     OptimizationInput,
+    OptimizationProperties,
     OptimizationProtocols,
     OptimizationResult,
     OptimizationSpecification,

--- a/qcelemental/models/v2/__init__.py
+++ b/qcelemental/models/v2/__init__.py
@@ -10,10 +10,10 @@ from .procedures import (
     OptimizationProtocols,
     OptimizationResult,
     OptimizationSpecification,
-    QCInputSpecification,
     TDKeywords,
     TorsionDriveInput,
     TorsionDriveResult,
+    TorsionDriveSpecification,
 )
 from .results import (
     AtomicInput,

--- a/qcelemental/models/v2/common_models.py
+++ b/qcelemental/models/v2/common_models.py
@@ -170,10 +170,6 @@ def check_convertible_version(ver: int, error: str):
         raise ValueError(f"QCSchema {error} version={version} does not exist for conversion.")
 
 
-qcschema_input_default = "qcschema_input"
-qcschema_output_default = "qcschema_output"
-qcschema_optimization_input_default = "qcschema_optimization_input"
-qcschema_optimization_output_default = "qcschema_optimization_output"
 qcschema_torsion_drive_input_default = "qcschema_torsion_drive_input"
 qcschema_torsion_drive_output_default = "qcschema_torsion_drive_output"
 qcschema_molecule_default = "qcschema_molecule"

--- a/qcelemental/models/v2/common_models.py
+++ b/qcelemental/models/v2/common_models.py
@@ -141,20 +141,22 @@ class FailedOperation(ProtoModel):
         return 2
 
     def convert_v(
-        self, version: int
+        self, target_version: int, /
     ) -> Union["qcelemental.models.v1.FailedOperation", "qcelemental.models.v2.FailedOperation"]:
         """Convert to instance of particular QCSchema version."""
         import qcelemental as qcel
 
-        if check_convertible_version(version, error="FailedOperation") == "self":
+        if check_convertible_version(target_version, error="FailedOperation") == "self":
             return self
 
         dself = self.model_dump()
-        if version == 1:
+        if target_version == 1:
             dself.pop("schema_name")
             dself.pop("schema_version")
 
             self_vN = qcel.models.v1.FailedOperation(**dself)
+        else:
+            assert False, target_version
 
         return self_vN
 

--- a/qcelemental/models/v2/common_models.py
+++ b/qcelemental/models/v2/common_models.py
@@ -170,6 +170,4 @@ def check_convertible_version(ver: int, error: str):
         raise ValueError(f"QCSchema {error} version={version} does not exist for conversion.")
 
 
-qcschema_torsion_drive_input_default = "qcschema_torsion_drive_input"
-qcschema_torsion_drive_output_default = "qcschema_torsion_drive_output"
 qcschema_molecule_default = "qcschema_molecule"

--- a/qcelemental/models/v2/procedures.py
+++ b/qcelemental/models/v2/procedures.py
@@ -95,18 +95,20 @@ class OptimizationInput(ProtoModel):
         return 2
 
     def convert_v(
-        self, version: int
+        self, target_version: int, /
     ) -> Union["qcelemental.models.v1.OptimizationInput", "qcelemental.models.v2.OptimizationInput"]:
         """Convert to instance of particular QCSchema version."""
         import qcelemental as qcel
 
-        if check_convertible_version(version, error="OptimizationInput") == "self":
+        if check_convertible_version(target_version, error="OptimizationInput") == "self":
             return self
 
         dself = self.model_dump()
-        if version == 1:
+        if target_version == 1:
             dself["input_specification"].pop("schema_version", None)
             self_vN = qcel.models.v1.OptimizationInput(**dself)
+        else:
+            assert False, target_version
 
         return self_vN
 
@@ -161,22 +163,24 @@ class OptimizationResult(OptimizationInput):
         return 2
 
     def convert_v(
-        self, version: int
+        self, target_version: int, /
     ) -> Union["qcelemental.models.v1.OptimizationResult", "qcelemental.models.v2.OptimizationResult"]:
         """Convert to instance of particular QCSchema version."""
         import qcelemental as qcel
 
-        if check_convertible_version(version, error="OptimizationResult") == "self":
+        if check_convertible_version(target_version, error="OptimizationResult") == "self":
             return self
 
         dself = self.model_dump()
-        if version == 1:
+        if target_version == 1:
             trajectory_class = self.trajectory[0].__class__
 
-            dself["trajectory"] = [trajectory_class(**atres).convert_v(version) for atres in dself["trajectory"]]
+            dself["trajectory"] = [trajectory_class(**atres).convert_v(target_version) for atres in dself["trajectory"]]
             dself["input_specification"].pop("schema_version", None)
 
             self_vN = qcel.models.v1.OptimizationResult(**dself)
+        else:
+            assert False, target_version
 
         return self_vN
 
@@ -285,20 +289,22 @@ class TorsionDriveInput(ProtoModel):
         return 2
 
     def convert_v(
-        self, version: int
+        self, target_version: int, /
     ) -> Union["qcelemental.models.v1.TorsionDriveInput", "qcelemental.models.v2.TorsionDriveInput"]:
         """Convert to instance of particular QCSchema version."""
         import qcelemental as qcel
 
-        if check_convertible_version(version, error="TorsionDriveInput") == "self":
+        if check_convertible_version(target_version, error="TorsionDriveInput") == "self":
             return self
 
         dself = self.model_dump()
-        if version == 1:
+        if target_version == 1:
             if dself["optimization_spec"].pop("extras", None):
                 pass
 
             self_vN = qcel.models.v1.TorsionDriveInput(**dself)
+        else:
+            assert False, target_version
 
         return self_vN
 
@@ -341,26 +347,28 @@ class TorsionDriveResult(TorsionDriveInput):
         return 2
 
     def convert_v(
-        self, version: int
+        self, target_version: int, /
     ) -> Union["qcelemental.models.v1.TorsionDriveResult", "qcelemental.models.v2.TorsionDriveResult"]:
         """Convert to instance of particular QCSchema version."""
         import qcelemental as qcel
 
-        if check_convertible_version(version, error="TorsionDriveResult") == "self":
+        if check_convertible_version(target_version, error="TorsionDriveResult") == "self":
             return self
 
         dself = self.model_dump()
-        if version == 1:
+        if target_version == 1:
             opthist_class = next(iter(self.optimization_history.values()))[0].__class__
 
             if dself["optimization_spec"].pop("extras", None):
                 pass
 
             dself["optimization_history"] = {
-                k: [opthist_class(**res).convert_v(version) for res in lst]
+                k: [opthist_class(**res).convert_v(target_version) for res in lst]
                 for k, lst in dself["optimization_history"].items()
             }
 
             self_vN = qcel.models.v1.TorsionDriveResult(**dself)
+        else:
+            assert False, target_version
 
         return self_vN

--- a/qcelemental/models/v2/procedures.py
+++ b/qcelemental/models/v2/procedures.py
@@ -1,5 +1,12 @@
 from enum import Enum
-from typing import TYPE_CHECKING, Annotated, Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
+
+from typing import Dict, List, Optional
+try:
+    from typing import Annotated
+except ImportError:
+    # remove when minimum py39
+    from typing_extensions import Annotated
 
 from pydantic import Field, conlist, constr, field_validator
 

--- a/qcelemental/models/v2/results.py
+++ b/qcelemental/models/v2/results.py
@@ -671,17 +671,17 @@ class AtomicSpecification(ProtoModel):
     )
 
     def convert_v(
-        self, version: int
+        self, target_version: int, /
     ) -> Union["qcelemental.models.v1.QCInputSpecification", "qcelemental.models.v2.AtomicSpecification"]:
         """Convert to instance of particular QCSchema version."""
         import qcelemental as qcel
 
-        if check_convertible_version(version, error="AtomicSpecification") == "self":
+        if check_convertible_version(target_version, error="AtomicSpecification") == "self":
             return self
 
         loss_store = {}
         dself = self.model_dump()
-        if version == 1:
+        if target_version == 1:
             loss_store["protocols"] = dself.pop("protocols")
             loss_store["program"] = dself.pop("program")
 
@@ -689,6 +689,8 @@ class AtomicSpecification(ProtoModel):
                 dself["extras"]["_qcsk_conversion_loss"] = loss_store
 
             self_vN = qcel.models.v1.QCInputSpecification(**dself)
+        else:
+            assert False, target_version
 
         return self_vN
 
@@ -763,6 +765,8 @@ class AtomicInput(ProtoModel):
             dself.pop("specification")  # now empty
 
             self_vN = qcel.models.v1.AtomicInput(**dself)
+        else:
+            assert False, target_version
 
         return self_vN
 
@@ -973,5 +977,7 @@ class AtomicResult(ProtoModel):
             dself = {**input_data, **dself}
 
             self_vN = qcel.models.v1.AtomicResult(**dself)
+        else:
+            assert False, target_version
 
         return self_vN

--- a/qcelemental/models/v2/results.py
+++ b/qcelemental/models/v2/results.py
@@ -8,20 +8,15 @@ from pydantic import Field, constr, field_validator
 from ...util import provenance_stamp
 from .basemodels import ExtendedConfigDict, ProtoModel, qcschema_draft
 from .basis import BasisSet
-from .common_models import (
-    ComputeError,
-    DriverEnum,
-    Model,
-    Provenance,
-    check_convertible_version,
-    qcschema_input_default,
-    qcschema_output_default,
-)
+from .common_models import ComputeError, DriverEnum, Model, Provenance, check_convertible_version
 from .molecule import Molecule
 from .types import Array
 
 if TYPE_CHECKING:
     from .common_models import ReprArgs
+
+
+# ====  Properties  =============================================================
 
 
 class AtomicResultProperties(ProtoModel):
@@ -34,25 +29,24 @@ class AtomicResultProperties(ProtoModel):
     * nmo: number of molecular orbitals = :attr:`~qcelemental.models.AtomicResultProperties.calcinfo_nmo`
     """
 
-    schema_name: Literal["qcschema_atomicproperties"] = Field(
-        "qcschema_atomicproperties",
-        description=(
-            f"The QCSchema specification this model conforms to. Explicitly fixed as qcschema_atomicproperties."
-        ),
+    schema_name: Literal["qcschema_atomic_properties"] = Field(
+        "qcschema_atomic_properties", description=(f"The QCSchema specification to which this model conforms.")
     )
     # TRIAL schema_version: Literal[2] = Field(
     # TRIAL     2,
     # TRIAL     description="The version number of :attr:`~qcelemental.models.AtomicResultProperties.schema_name` to which this model conforms.",
     # TRIAL )
 
-    # Calcinfo
+    # ========  Calcinfo  =======================================================
+
     calcinfo_nbasis: Optional[int] = Field(None, description="The number of basis functions for the computation.")
     calcinfo_nmo: Optional[int] = Field(None, description="The number of molecular orbitals for the computation.")
     calcinfo_nalpha: Optional[int] = Field(None, description="The number of alpha electrons in the computation.")
     calcinfo_nbeta: Optional[int] = Field(None, description="The number of beta electrons in the computation.")
     calcinfo_natom: Optional[int] = Field(None, description="The number of atoms in the computation.")
 
-    # Canonical
+    # ========  Canonical  ======================================================
+
     nuclear_repulsion_energy: Optional[float] = Field(None, description="The nuclear repulsion energy.")
     return_energy: Optional[float] = Field(
         None,
@@ -68,6 +62,8 @@ class AtomicResultProperties(ProtoModel):
         description=f"The Hessian of the requested method, identical to :attr:`~qcelemental.models.AtomicResult.return_result` for :attr:`~qcelemental.models.AtomicInput.driver`\\ =\\ :attr:`~qcelemental.models.DriverEnum.hessian` computations.",
         json_schema_extra={"units": "E_h/a0^2"},
     )
+
+    # ========  Method data  ====================================================
 
     # SCF Keywords
     scf_one_electron_energy: Optional[float] = Field(
@@ -335,6 +331,10 @@ class WavefunctionProperties(ProtoModel):
         "occupations_b",
     }
 
+    schema_name: Literal["qcschema_wavefunction_properties"] = Field(
+        "qcschema_wavefunction_properties", description=f"The QCSchema specification to which this model conforms."
+    )
+
     # The full basis set description of the quantities
     basis: BasisSet = Field(..., description=str(BasisSet.__doc__))
     restricted: bool = Field(
@@ -589,6 +589,9 @@ class WavefunctionProperties(ProtoModel):
         return v
 
 
+# ====  Protocols  ==============================================================
+
+
 class WavefunctionProtocolEnum(str, Enum):
     r"""Wavefunction to keep from a computation."""
 
@@ -632,6 +635,8 @@ class NativeFilesProtocolEnum(str, Enum):
 class AtomicResultProtocols(ProtoModel):
     r"""Protocols regarding the manipulation of computational result data."""
 
+    schema_name: Literal["qcschema_atomic_protocols"] = "qcschema_atomic_protocols"
+
     wavefunction: WavefunctionProtocolEnum = Field(
         WavefunctionProtocolEnum.none, description=str(WavefunctionProtocolEnum.__doc__)
     )
@@ -647,10 +652,13 @@ class AtomicResultProtocols(ProtoModel):
     model_config = ExtendedConfigDict(force_skip_defaults=True)
 
 
+# ====  Inputs (Kw/Spec/In)  ====================================================
+
+
 class AtomicSpecification(ProtoModel):
     """Specification for a single point QC calculation"""
 
-    # schema_name: Literal["qcschema_atomicspecification"] = "qcschema_atomicspecification"
+    schema_name: Literal["qcschema_atomic_specification"] = "qcschema_atomic_specification"
     # schema_version: Literal[2] = Field(
     #     2,
     #     description="The version number of ``schema_name`` to which this model conforms.",
@@ -682,6 +690,8 @@ class AtomicSpecification(ProtoModel):
         loss_store = {}
         dself = self.model_dump()
         if target_version == 1:
+            dself.pop("schema_name")
+
             loss_store["protocols"] = dself.pop("protocols")
             loss_store["program"] = dself.pop("program")
 
@@ -695,9 +705,6 @@ class AtomicSpecification(ProtoModel):
         return self_vN
 
 
-### Primary models
-
-
 def atomic_input_json_schema_extra(schema, model):
     schema["$schema"] = qcschema_draft
 
@@ -706,11 +713,8 @@ class AtomicInput(ProtoModel):
     r"""The MolSSI Quantum Chemistry Schema"""
 
     id: Optional[str] = Field(None, description="The optional ID for the computation.")
-    schema_name: Literal["qcschema_input"] = Field(
-        qcschema_input_default,
-        description=(
-            f"The QCSchema specification this model conforms to. Explicitly fixed as {qcschema_input_default}."
-        ),
+    schema_name: Literal["qcschema_atomic_input"] = Field(
+        "qcschema_atomic_input", description=(f"The QCSchema specification to which this model conforms.")
     )
     schema_version: Literal[2] = Field(
         2,
@@ -755,12 +759,15 @@ class AtomicInput(ProtoModel):
 
         dself = self.model_dump()
         if target_version == 1:
+            dself.pop("schema_name")
+
             dself["driver"] = dself["specification"].pop("driver")
             dself["model"] = dself["specification"].pop("model")
             dself["keywords"] = dself["specification"].pop("keywords", None)
             dself["protocols"] = dself["specification"].pop("protocols", None)
             dself["extras"] = dself["specification"].pop("extras", {})
             dself["specification"].pop("program", None)  # TODO store?
+            dself["specification"].pop("schema_name", None)
             assert not dself["specification"], dself["specification"]
             dself.pop("specification")  # now empty
 
@@ -771,14 +778,14 @@ class AtomicInput(ProtoModel):
         return self_vN
 
 
+# ====  Results  ================================================================
+
+
 class AtomicResult(ProtoModel):
     r"""Results from a CMS program execution."""
 
-    schema_name: constr(strip_whitespace=True, pattern=r"^(qc\_?schema_output)$") = Field(  # type: ignore
-        qcschema_output_default,
-        description=(
-            f"The QCSchema specification this model conforms to. Explicitly fixed as {qcschema_output_default}."
-        ),
+    schema_name: Literal["qcschema_atomic_output"] = Field(
+        "qcschema_atomic_output", description=(f"The QCSchema specification to which this model conforms.")
     )
     schema_version: Literal[2] = Field(
         2,
@@ -810,17 +817,6 @@ class AtomicResult(ProtoModel):
         {},
         description="Additional information to bundle with the computation. Use for schema development and scratch space.",
     )
-
-    @field_validator("schema_name", mode="before")
-    @classmethod
-    def _input_to_output(cls, v):
-        r"""If qcschema_input is passed in, cast it to output, otherwise no"""
-        if v.lower().strip() in [qcschema_input_default, qcschema_output_default]:
-            return qcschema_output_default
-        raise ValueError(
-            "Only {0} or {1} is allowed for schema_name, "
-            "which will be converted to {0}".format(qcschema_output_default, qcschema_input_default)
-        )
 
     @field_validator("schema_version", mode="before")
     def _version_stamp(cls, v):
@@ -968,6 +964,8 @@ class AtomicResult(ProtoModel):
 
         dself = self.model_dump()
         if target_version == 1:
+            dself.pop("schema_name")
+
             # for input_data, work from model, not dict, to use convert_v
             dself.pop("input_data")
             input_data = self.input_data.convert_v(1).model_dump()  # exclude_unset=True, exclude_none=True

--- a/qcelemental/tests/test_model_general.py
+++ b/qcelemental/tests/test_model_general.py
@@ -74,15 +74,20 @@ def test_repr_result(request, schema_versions):
     assert "'gradient'" in str(result)
 
 
-def test_repr_optimization(schema_versions):
+def test_repr_optimization(schema_versions, request):
     OptimizationInput = schema_versions.OptimizationInput
 
-    opt = OptimizationInput(
-        **{
+    if "v2" in request.node.name:
+        optin = {
+            "specification": {"specification": {"driver": "gradient", "model": {"method": "UFF"}}},
+            "initial_molecule": {"symbols": ["He"], "geometry": [0, 0, 0]},
+        }
+    else:
+        optin = {
             "input_specification": {"driver": "gradient", "model": {"method": "UFF"}},
             "initial_molecule": {"symbols": ["He"], "geometry": [0, 0, 0]},
         }
-    )
+    opt = OptimizationInput(**optin)
 
     assert "molecule_hash" in str(opt)
     assert "molecule_hash" in repr(opt)

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -186,24 +186,44 @@ CARBON      6.0      0.0000000000      0.0000000000     -0.1018060978
 
 
 @pytest.fixture(scope="function")
-def optimization_data_fixture(result_data_fixture):
+def optimization_data_fixture(result_data_fixture, request):
     trajectory = []
     energies = []
+    props = []
     for x in range(5):
         result = result_data_fixture.copy()
         result["return_result"] = x
         trajectory.append(result)
         energies.append(x)
+        props.append({"return_energy": x})
 
-    ret = {
-        "initial_molecule": result_data_fixture["molecule"],
-        "final_molecule": result_data_fixture["molecule"],
-        "trajectory": trajectory,
-        "energies": energies,
-        "success": True,
-        "provenance": {"creator": "qcel"},
-        "input_specification": {"model": {"method": "UFF"}},
-    }
+    if "v2" in request.node.name:
+        ret = {
+            "final_molecule": result_data_fixture["molecule"],
+            "trajectory_results": trajectory,
+            "trajectory_properties": props,
+            "success": True,
+            "provenance": {"creator": "qcel"},
+            "input_data": {
+                "initial_molecule": result_data_fixture["molecule"],
+                "specification": {
+                    "program": "an opt program",
+                    "specification": {"driver": "gradient", "model": {"method": "UFF"}, "program": "a qc program"},
+                },
+            },
+            "properties": {"optimization_iterations": 14},
+        }
+    else:
+        ret = {
+            "initial_molecule": result_data_fixture["molecule"],
+            "final_molecule": result_data_fixture["molecule"],
+            "trajectory": trajectory,
+            "energies": energies,
+            "success": True,
+            "provenance": {"creator": "qcel"},
+            "keywords": {"program": "a qc program"},
+            "input_specification": {"model": {"method": "UFF"}},
+        }
 
     return ret
 
@@ -540,15 +560,19 @@ def test_native_protocols(protocol, provided, expected, native_data_fixture, req
     "keep, indices",
     [(None, [0, 1, 2, 3, 4]), ("all", [0, 1, 2, 3, 4]), ("initial_and_final", [0, 4]), ("final", [4]), ("none", [])],
 )
-def test_optimization_trajectory_protocol(keep, indices, optimization_data_fixture, schema_versions):
+def test_optimization_trajectory_protocol(keep, indices, optimization_data_fixture, schema_versions, request):
     OptimizationResult = schema_versions.OptimizationResult
 
     if keep is not None:
-        optimization_data_fixture["protocols"] = {"trajectory": keep}
+        if "v2" in request.node.name:
+            optimization_data_fixture["input_data"]["specification"]["protocols"] = {"trajectory": keep}
+        else:
+            optimization_data_fixture["protocols"] = {"trajectory": keep}
     opt = OptimizationResult(**optimization_data_fixture)
 
-    assert len(opt.trajectory) == len(indices)
-    for result, index in zip(opt.trajectory, indices):
+    trajs_target = opt.trajectory_results if "v2" in request.node.name else opt.trajectory
+    assert len(trajs_target) == len(indices)
+    for result, index in zip(trajs_target, indices):
         assert result.return_result == index
 
 
@@ -745,11 +769,18 @@ def every_model_fixture(request):
 
     smodel = "OptimizationInput"
     data = request.getfixturevalue("optimization_data_fixture")
-    data = {k: data[k] for k in ["initial_molecule", "input_specification"]}
+    if "v2" in request.node.name:
+        data = data["input_data"]
+    else:
+        data = {k: data[k] for k in ["initial_molecule", "input_specification", "keywords"]}
     datas[smodel] = data
 
     smodel = "OptimizationSpecification"
-    data = {"procedure": "pyberny"}
+    if "v2" in request.node.name:
+        data = request.getfixturevalue("optimization_data_fixture")
+        data = data["input_data"]["specification"]
+    else:
+        data = {"procedure": "pyberny"}
     datas[smodel] = data
 
     smodel = "OptimizationProtocols"
@@ -830,7 +861,7 @@ _model_classes_struct = [
     pytest.param("OptimizationSpecification",   "OptimizationSpecification",    id="OptSpec"),
     pytest.param("OptimizationProtocols",       "OptimizationProtocols",        id="OptPtcl"),
     pytest.param("OptimizationResult",          "OptimizationResult",           id="OptRes"),
-    # pytest.param(None,                        "OptimizationProperties",       id="OptProp"),
+    pytest.param(None,                          "OptimizationProperties",       id="OptProp"),
     pytest.param("TorsionDriveInput",           "TorsionDriveInput",            id="TDIn"), 
     # pytest.param(None,                        "TorsionDriveSpecification",    id="TDSpec"), 
     pytest.param("TDKeywords",                  "TDKeywords",                   id="TDKw"),  # TODO TorsionDriveKeywords
@@ -877,7 +908,7 @@ def test_model_survey_success(smodel1, smodel2, every_model_fixture, request, sc
         "v1-MBSpec"   : None,  "v2-MBSpec"   : None,  # v2 DNE
         "v1-MBKw"     : None,  "v2-MBKw"     : None,  # v2 DNE
         "v1-MBPtcl"   : None,  "v2-MBPtcl"   : None,  # v2 DNE
-        "v1-MBRes"    : True,  "v2-MBRes"    : True,  # v2 DNE
+        "v1-MBRes"    : True,  "v2-MBRes"    : None,  # v2 DNE  TODO v2 True
         "v1-MBProp"   : None,  "v2-MBProp"   : None,  # v2 DNE
     }[anskey]
     # fmt: on
@@ -904,16 +935,33 @@ def test_model_survey_success(smodel1, smodel2, every_model_fixture, request, sc
 
     # check success override
     if ans is not None:
-        data["success"] = not ans
+        data2 = copy.deepcopy(data)
+        data2["success"] = not ans
         if "v2" in anskey:
             # v2 has enforced T/F
             with pytest.raises(pydantic.ValidationError) as e:
-                instance = model(**data)
+                instance = model(**data2)
             assert (cptd := getattr(instance, fld, "not found!")) == ans, f"[b] field {fld} = {cptd} != {ans}"
         else:
             # v1 can be reset to T/F
-            instance = model(**data)
+            instance = model(**data2)
             assert (cptd := getattr(instance, fld, "not found!")) == (not ans), f"[b] field {fld} = {cptd} != {not ans}"
+
+    # check inheritance
+    if smodel.endswith("Result"):
+        instance = model(**data)
+        smodelin = smodel.replace("Result", "Input")
+        if "ManyBody" in smodelin:
+            modelin = getattr(qcmanybody.models, smodelin)
+        else:
+            modelin = getattr(schema_versions, smodelin)
+
+        if "v2" in anskey or "ManyBody" in smodel:
+            # for v2, <>Result has a field that contains <>Input. ManyBody v1 led the way here.
+            assert not isinstance(instance, modelin), f"[c] v2 {smodel} unexpectedly inherits {smodelin}"
+        else:
+            # for v1, <>Result inherits <>Input
+            assert isinstance(instance, modelin), f"[c] v1 {smodel} does not inherit {smodelin}"
 
 
 @pytest.mark.parametrize("smodel1,smodel2", _model_classes_struct)
@@ -990,7 +1038,7 @@ def test_model_survey_extras(smodel1, smodel2, every_model_fixture, request, sch
     anskey = request.node.callspec.id.replace("None", "v1")
     # fmt: off
     ans = {
-        # v2: In/Ptcl/Prop/Kw + BasisSet, no! others, yes. In is questionable.
+        # v2: In/Ptcl/Prop/Kw + BasisSet, no! others, yes. <In> is questionable.
         "v1-Mol-A"    : {},    "v2-Mol-A"    : {},
         "v1-Mol-B"    : {},    "v2-Mol-B"    : {},
         "v1-BasisSet" : None,  "v2-BasisSet" : None,
@@ -1001,7 +1049,7 @@ def test_model_survey_extras(smodel1, smodel2, every_model_fixture, request, sch
         "v1-AtRes"    : {},    "v2-AtRes"    : {},
         "v1-AtProp"   : None,  "v2-AtProp"   : None,
         "v1-WfnProp"  : None,  "v2-WfnProp"  : None,
-        "v1-OptIn"    : {},    "v2-OptIn"    : {},  # TODO None
+        "v1-OptIn"    : {},    "v2-OptIn"    : None,
         "v1-OptSpec"  : None,  "v2-OptSpec"  : {},
         "v1-OptPtcl"  : None,  "v2-OptPtcl"  : None,
         "v1-OptRes"   : {},    "v2-OptRes"   : {},
@@ -1093,9 +1141,10 @@ def test_model_survey_convertable(smodel1, smodel2, every_model_fixture, request
     anskey = request.node.callspec.id.replace("None", "v1")
     # fmt: off
     ans = {
-        # "v1-Mol-A"    ,  "v2-Mol-A"   ,   
-        # "v1-Mol-B"    ,  "v2-Mol-B"   ,   
-        # "v1-BasisSet" ,  "v2-BasisSet",
+        # convert_v() for user-facing fns. uncomment lines if this expands
+        # "v1-Mol-A"    ,  "v2-Mol-A"   ,  # TODO
+        # "v1-Mol-B"    ,  "v2-Mol-B"   ,  # TODO
+        # "v1-BasisSet" ,  "v2-BasisSet",  # TODO
         "v1-FailedOp" ,  "v2-FailedOp",
         "v1-AtIn"     ,  "v2-AtIn"    ,
         "v1-AtSpec"   ,  "v2-AtSpec"  ,
@@ -1104,7 +1153,7 @@ def test_model_survey_convertable(smodel1, smodel2, every_model_fixture, request
         # "v1-AtProp"   ,  "v2-AtProp"  , 
         # "v1-WfnProp"  ,  "v2-WfnProp" , 
         "v1-OptIn"    ,  "v2-OptIn"   , 
-        # "v1-OptSpec"  ,  "v2-OptSpec" , 
+        "v1-OptSpec"  ,  "v2-OptSpec" , 
         # "v1-OptPtcl"  ,  "v2-OptPtcl" , 
         "v1-OptRes"   ,  "v2-OptRes"  , 
         # "v1-OptProp"  ,  "v2-OptProp" , 
@@ -1141,9 +1190,84 @@ def test_model_survey_convertable(smodel1, smodel2, every_model_fixture, request
     data = every_model_fixture[smodel_fro]
 
     # check converts and converts to expected class
-    instance_fro = model_fro(**data)
-    instance_to = instance_fro.convert_v(1 if "v2" in anskey else 2)
-    assert isinstance(instance_to, model_to), f"instance {model_fro} failed to convert to {model_to}"
+    if anskey == "v1-OptSpec":
+        # v1 OptSpec has no convert_v
+        instance_fro = model_fro(**data)
+        with pytest.raises(AttributeError):
+            instance_to = instance_fro.convert_v(2)
+    else:
+        instance_fro = model_fro(**data)
+        instance_to = instance_fro.convert_v(1 if "v2" in anskey else 2)
+        assert isinstance(instance_to, model_to), f"instance {model_fro} failed to convert to {model_to}"
+
+
+@pytest.mark.parametrize("smodel1,smodel2", _model_classes_struct)
+def test_model_survey_schema_name(smodel1, smodel2, every_model_fixture, request, schema_versions):
+    anskey = request.node.callspec.id.replace("None", "v1")
+    # fmt: off
+    ans = {
+        # v2: In/Res + Mol/BasisSet/FailedOp, yes! Kw/Ptcl, no. Prop/Spec uncertain.
+        # note output not result
+        "v1-Mol-A"    : "qcschema_molecule",                    "v2-Mol-A"    : "qcschema_molecule",
+        "v1-Mol-B"    : "qcschema_molecule",                    "v2-Mol-B"    : "qcschema_molecule",
+        "v1-BasisSet" : "qcschema_basis",                       "v2-BasisSet" : "qcschema_basis",  # TODO qcschema_basis_set?
+        "v1-FailedOp" : None,                                   "v2-FailedOp" : "qcschema_failed_operation",
+        "v1-AtIn"     : "qcschema_input",                       "v2-AtIn"     : "qcschema_atomic_input",  # TODO standardize!
+        "v1-AtSpec"   : "qcschema_input",                       "v2-AtSpec"   : "qcschema_atomic_specification",
+        "v1-AtPtcl"   : None,                                   "v2-AtPtcl"   : "qcschema_atomic_protocols",
+        "v1-AtRes"    : "qcschema_output",                      "v2-AtRes"    : "qcschema_atomic_output",  # TODO standardize! _result?
+        "v1-AtProp"   : None,                                   "v2-AtProp"   : "qcschema_atomic_properties",
+        "v1-WfnProp"  : None,                                   "v2-WfnProp"  : "qcschema_wavefunction_properties",
+        "v1-OptIn"    : "qcschema_optimization_input",          "v2-OptIn"    : "qcschema_optimization_input",
+        "v1-OptSpec"  : "qcschema_optimization_specification",  "v2-OptSpec"  : "qcschema_optimization_specification",
+        "v1-OptPtcl"  : None,                                   "v2-OptPtcl"  : "qcschema_optimization_protocols",
+        "v1-OptRes"   : "qcschema_optimization_output",         "v2-OptRes"   : "qcschema_optimization_output",  # TODO change to _result?
+        "v1-OptProp"  : None,                                   "v2-OptProp"  : "qcschema_optimization_properties",  # v1 DNE
+        "v1-TDIn"     : "qcschema_torsion_drive_input",         "v2-TDIn"     : "qcschema_torsion_drive_input",
+        "v1-TDSpec"   : None,                                   "v2-TDSpec"   : "qcschema_torsion_drive_specification",  # v1 DNE
+        "v1-TDKw"     : None,                                   "v2-TDKw"     : "qcschema_torsion_drive_keywords",
+        "v1-TDPtcl"   : None,                                   "v2-TDPtcl"   : None,  # v1 DNE, v2 DNE
+        "v1-TDRes"    : "qcschema_torsion_drive_output",        "v2-TDRes"    : "qcschema_torsion_drive_output",  # TODO change to _result?
+        "v1-TDProp"   : None,                                   "v2-TDProp"   : None,  # v1 DNE, v2 DNE
+        "v1-MBIn"     : "qcschema_manybodyinput",               "v2-MBIn"     : "qcschema_many_body_input",     # v2 DNE
+        "v1-MBSpec"   : "qcschema_manybodyspecification",       "v2-MBSpec"   : "qcschema_many_body_specification",  # v2 DNE
+        "v1-MBKw"     : "qcschema_manybodykeywords",            "v2-MBKw"     : "qcschema_many_body_keywords",       # v2 DNE
+        "v1-MBPtcl"   : None,                                   "v2-MBPtcl"   : "qcschema_many_body_protocols",  # v2 DNE
+        "v1-MBRes"    : "qcschema_manybodyresult",              "v2-MBRes"    : "qcschema_many_body_result",     # v2 DNE
+        "v1-MBProp"   : "qcschema_manybodyproperties",          "v2-MBProp"   : "qcschema_many_body_properties",  # v2 DNE
+    }[anskey]
+    # fmt: on
+
+    fieldsattr = "model_fields" if "v2" in anskey else "__fields__"
+    smodel = smodel2 if "v2" in anskey else smodel1
+    if smodel is None:
+        pytest.skip("model not available for this schema version")
+    if "ManyBody" in smodel:
+        import qcmanybody
+
+        model = getattr(qcmanybody.models, smodel.split("-")[0])
+    else:
+        model = getattr(schema_versions, smodel.split("-")[0])
+    data = every_model_fixture[smodel]
+
+    # check default name set
+    instance = model(**data)
+    fld = "schema_name"
+    if ans is None:
+        assert fld not in (cptd := getattr(instance, fieldsattr)), f"[a] field {fld} unexpectedly present: {cptd}"
+    else:
+        assert (cptd := getattr(instance, fld, "not found!")) == ans, f"[a] field {fld} = {cptd} != {ans}"
+
+    # check wrong name fatal
+    if ans is not None:
+        data["schema_name"] = "Asdf"
+        if "Molecule-B" in smodel:
+            # TODO fix mol validated pathway when upgrade Mol
+            with pytest.raises(qcel.ValidationError) as e:
+                instance = model(**data)
+        else:
+            with pytest.raises((pydantic.ValidationError, pydantic.v1.ValidationError)) as e:
+                instance = model(**data)
 
 
 def test_result_model_deprecations(result_data_fixture, optimization_data_fixture, request):

--- a/qcelemental/tests/test_utils.py
+++ b/qcelemental/tests/test_utils.py
@@ -385,6 +385,7 @@ def atomic_result_data(request):
         "success": True,
     }
     if "v2" in request.node.name:
+        data["schema_name"] = "qcschema_atomic_output"
         data["input_data"] = {
             "molecule": data["molecule"],
             "specification": {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
- [x] Unlike previous PRs that changed one field at a time in Atomic<> schema (has a large footprint in QCEngine), this does the more extensive rearrangement of Opt<> and TD<> schemas all at once (albeit small footprint in QCEngine).
- The changelog is overdetailed and unorganized at this point. A easier way (for some) to see the planned changes is in this  figure, where v1/v2 pairs of Atomic<>, Opt<>, TD<> schemas are shown with old/new fields aligned.

[QCSchema_models_wide2_12Dec_cean.pdf](https://github.com/user-attachments/files/18128276/QCSchema_models_wide2_12Dec_cean.pdf)

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
