### PR TITLE
Some small fixes for v2 Molecule

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,7 @@ Breaking Changes
 Breaking Changes (low impact)
 +++++++++++++++++++++++++++++
 - (:pr:`382`) Remove CPU (`ProcessorInfo` and `ProcessorContext`) and DFT info (`DFTFunctionalInfo` and `DFTFunctionalContext`) classes and functionality
+- (:pr:`388`) Molecule: Fix imports, printing of float multiplicity, and returning `type(self)` to handle derived classes
 - (:pr:`389`) Remove the QCElemental pydantic autodoc module (`util.autodocs` module, classes `AutoPydanticDocGenerator` and `AutodocBaseSettings`)
 
 New Features

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,7 +31,7 @@ Breaking Changes
 Breaking Changes (low impact)
 +++++++++++++++++++++++++++++
 - (:pr:`382`) Remove CPU (`ProcessorInfo` and `ProcessorContext`) and DFT info (`DFTFunctionalInfo` and `DFTFunctionalContext`) classes and functionality
-- (:pr:`388`) Molecule: Fix imports, printing of float multiplicity, and returning `type(self)` to handle derived classes
+- (:pr:`388`) Molecule: Fix imports, typing, `@property` logic, printing of float multiplicity, and returning `type(self)` to handle derived classes
 - (:pr:`389`) Remove the QCElemental pydantic autodoc module (`util.autodocs` module, classes `AutoPydanticDocGenerator` and `AutodocBaseSettings`)
 
 New Features

--- a/qcelemental/models/v1/molecule.py
+++ b/qcelemental/models/v1/molecule.py
@@ -603,7 +603,7 @@ class Molecule(ProtoModel):
         """
         text = ""
 
-        text += """    Geometry (in {0:s}), charge = {1:.1f}, multiplicity = {2:d}:\n\n""".format(
+        text += """    Geometry (in {0:s}), charge = {1:.1f}, multiplicity = {2:.2f}:\n\n""".format(
             "Angstrom", self.molecular_charge, self.molecular_multiplicity
         )
         text += """       Center              X                  Y                   Z       \n"""

--- a/qcelemental/models/v2/molecule.py
+++ b/qcelemental/models/v2/molecule.py
@@ -5,13 +5,14 @@ Molecule Object Model
 import collections
 import hashlib
 import json
+import sys
 import warnings
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Optional, Tuple, Union, cast
 
 import numpy as np
-from pydantic import Field, constr, field_validator, model_serializer
+from pydantic import Field, field_validator, model_serializer
 from typing_extensions import Annotated
 
 try:

--- a/qcelemental/models/v2/molecule.py
+++ b/qcelemental/models/v2/molecule.py
@@ -593,7 +593,7 @@ class Molecule(ProtoModel):
         r"""
         Centers the molecule and orients via inertia tensor before returning a new Molecule
         """
-        return Molecule(orient=True, **self.model_dump())
+        return type(self)(orient=True, **self.model_dump())
 
     def compare(self, other):
         warnings.warn(
@@ -610,7 +610,7 @@ class Molecule(ProtoModel):
         import qcelemental
 
         if isinstance(other, dict):
-            other = Molecule(orient=False, **other)
+            other = type(self)(orient=False, **other)
         elif isinstance(other, Molecule) or (
             sys.version_info < (3, 14) and isinstance(other, (Molecule, qcelemental.models.v1.Molecule))
         ):
@@ -808,7 +808,7 @@ class Molecule(ProtoModel):
         constructor_dict["real"] = real_atoms
         constructor_dict["masses"] = masses
 
-        return Molecule(orient=orient, **constructor_dict)
+        return type(self)(orient=orient, **constructor_dict)
 
     def to_string(  # type: ignore
         self,
@@ -1451,7 +1451,7 @@ class Molecule(ProtoModel):
         adict = {**concern_mol.model_dump(), **aupdate}
 
         # preserve intrinsic symmetry with lighter truncation
-        amol = Molecule(validate=True, **adict, geometry_noise=13)
+        amol = type(self)(validate=True, **adict, geometry_noise=13)
 
         # TODO -- can probably do more with fragments in amol now that
         #         Mol is something with non-contig frags. frags now discarded.
@@ -1575,7 +1575,7 @@ class Molecule(ProtoModel):
         cdict = {**ref_mol.model_dump(), **cupdate}
 
         # preserve intrinsic symmetry with lighter truncation
-        cmol = Molecule(validate=True, **cdict, geometry_noise=13)
+        cmol = type(self)(validate=True, **cdict, geometry_noise=13)
 
         rmsd = np.linalg.norm(cgeom - rgeom) * constants.bohr2angstroms / np.sqrt(nat)
         if verbose >= 1:

--- a/qcelemental/models/v2/molecule.py
+++ b/qcelemental/models/v2/molecule.py
@@ -649,7 +649,7 @@ class Molecule(ProtoModel):
         """
         text = ""
 
-        text += """    Geometry (in {0:s}), charge = {1:.1f}, multiplicity = {2:d}:\n\n""".format(
+        text += """    Geometry (in {0:s}), charge = {1:.1f}, multiplicity = {2:.2f}:\n\n""".format(
             "Angstrom", self.molecular_charge, self.molecular_multiplicity
         )
         text += """       Center              X                  Y                   Z       \n"""

--- a/qcelemental/models/v2/molecule.py
+++ b/qcelemental/models/v2/molecule.py
@@ -2,6 +2,8 @@
 Molecule Object Model
 """
 
+from __future__ import annotations
+
 import collections
 import hashlib
 import json
@@ -15,12 +17,9 @@ import numpy as np
 from pydantic import Field, field_validator, model_serializer
 from typing_extensions import Annotated
 
-try:
-    import nglview
-except ModuleNotFoundError:
-    # import is purely for forward reference for docs-build. import is not required except for Molecule.show()
-    pass
-
+from .basemodels import ProtoModel, check_convertible_version, qcschema_draft
+from .common_models import Provenance
+from .types import Array
 # molparse imports separated b/c https://github.com/python/mypy/issues/7203
 from ...molparse.from_arrays import from_arrays
 from ...molparse.from_schema import from_schema
@@ -31,11 +30,11 @@ from ...periodic_table import periodictable
 from ...physical_constants import constants
 from ...testing import compare, compare_values
 from ...util import deserialize, measure_coordinates, msgpackext_loads, provenance_stamp, which_import
-from .basemodels import ProtoModel, check_convertible_version, qcschema_draft
-from .common_models import Provenance
-from .types import Array
 
 if TYPE_CHECKING:
+    import nglview
+    from numpy.typing import NDArray
+
     import qcelemental
 
     from .common_models import ReprArgs
@@ -247,14 +246,13 @@ class Molecule(ProtoModel):
     )
 
     # Fragment and connection data
-    connectivity_: Optional[List[Tuple[NonnegativeInt, NonnegativeInt, BondOrderFloat]]] = Field(  # type: ignore
+    connectivity: Optional[List[Tuple[NonnegativeInt, NonnegativeInt, BondOrderFloat]]] = Field(  # type: ignore
         None,
         description="A list of bonds within the molecule. "
         "Each entry is a tuple of ``(atom_index_A, atom_index_B, bond_order)`` where the ``atom_index`` "
         "matches the 0-indexed indices of all other per-atom settings like "
         ":attr:`~qcelemental.models.Molecule.symbols` and :attr:`~qcelemental.models.Molecule.real`. "
         "Bonds may be freely reordered and inverted.",
-        alias="connectivity",
         min_length=1,
     )
     fragments_: Optional[List[Array[np.int32]]] = Field(  # type: ignore
@@ -475,66 +473,60 @@ class Molecule(ProtoModel):
         ]
 
     @property
-    def masses(self) -> Array[float]:
-        masses = self.__dict__.get("masses_")
-        if masses is None:
-            masses = np.array([periodictable.to_mass(x) for x in self.symbols])
-        return masses
+    def masses(self) -> NDArray[np.float64]:
+        if self.masses_ is not None:
+            return self.masses_
+
+        return np.array([periodictable.to_mass(x) for x in self.symbols])
 
     @property
-    def real(self) -> Array[bool]:
-        real = self.__dict__.get("real_")
-        if real is None:
-            real = np.array([True for x in self.symbols])
-        return real
+    def real(self) -> NDArray[np.bool_]:
+        if self.real_ is not None:
+            return self.real_
+
+        return np.array([True for _ in self.symbols])
 
     @property
-    def atom_labels(self) -> Array[str]:
-        atom_labels = self.__dict__.get("atom_labels_")
-        if atom_labels is None:
-            atom_labels = np.array(["" for x in self.symbols])
-        return atom_labels
+    def atom_labels(self) -> NDArray[np.str_]:
+        if self.atom_labels_ is not None:
+            return self.atom_labels_
+
+        return np.array(["" for x in self.symbols])
 
     @property
-    def atomic_numbers(self) -> Array[np.int16]:
-        atomic_numbers = self.__dict__.get("atomic_numbers_")
-        if atomic_numbers is None:
-            atomic_numbers = np.array([periodictable.to_Z(x) for x in self.symbols])
-        return atomic_numbers
+    def atomic_numbers(self) -> NDArray[np.int16]:
+        if self.atomic_numbers_ is not None:
+            return self.atomic_numbers_
+
+        return np.array([periodictable.to_Z(x) for x in self.symbols], dtype=np.int16)
 
     @property
-    def mass_numbers(self) -> Array[np.int16]:
-        mass_numbers = self.__dict__.get("mass_numbers_")
-        if mass_numbers is None:
-            mass_numbers = np.array([periodictable.to_A(x) for x in self.symbols])
-        return mass_numbers
+    def mass_numbers(self) -> NDArray[np.int16]:
+        if self.mass_numbers_ is not None:
+            return self.mass_numbers_
+
+        return np.array([periodictable.to_A(x) for x in self.symbols], dtype=np.int16)
 
     @property
-    def connectivity(self) -> List[Tuple[int, int, float]]:
-        connectivity = self.__dict__.get("connectivity_")
-        # default is None, not []
-        return connectivity
+    def fragments(self) -> List[NDArray[np.int32]]:
+        if self.fragments_ is not None:
+            return self.fragments_
 
-    @property
-    def fragments(self) -> List[Array[np.int32]]:
-        fragments = self.__dict__.get("fragments_")
-        if fragments is None:
-            fragments = [np.arange(len(self.symbols), dtype=np.int32)]
-        return fragments
+        return [np.arange(len(self.symbols), dtype=np.int32)]
 
     @property
     def fragment_charges(self) -> List[float]:
-        fragment_charges = self.__dict__.get("fragment_charges_")
-        if fragment_charges is None:
-            fragment_charges = [self.molecular_charge]
-        return fragment_charges
+        if self.fragment_charges_ is not None:
+            return self.fragment_charges_
+
+        return [self.molecular_charge]
 
     @property
     def fragment_multiplicities(self) -> List[float]:
-        fragment_multiplicities = self.__dict__.get("fragment_multiplicities_")
-        if fragment_multiplicities is None:
-            fragment_multiplicities = [self.molecular_multiplicity]
-        return fragment_multiplicities
+        if self.fragment_multiplicities_ is not None:
+            return self.fragment_multiplicities_
+
+        return [self.molecular_multiplicity]
 
     ### Non-Pydantic API functions
 
@@ -880,7 +872,7 @@ class Molecule(ProtoModel):
         Examples
         --------
 
-        >>> methane = qcelemental.models.Molecule('''
+        >>> methane = qcelemental.models.v2.Molecule.from_data('''
         ... H      0.5288      0.1610      0.9359
         ... C      0.0000      0.0000      0.0000
         ... H      0.2051      0.8240     -0.6786
@@ -890,14 +882,14 @@ class Molecule(ProtoModel):
         >>> methane.get_molecular_formula()
         CH4
 
-        >>> hcl = qcelemental.models.Molecule('''
+        >>> hcl = qcelemental.models.v2.Molecule.from_data('''
         ... H      0.0000      0.0000      0.0000
         ... Cl     0.0000      0.0000      1.2000
         ... ''')
         >>> hcl.get_molecular_formula()
         ClH
 
-        >>> two_pentanol_radcat = qcelemental.models.Molecule('''
+        >>> two_pentanol_radcat = qcelemental.models.v2.Molecule.from_data('''
         ... 1 2
         ... C         -4.43914        1.67538       -0.14135
         ... C         -2.91385        1.70652       -0.10603
@@ -1483,8 +1475,8 @@ class Molecule(ProtoModel):
     def scramble(
         self,
         *,
-        do_shift: Union[bool, Array[float], List] = True,
-        do_rotate: Union[bool, Array[float], List[List]] = True,
+        do_shift: Union[bool, NDArray[np.float64], List] = True,
+        do_rotate: Union[bool, NDArray[np.float64], List[List]] = True,
         do_resort: Union[bool, List] = True,
         deflection: float = 1.0,
         do_mirror: bool = False,

--- a/qcelemental/models/v2/molecule.py
+++ b/qcelemental/models/v2/molecule.py
@@ -17,9 +17,6 @@ import numpy as np
 from pydantic import Field, field_validator, model_serializer
 from typing_extensions import Annotated
 
-from .basemodels import ProtoModel, check_convertible_version, qcschema_draft
-from .common_models import Provenance
-from .types import Array
 # molparse imports separated b/c https://github.com/python/mypy/issues/7203
 from ...molparse.from_arrays import from_arrays
 from ...molparse.from_schema import from_schema
@@ -30,6 +27,9 @@ from ...periodic_table import periodictable
 from ...physical_constants import constants
 from ...testing import compare, compare_values
 from ...util import deserialize, measure_coordinates, msgpackext_loads, provenance_stamp, which_import
+from .basemodels import ProtoModel, check_convertible_version, qcschema_draft
+from .common_models import Provenance
+from .types import Array
 
 if TYPE_CHECKING:
     import nglview

--- a/qcelemental/models/v2/types.py
+++ b/qcelemental/models/v2/types.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import warnings
 from typing import Any, Dict
 
@@ -83,23 +82,5 @@ class ValidatableArrayAnnotation:
         output_schema.update(type="array", items=items)
         return output_schema
 
-
-if sys.version_info < (3, 9):
-    # LNN: Ooooooooohhhh boy...
-    # Source information: https://github.com/beartype/beartype/issues/42
-    # Annotated checks against instances of _GenericAlias to see if you can support Data[type_info], e.g. NDArray[int]
-    # (in Python types since 3.9, and kinda of as _GenricAlias before that)
-    # Prior to 3.9, Numpy implemented their own version of _GenericAlias which isn't Python _GenericAlias, so the types
-    # are not considered "Generic" when Annotated[NDArray, Metadata][type_info] does its thing.
-    # So. This code block does a TON of heavy lifting to re-cast the NDArray type with _GenericAlias from python typing.
-    # I've tried to reuse as much data from NDArray as I possibly can and still use np.ndarray (which is not
-    # np.typing.NDArray) to still correctly type hint np.ndarrays.
-    # See (pre 3.9) numpy/typing/_generic_alias.py
-    from typing import _GenericAlias
-
-    _shape_info, _dtype_info = NDArray.__args__
-    _generic_dtype = _GenericAlias(_dtype_info, _dtype_info.__args__)
-    _generic_ndarr = _GenericAlias(np.ndarray, (_shape_info, _generic_dtype))
-    NDArray = _generic_ndarr
 
 Array = Annotated[NDArray, ValidatableArrayAnnotation]

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -212,7 +212,7 @@ def test_water_minima_data(Molecule, water_dimer_minima_data):
     mol_dict["name"] = "water dimer"
     mol = Molecule(orient=True, **mol_dict)
 
-    assert len(mol.pretty_print()) == 661
+    assert len(mol.pretty_print()) == 664
     assert len(mol.to_string("psi4")) == 479
 
     assert sum(x == y for x, y in zip(mol.symbols, ["O", "H", "H", "O", "H", "H"])) == mol.geometry.shape[0]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
3 small fixes for the v2  molecule in next2026. No change in behavior or interface

1. Need to import sys (and cleans up other unused imports)
2. Fixes printing for float multiplicity
3. Utility should use `type(self)` rather than `Molecule` in order to handle being called from derived classes
4. Remove unused NDArray stuff for python < 3.9
5. Fix typing of function parameters & return types
6. Improve logic of molecule `@property` (connectivity doesn't need an aliased attribute, and don't use `__dict__` when aliases are used)

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Fixes imports, printing, and returned objects in v2 `Molecule` class

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [X] Code base linted
- [X] Ready to go
