### PR TITLE
fix: if verbose, do log info statements

### DIFF
--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -1413,7 +1413,7 @@ class Molecule(ProtoModel):
             amol.nuclear_repulsion_energy(),
             "Q: concern_mol-->returned_mol NRE uncorrupted",
             atol=1.0e-4,
-            quiet=(verbose > 1),
+            quiet=(verbose < 1),
         )
         if mols_align:
             assert compare_values(
@@ -1421,13 +1421,13 @@ class Molecule(ProtoModel):
                 amol.nuclear_repulsion_energy(),
                 "Q: concern_mol-->returned_mol NRE matches ref_mol",
                 atol=1.0e-4,
-                quiet=(verbose > 1),
+                quiet=(verbose < 1),
             )
             assert compare(
                 True,
                 np.allclose(ref_mol.geometry, amol.geometry, atol=4),
                 "Q: concern_mol-->returned_mol geometry matches ref_mol",
-                quiet=(verbose > 1),
+                quiet=(verbose < 1),
             )
 
         return amol, {"rmsd": rmsd, "mill": solution}
@@ -1547,17 +1547,17 @@ class Molecule(ProtoModel):
             solution = data["mill"]
 
             assert compare(
-                True, np.allclose(solution.shift, perturbation.shift, atol=1.0e-6), "shifts equiv", quiet=(verbose > 1)
+                True, np.allclose(solution.shift, perturbation.shift, atol=1.0e-6), "shifts equiv", quiet=(verbose < 1)
             )
             if not do_resort:
                 assert compare(
                     True,
                     np.allclose(solution.rotation.T, perturbation.rotation),
                     "rotations transpose",
-                    quiet=(verbose > 1),
+                    quiet=(verbose < 1),
                 )
             if solution.mirror:
-                assert compare(True, do_mirror, "mirror allowed", quiet=(verbose > 1))
+                assert compare(True, do_mirror, "mirror allowed", quiet=(verbose < 1))
 
         return cmol, {"rmsd": rmsd, "mill": perturbation}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
there is a small issue in the molecule. a higher verbosity, in general, results in more log messages. however, in the molecule-model, it is implemented the wrong way around. a higher verbosity results in quiet=True, which is not expected.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
fix verbosity of models/molecule.py log messages

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
