### PR TITLE
avoid uncontrollable printing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,8 +20,13 @@ Changelog
 .. +++++
 
 
-0.30.0 / 2025-MM-DD (Unreleased)
+0.30.0 / 2026-01-07
 -------------------
+
+Enhancements
+++++++++++++
+- (:issue:`368`, :pr:`379`) Remove uneeded printing and hook up verbosity control for
+  charge/multiplicity reconciliation for ``Molecule.from_data``. @jaclark5
 
 Bug Fixes
 +++++++++

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -946,7 +946,11 @@ class Molecule(ProtoModel):
                 raise TypeError("Input type not understood, please supply the 'dtype' kwarg.")
 
         if dtype in ["string", "psi4", "xyz", "xyz+"]:
-            mol_dict = from_string(data, dtype if dtype != "string" else None)
+            subkwargs = {}
+            for key in ["verbose"]:
+                if key in kwargs:
+                    subkwargs[key] = kwargs.pop(key)
+            mol_dict = from_string(data, dtype if dtype != "string" else None, **subkwargs)
             assert isinstance(mol_dict, dict)
             input_dict = to_schema(mol_dict["qm"], dtype=2, np_out=True)
             input_dict = _filter_defaults(input_dict)

--- a/qcelemental/molparse/chgmult.py
+++ b/qcelemental/molparse/chgmult.py
@@ -517,8 +517,9 @@ def validate_and_fill_chgmult(
         err = """Inconsistent or unspecified chg/mult: sys chg: {}, frag chg: {}, sys mult: {}, frag mult: {}""".format(
             molecular_charge, fragment_charges, molecular_multiplicity, fragment_multiplicities
         )
-        if verbose > -1:
-            print("\n\n" + "\n".join(text))
+        extra_err = [ln for ln in text if "candidate" in ln]
+        if extra_err:
+            err += "\n\n" + "\n".join(extra_err)
         raise ValidationError(err)
 
     def stringify(start, final):

--- a/qcelemental/molparse/from_arrays.py
+++ b/qcelemental/molparse/from_arrays.py
@@ -124,7 +124,7 @@ def from_input_arrays(
             nonphysical=nonphysical,
             mtol=mtol,
             copy=copy,
-            verbose=1,
+            verbose=verbose,
         )
         update_with_error(molinit, {"qm": processed})
         if molinit["qm"] == {}:

--- a/qcelemental/molparse/from_string.py
+++ b/qcelemental/molparse/from_string.py
@@ -279,6 +279,7 @@ def from_string(
         enable_efp=enable_efp,
         missing_enabled_return_qm=missing_enabled_return_qm,
         missing_enabled_return_efp=missing_enabled_return_efp,
+        verbose=verbose,
         **molinit,
     )
 

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -990,3 +990,41 @@ def test_molecular_weight(mol_string, args, formula, formula_dict, molecular_wei
     # assert (abs(ret := mol.nuclear_repulsion_energy(**args)) - nre) < 1.0e-5, f"nre: {ret} != {nre}"
     # assert (ret := mol.element_composition(**args)) == formula_dict, f"element_composition: {ret} != {formula_dict}"
     # assert (ret := mol.get_molecular_formula()) == formula, f"get_molecular_formula: {ret} != {formula}"
+
+
+@pytest.mark.parametrize("verbose", [1, 5])
+def test_molecule_verbose(capsys, verbose):
+    Molecule.from_data("""0 3\nNe 0 0 0\n--\nNe 2 2 2\n""", verbose=verbose)
+    captured = capsys.readouterr()
+    if verbose > 1:
+        assert "Assess candidate" in captured.out
+    else:
+        assert captured.out == ""
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize("verbose", [1, 2])
+def test_molecule_verbose_368(capsys, verbose):
+    with pytest.raises(qcel.ValidationError) as e:
+        qcel.models.Molecule(
+            symbols=["C", "C", "Pd", "C", "H", "H", "H", "H", "H"],
+            geometry=[
+                [-39.98282536, -71.86061537, 15.18016997],
+                [-38.04585608, -70.66630846, 16.10613577],
+                [-36.50194984, -73.22499764, 13.02399246],
+                [-35.83676624, -71.39763247, 16.918718],
+                [-40.95225486, -73.22688736, 16.41038167],
+                [-41.39256105, -70.74756668, 14.13326169],
+                [-37.87578073, -68.8030385, 15.20284668],
+                [-34.33821343, -69.96522007, 17.07556527],
+                [-35.77818473, -72.64674144, 18.57978727],
+            ],
+            molecular_charge=0,
+            molecular_multiplicity=3,
+            verbose=verbose,
+        )
+    captured = capsys.readouterr()
+
+    # check https://github.com/MolSSI/QCElemental/pull/379 sticks, regardless of verbose
+    assert "fm: [3, 1, 2]" not in captured.out
+    assert "Inconsistent or unspecified chg/mult" in str(e.value)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Addresses #368 as stated. I moved the printing to the error msg and allowed verbose to be passed through from Mol creation. But I wonder if your trouble was definitely around line 522 (which only printed when it was about to throw) or similar content around line 563, @jaclark5?

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [x] Code base linted
- [x] Ready to go

closes #368 