### PR TITLE
Rework serialization and model dumping for v2 models

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -10,6 +10,7 @@ This project ships two QCSchema families:
   - Make subschema more re-useable and composible
   - Standardize naming and field availability to be more predictable
   - Bring visible change to accompany the Pydantic v2 transition
+  - Make models more compatible with standard Pydantic v2 paradigms and workflows
 
 - This guide is AI generated and edited with some care. But a better guide is the [cheat sheet](docs/qcschema_cheatsheet_9Jan2026.pdf).
 
@@ -27,6 +28,11 @@ This project ships two QCSchema families:
   qcelemental.models.v1 import SomeQCSchemaClass`. Never use `somefile`-style imports again.
 - Change your `SomeQCSchemaClass.dict()`, `.json()`, and `.copy()` to `.model_dump()`, `.model_dump_json()`, and `.model_copy()`.
   Both v1 and v2 classes define both sets, but the latter set is the Pydantic v2 way and will quench a lot of warnings.
+  - Replace `SomeQCSchemaClass.dict(encoding="json")` with `SomeQCSchemaClass.model_dump(mode="json")`
+- Models will dump all fields by default (except some models will exclude fields with a value of `None`). If you want to
+  exclude fields with default or unset values, use `.model_dump(exclude_unset=True)` and/or `.model_dump_json(exclude_unset=True)`.
+  - Note that this will cause `schema_name` and `schema_version` to be excluded, which may cause problems with
+    validation later on.
 
 ## Migrating to v2
 
@@ -72,6 +78,13 @@ v2, return control to the schema wrapper, call `convert_v(return_version)`, and 
   - The package provides visible, non-destructive warnings and placeholder behavior such that importing `qcelemental.models.v1` succeeds, but
     instantiating v1 models raises a clear `RuntimeError` on Python versions >=3.14.
 
+- Serialization is handled in a more standard pydantic way. This makes the typical pydantic functions like `model_dump()`
+  `model_dump_json()` behave as expected, removing the custom serialize functions we previously had.
+  - Numpy serialization is handled by using a custom type annotation (`Array`) which will serialize to a list of floats
+    in "json" mode, and as a numpy array in "python" mode. Validation is handled here as well.
+  - `model_dump(mode="python")` will return a dict in Python format, where numpy arrays are kept as numpy arrays.
+  - `model_dump(mode="json")` will return a dict in JSON format, where numpy arrays are converted to lists.
+  - The above will make features like `model_dump_json()` work without any other custom code.
 
 ---
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,10 @@ Changelog
 Breaking Changes
 ++++++++++++++++
 
+- (:pr:`393`) Reworks serialization and model dumping for v2 models. Many models will now include
+  unset and default fields by default. Also removes buggy custom serialization logic, leaning more on standard
+  pydantic recommendations. Also makes more models tolerant of `None` values being passed in for certain fields.
+
 New Features
 ++++++++++++
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,29 @@ Changelog
 .. +++++
 
 
+.. _`sec:cl0500rc4`:
+
+0.50.0rc4 / 2026-MM-DD (Unreleased)
+-----------------------------------
+
+:docs:`v0.50.0rc4` for current. :docs:`v0.30.2` for QCSchema v1.
+
+Breaking Changes
+++++++++++++++++
+
+New Features
+++++++++++++
+
+Enhancements
+++++++++++++
+
+Bug Fixes
++++++++++
+
+Misc.
++++++
+
+
 .. _`sec:cl0500rc3`:
 
 0.50.0rc3 / 2026-03-10

--- a/qcelemental/datum.py
+++ b/qcelemental/datum.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import Any, Dict, Optional, Union
 
 import numpy as np
+from numpy.typing import NDArray
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -26,9 +27,7 @@ def reduce_complex(data):
     return data
 
 
-def keep_decimal_cast_ndarray_complex(
-    v: Any, nxt: SerializerFunctionWrapHandler, info: SerializationInfo
-) -> Union[list, Decimal, float]:
+def keep_decimal_cast_ndarray_complex(v: Any, nxt: SerializerFunctionWrapHandler, info: SerializationInfo) -> Any:
     """
     Ensure Decimal types are preserved on the way out
 

--- a/qcelemental/models/_v1v2/atomic.py
+++ b/qcelemental/models/_v1v2/atomic.py
@@ -10,7 +10,7 @@ from ...util import provenance_stamp
 #   from v1, they'll need redefining here
 from ..v2.atomic import AtomicProperties as AtomicProperties_v2
 from ..v2.atomic import WavefunctionProperties as WavefunctionProperties_v2
-from ..v2.basemodels import ExtendedConfigDict, ProtoModel
+from ..v2.basemodels import ProtoModel
 from ..v2.common_models import DriverEnum, Model, Provenance
 from ..v2.failed_operation import ComputeError
 from ..v2.types import Array
@@ -82,8 +82,6 @@ class AtomicResultProtocols(ProtoModel):
     stdout: bool = Field(True)
     error_correction: ErrorCorrectionProtocol = Field(default_factory=ErrorCorrectionProtocol)
     native_files: NativeFilesProtocolEnum = Field(NativeFilesProtocolEnum.none)
-
-    model_config = ExtendedConfigDict(force_skip_defaults=True)
 
 
 # ====  Inputs (Kw/Spec/In)  ====================================================

--- a/qcelemental/models/v2/align.py
+++ b/qcelemental/models/v2/align.py
@@ -4,7 +4,7 @@ import numpy as np
 from pydantic import Field, field_validator
 
 from ...util import blockwise_contract, blockwise_expand
-from .basemodels import ExtendedConfigDict, ProtoModel
+from .basemodels import ProtoModel
 from .types import Array
 
 __all__ = ["AlignmentMill"]
@@ -25,8 +25,6 @@ class AlignmentMill(ProtoModel):
     rotation: Optional[Array[float]] = Field(None, description="Rotation array (3, 3) for coordinates.")  # type: ignore
     atommap: Optional[Array[int]] = Field(None, description="Atom exchange map (nat,) for coordinates.")  # type: ignore
     mirror: bool = Field(False, description="Do mirror invert coordinates?")
-
-    model_config = ExtendedConfigDict(force_skip_defaults=True)
 
     @field_validator("shift")
     @classmethod

--- a/qcelemental/models/v2/atomic.py
+++ b/qcelemental/models/v2/atomic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Set, Union
@@ -7,7 +9,7 @@ from pydantic import Field, field_validator
 
 from ...models import QCEL_V1V2_SHIM_CODE
 from ...util import provenance_stamp
-from .basemodels import ExtendedConfigDict, ProtoModel, check_convertible_version, qcschema_draft
+from .basemodels import ProtoModel, check_convertible_version, qcschema_draft
 from .basis_set import BasisSet
 from .common_models import DriverEnum, Model, Provenance
 from .molecule import Molecule
@@ -249,10 +251,8 @@ class AtomicProperties(ProtoModel):
         None, description="The number of CCSDTQ iterations taken before convergence."
     )
 
-    model_config = ProtoModel._merge_config_with(force_skip_defaults=True)
-
     def __repr_args__(self) -> "ReprArgs":
-        return [(k, v) for k, v in self.dict().items()]
+        return [(k, v) for k, v in self.model_dump(exclude_unset=True).items()]
 
     @field_validator(
         "scf_dipole_moment",
@@ -299,13 +299,6 @@ class AtomicProperties(ProtoModel):
         except (ValueError, AttributeError):
             raise ValueError(f"Derivative must be castable to shape {shape}!")
         return v
-
-    def dict(self, *args, **kwargs):
-        # pure-json dict repr for QCFractal compliance, see https://github.com/MolSSI/QCFractal/issues/579
-        # Sep 2021: commenting below for now to allow recomposing AtomicResult.properties for qcdb.
-        #   This will break QCFractal tests for now, but future qcf will be ok with it.
-        # kwargs["encoding"] = "json"
-        return super().model_dump(*args, **kwargs)
 
     def convert_v(
         self, target_version: int, /
@@ -536,11 +529,6 @@ class WavefunctionProperties(ProtoModel):
         None, description="Index to the beta-spin orbital occupations of the primary return."
     )
 
-    # Note that serializing WfnProp skips unset fields (and indeed the validator will error upon None values)
-    #   while including all fields for the submodel BasisSet. This is the right behavior, imo, but note that
-    #   v1 skips unset fields in BasisSet as well as the top-level model.
-    model_config = ProtoModel._merge_config_with(force_skip_defaults=True)
-
     @field_validator("scf_eigenvalues_a", "scf_eigenvalues_b", "scf_occupations_a", "scf_occupations_b")
     @classmethod
     def _assert1d(cls, v):
@@ -628,9 +616,9 @@ class WavefunctionProperties(ProtoModel):
         if check_convertible_version(target_version, error="WavefunctionProperties") == "self":
             return self
 
-        dself = self.model_dump()
+        dself = self.model_dump(exclude_unset=True, exclude_none=True)  # v1 models don't handle None
         if target_version in [1, QCEL_V1V2_SHIM_CODE]:
-            dself["basis"] = self.basis.convert_v(target_version).dict()
+            dself["basis"] = self.basis.convert_v(target_version).model_dump()
 
             if target_version == 1:
                 self_vN = qcel.models.v1.WavefunctionProperties(**dself)
@@ -701,8 +689,6 @@ class AtomicProtocols(ProtoModel):
         NativeFilesProtocolEnum.none,
         description="Policies for keeping processed files from the computation",
     )
-
-    model_config = ExtendedConfigDict(force_skip_defaults=True)
 
     def convert_v(
         self, target_version: int, /

--- a/qcelemental/models/v2/atomic.py
+++ b/qcelemental/models/v2/atomic.py
@@ -13,7 +13,7 @@ from .basemodels import ProtoModel, check_convertible_version, qcschema_draft
 from .basis_set import BasisSet
 from .common_models import DriverEnum, Model, Provenance
 from .molecule import Molecule
-from .types import Array
+from .types import Array, NestedData
 
 if TYPE_CHECKING:
     import qcelemental
@@ -863,7 +863,7 @@ class AtomicResult(ProtoModel):
     properties: AtomicProperties = Field(..., description=str(AtomicProperties.__doc__))
     wavefunction: Optional[WavefunctionProperties] = Field(None, description=str(WavefunctionProperties.__doc__))
 
-    return_result: Union[float, Array[float], Dict[str, Any]] = Field(
+    return_result: NestedData = Field(
         ...,
         description="The primary return specified by the :attr:`~qcelemental.models.AtomicInput.driver` field. Scalar if energy; array if gradient or hessian; dictionary with property keys if properties.",
     )  # type: ignore
@@ -879,7 +879,7 @@ class AtomicResult(ProtoModel):
         True, description="The success of program execution. If False, other fields may be blank."
     )
     provenance: Provenance = Field(..., description=str(Provenance.__doc__))
-    extras: Dict[str, Any] = Field(
+    extras: NestedData = Field(
         {},
         description="Additional information to bundle with the computation. Use for schema development and scratch space.",
     )

--- a/qcelemental/models/v2/atomic.py
+++ b/qcelemental/models/v2/atomic.py
@@ -5,7 +5,8 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Set, Union
 
 import numpy as np
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_serializer
+from pydantic_core.core_schema import SerializerFunctionWrapHandler
 
 from ...models import QCEL_V1V2_SHIM_CODE
 from ...util import provenance_stamp
@@ -299,6 +300,12 @@ class AtomicProperties(ProtoModel):
         except (ValueError, AttributeError):
             raise ValueError(f"Derivative must be castable to shape {shape}!")
         return v
+
+    @model_serializer(mode="wrap")
+    def _remove_none(self, handler: SerializerFunctionWrapHandler) -> Dict[str, Any]:
+        # Removes fields with a value of None from the serialized output
+        serialized = handler(self)
+        return {k: v for k, v in serialized.items() if v is not None}
 
     def convert_v(
         self, target_version: int, /
@@ -606,6 +613,12 @@ class WavefunctionProperties(ProtoModel):
         if info.data.get(v, None) is None:
             raise ValueError(f"Return quantity {v} does not exist in the values.")
         return v
+
+    @model_serializer(mode="wrap")
+    def _remove_none(self, handler: SerializerFunctionWrapHandler) -> Dict[str, Any]:
+        # Removes fields with a value of None from the serialized output
+        serialized = handler(self)
+        return {k: v for k, v in serialized.items() if v is not None}
 
     def convert_v(
         self, target_version: int, /

--- a/qcelemental/models/v2/basemodels.py
+++ b/qcelemental/models/v2/basemodels.py
@@ -108,7 +108,7 @@ class ProtoModel(BaseModel):
         return cls.parse_raw(path.read_bytes(), encoding=encoding)
 
     def dict(self, **kwargs) -> Dict[str, Any]:
-        warnings.warn("The `dict` method is deprecated; use `model_dump` instead.", DeprecationWarning)
+        warnings.warn("The `dict` method is deprecated; use `model_dump` instead.", DeprecationWarning, stacklevel=2)
 
         if "encoding" in kwargs:
             kwargs["mode"] = kwargs.pop("encoding")
@@ -167,7 +167,9 @@ class ProtoModel(BaseModel):
     # UNCOMMENT IF NEEDED FOR UPGRADE REDO!!!
     def json(self, **kwargs):
         # Alias JSON here from BaseModel to reflect dict changes
-        warnings.warn("The `json` method is deprecated; use `model_dump_json` instead.", DeprecationWarning)
+        warnings.warn(
+            "The `json` method is deprecated; use `model_dump_json` instead.", DeprecationWarning, stacklevel=2
+        )
         return self.model_dump_json(**kwargs)
 
     def compare(self, other: Union["ProtoModel", BaseModel], **kwargs) -> bool:

--- a/qcelemental/models/v2/basemodels.py
+++ b/qcelemental/models/v2/basemodels.py
@@ -1,6 +1,6 @@
 import warnings
 from pathlib import Path
-from typing import Optional, Set, Union
+from typing import Any, Dict, Optional, Set, Union
 
 from pydantic import BaseModel, ConfigDict
 
@@ -106,6 +106,14 @@ class ProtoModel(BaseModel):
                 raise TypeError("Could not infer `encoding`, please provide a `encoding` for this file.")
 
         return cls.parse_raw(path.read_bytes(), encoding=encoding)
+
+    def dict(self, **kwargs) -> Dict[str, Any]:
+        warnings.warn("The `dict` method is deprecated; use `model_dump` instead.", DeprecationWarning)
+
+        if "encoding" in kwargs:
+            kwargs["mode"] = kwargs.pop("encoding")
+
+        return self.model_dump(**kwargs)
 
     def serialize(
         self,

--- a/qcelemental/models/v2/basemodels.py
+++ b/qcelemental/models/v2/basemodels.py
@@ -1,9 +1,8 @@
-import json
 import warnings
 from pathlib import Path
-from typing import Any, Dict, Optional, Set, Union
+from typing import Optional, Set, Union
 
-from pydantic import BaseModel, ConfigDict, model_serializer
+from pydantic import BaseModel, ConfigDict
 
 from qcelemental.models import QCEL_V1V2_SHIM_CODE
 
@@ -14,23 +13,12 @@ def _repr(self) -> str:
     return f'{self.__repr_name__()}({self.__repr_str__(", ")})'
 
 
-class ExtendedConfigDict(ConfigDict, total=False):
-    serialize_skip_defaults: bool
-    """When serializing, ignore default values (i.e. those not set by user)"""
-
-    force_skip_defaults: bool
-    """Manually force defaults to not be included in output dictionary"""
-
-
 class ProtoModel(BaseModel):
     """QCSchema extension of pydantic.BaseModel."""
 
-    model_config = ExtendedConfigDict(
+    model_config = ConfigDict(
         frozen=True,
         extra="forbid",
-        populate_by_name=True,  # Allows using alias to populate
-        serialize_skip_defaults=False,
-        force_skip_defaults=False,
     )
 
     def __init_subclass__(cls, **kwargs) -> None:
@@ -119,57 +107,6 @@ class ProtoModel(BaseModel):
 
         return cls.parse_raw(path.read_bytes(), encoding=encoding)
 
-    # UNCOMMENT IF NEEDED FOR UPGRADE
-    #   defining this is maybe bad idea as dict(v2) does non-recursive dictionary, whereas model_dump does nested
-    # def dict(self, **kwargs) -> Dict[str, Any]:
-    #    warnings.warn("The `dict` method is deprecated; use `model_dump` instead.", DeprecationWarning)
-    #    return self.model_dump(**kwargs)
-
-    @model_serializer(mode="wrap")
-    def _serialize_model(self, handler) -> Dict[str, Any]:
-        """
-        Customize the serialization output. Does duplicate with some code in model_dump, but handles the case of nested
-        models and any model config options.
-
-        Encoding is handled at the `model_dump` level and not here as that should happen only after EVERYTHING has been
-        dumped/de-pydantic-ized.
-
-        DEVELOPER WARNING: If default values for nested ProtoModels are not validated and are also not the expected
-        model (e.g. Provenance fields are dicts by default), then this function will throw an error because the self
-        field becomes the current value, not the model.
-        """
-
-        # Get the default return, let the model_dump handle kwarg
-        default_result = handler(self)
-        force_skip_default = self.model_config["force_skip_defaults"]
-        output_dict = {}
-        # Could handle this with a comprehension, easier this way
-        for key, value in default_result.items():
-            # Skip defaults on config level (skip default must be on and k has to be unset)
-            # Also check against exclusion set on a model_config level
-            if force_skip_default and key not in self.model_fields_set:
-                continue
-            output_dict[key] = value
-        return output_dict
-
-    def model_dump(self, **kwargs) -> Dict[str, Any]:
-        encoding = kwargs.pop("encoding", None)
-
-        # kwargs.setdefault("exclude_unset", self.model_config["serialize_skip_defaults"])  # type: ignore
-        # if self.model_config["force_skip_defaults"]:  # type: ignore
-        #     kwargs["exclude_unset"] = True
-
-        # Model config defaults will be handled in the @model_serializer function
-        # The @model_serializer function will be called AFTER this is called
-        data = super().model_dump(**kwargs)
-
-        if encoding is None:
-            return data
-        elif encoding == "json":
-            return json.loads(serialize(data, encoding="json"))
-        else:
-            raise KeyError(f"Unknown encoding type '{encoding}', valid encoding types: 'json'.")
-
     def serialize(
         self,
         encoding: str,
@@ -225,9 +162,6 @@ class ProtoModel(BaseModel):
         warnings.warn("The `json` method is deprecated; use `model_dump_json` instead.", DeprecationWarning)
         return self.model_dump_json(**kwargs)
 
-    def model_dump_json(self, **kwargs):
-        return self.serialize("json", **kwargs)
-
     def compare(self, other: Union["ProtoModel", BaseModel], **kwargs) -> bool:
         r"""Compares the current object to the provided object recursively.
 
@@ -252,7 +186,7 @@ class ProtoModel(BaseModel):
         """
         Helper function to merge protomodel's config with other args
 
-        args: other ExtendedConfigDict instances or equivalent dicts
+        args: other ConfigDict instances or equivalent dicts
         kwargs: Keys to add into the dictionary raw
         """
         output_dict = {**cls.model_config}
@@ -261,7 +195,7 @@ class ProtoModel(BaseModel):
         # Update any specific keywords
         output_dict.update(kwargs)
         # Finally, check against the Extended Config Dict
-        return ExtendedConfigDict(**output_dict)
+        return ConfigDict(**output_dict)
 
 
 def check_convertible_version(ver: int, error: str):

--- a/qcelemental/models/v2/molecule.py
+++ b/qcelemental/models/v2/molecule.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Optional, 
 
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import Field, field_validator
+from pydantic import Field, SerializerFunctionWrapHandler, field_validator, model_serializer
 from typing_extensions import Annotated
 
 # molparse imports separated b/c https://github.com/python/mypy/issues/7203
@@ -459,6 +459,12 @@ class Molecule(ProtoModel):
         if v < 1.0:
             raise ValueError("Molecular Multiplicity must be positive")
         return v
+
+    @model_serializer(mode="wrap")
+    def _remove_none(self, handler: SerializerFunctionWrapHandler) -> Dict[str, Any]:
+        # Removes fields with a value of None from the serialized output
+        serialized = handler(self)
+        return {k: v for k, v in serialized.items() if v is not None}
 
     @property
     def hash_fields(self):

--- a/qcelemental/models/v2/molecule.py
+++ b/qcelemental/models/v2/molecule.py
@@ -1209,7 +1209,7 @@ class Molecule(ProtoModel):
             for at2 in atoms[:iat1]:
                 dist = np.linalg.norm(self.geometry[at1] - self.geometry[at2])
                 nre += Zeff[at1] * Zeff[at2] / dist
-        return nre
+        return float(nre)
 
     def nelectrons(self, ifr: int = None, real_only: bool = True) -> int:
         r"""Number of electrons.

--- a/qcelemental/models/v2/molecule.py
+++ b/qcelemental/models/v2/molecule.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Optional, 
 
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import Field, field_validator, model_serializer
+from pydantic import Field, field_validator
 from typing_extensions import Annotated
 
 # molparse imports separated b/c https://github.com/python/mypy/issues/7203
@@ -337,8 +337,10 @@ class Molecule(ProtoModel):
     )
 
     model_config = ProtoModel._merge_config_with(
-        serialize_skip_defaults=True,
         json_schema_extra=molecule_json_schema_extras,
+        serialize_by_alias=True,
+        validate_by_alias=True,
+        validate_by_name=True,
     )
     # Alias fields are handled with the Field objects above
 
@@ -613,27 +615,6 @@ class Molecule(ProtoModel):
             raise TypeError("Comparison molecule not understood of type '{}'.".format(type(other)))
 
         return self.get_hash() == other.get_hash()
-
-    # UNCOMMENT IF NEEDED FOR UPGRADE REDO??
-    def dict(self, **kwargs):
-        warnings.warn("The `dict` method is deprecated; use `model_dump` instead.", DeprecationWarning)
-        return self.model_dump(**kwargs)
-        # TODO maybe bad idea as dict(v2) does non-recursive dictionary, whereas model_dump does nested
-
-    @model_serializer(mode="wrap")
-    def _serialize_molecule(self, handler) -> Dict[str, Any]:
-        default_result = handler(self)
-        output_dict = {}
-        for key, value in default_result.items():
-            # Could do this as a single comprehension dict, but this is easier to read
-            # Handle exclude unset is always true
-            if key not in self.model_fields_set:
-                continue
-            # Handle "by_alias" is always true
-            alias = self.__class__.model_fields[key].alias
-            output_key = alias if alias is not None else key
-            output_dict[output_key] = value
-        return output_dict
 
     def pretty_print(self):
         r"""Print the molecule in Angstroms. Same as :py:func:`print_out` only always in Angstroms.
@@ -1611,7 +1592,7 @@ class Molecule(ProtoModel):
         if check_convertible_version(target_version, error="Molecule") == "self":
             return self
 
-        dself = self.model_dump()
+        dself = self.model_dump(exclude_unset=True, exclude_none=True)
         if target_version in [1, QCEL_V1V2_SHIM_CODE]:
             # below is assignment rather than popping so Mol() records as set and future Mol.model_dump() includes the field.
             #   needed for QCEngine Psi4.

--- a/qcelemental/models/v2/optimization.py
+++ b/qcelemental/models/v2/optimization.py
@@ -14,7 +14,7 @@ from .atomic import AtomicProperties, AtomicResult, AtomicSpecification
 from .basemodels import ProtoModel, check_convertible_version
 from .common_models import Provenance
 from .molecule import Molecule
-from .types import Array
+from .types import Array, NestedData
 
 if TYPE_CHECKING:
     from qcmanybody.models.v2 import ManyBodyProperties, ManyBodyResult, ManyBodySpecification
@@ -150,7 +150,7 @@ class OptimizationSpecification(ProtoModel):
     )
     keywords: Dict[str, Any] = Field({}, description="The optimization specific keywords to be used.")
     protocols: OptimizationProtocols = Field(OptimizationProtocols(), description=str(OptimizationProtocols.__doc__))
-    extras: Dict[str, Any] = Field(
+    extras: NestedData = Field(
         {},
         description="Additional information to bundle with the computation. Use for schema development and scratch space.",
     )

--- a/qcelemental/models/v2/optimization.py
+++ b/qcelemental/models/v2/optimization.py
@@ -11,7 +11,7 @@ from pydantic import Discriminator, Field, Tag, field_validator
 
 from ...util import provenance_stamp, which_import
 from .atomic import AtomicProperties, AtomicResult, AtomicSpecification
-from .basemodels import ExtendedConfigDict, ProtoModel, check_convertible_version
+from .basemodels import ProtoModel, check_convertible_version
 from .common_models import Provenance
 from .molecule import Molecule
 from .types import Array
@@ -47,8 +47,6 @@ class OptimizationProtocols(ProtoModel):
     trajectory_results: TrajectoryProtocolEnum = Field(
         TrajectoryProtocolEnum.none, description=str(TrajectoryProtocolEnum.__doc__)
     )
-
-    model_config = ExtendedConfigDict(force_skip_defaults=True)
 
     def convert_v(
         self, target_version: int, /

--- a/qcelemental/models/v2/optimization.py
+++ b/qcelemental/models/v2/optimization.py
@@ -296,7 +296,14 @@ class OptimizationProperties(ProtoModel):
         None, description="The number of geometry iterations taken before convergence."
     )
 
-    final_rms_force: Optional[float] = Field(None, description="The final RMS gradient of the molecule in Eh/Bohr.")
+    final_max_force: Optional[float] = Field(None)
+    final_rms_force: Optional[float] = Field(
+        None,
+        description="The final RMS gradient of the molecule in Hartrees/Bohr.",
+        json_schema_extra={"units": "E_h/a0"},
+    )
+    final_max_displacement: Optional[float] = Field(None)
+    final_rms_displacement: Optional[float] = Field(None)
 
     model_config = ProtoModel._merge_config_with(force_skip_defaults=True)
 

--- a/qcelemental/models/v2/torsion_drive.py
+++ b/qcelemental/models/v2/torsion_drive.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Uni
 from pydantic import Field, conlist, field_validator
 
 from ...util import provenance_stamp
-from .basemodels import ExtendedConfigDict, ProtoModel, check_convertible_version
+from .basemodels import ProtoModel, check_convertible_version
 from .common_models import DriverEnum, Provenance
 from .molecule import Molecule
 from .optimization import OptimizationProperties, OptimizationResult, OptimizationSpecification
@@ -38,8 +38,6 @@ class TorsionDriveProtocols(ProtoModel):
     scan_results: ScanResultsProtocolEnum = Field(
         ScanResultsProtocolEnum.none, description=str(ScanResultsProtocolEnum.__doc__)
     )
-
-    model_config = ExtendedConfigDict(force_skip_defaults=True)
 
 
 # ====  Inputs (Kw/Spec/In)  ====================================================

--- a/qcelemental/models/v2/types.py
+++ b/qcelemental/models/v2/types.py
@@ -1,9 +1,10 @@
 import os
 import warnings
-from typing import Any, Dict
+from typing import Any, Dict, Mapping, Sequence
 
 import numpy as np
 from numpy.typing import NDArray
+from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
 from typing_extensions import Annotated, get_args
 
@@ -36,7 +37,7 @@ class ValidatableArrayAnnotation:
         shape, dtype_alias = get_args(source)
         dtype = get_args(dtype_alias)[0]
         validator = generate_caster(dtype)
-        # When using JSON, flatten and to list it
+        # When serializing to JSON, flatten and to list it
         serializer = core_schema.plain_serializer_function_ser_schema(lambda v: v.flatten().tolist(), when_used="json")
         # Affix dtype metadata to the schema we'll use in serialization
         schema = core_schema.no_info_plain_validator_function(
@@ -46,7 +47,6 @@ class ValidatableArrayAnnotation:
 
     @classmethod
     def __get_pydantic_json_schema__(cls, _core_schema, handler) -> Dict[str, Any]:
-        # Old __modify_schema__ method from v1 setup in v2 and customized for our purposes
         # Get the dtype metadata from our original schema
         if os.environ.get("SPHINX_BUILD") == "1":
             dt = float
@@ -68,4 +68,61 @@ class ValidatableArrayAnnotation:
         return output_schema
 
 
+class NestedDataAnnotation:
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        _source_type: Any,
+        _handler: GetCoreSchemaHandler,
+    ) -> core_schema.CoreSchema:
+        """
+        An annotation for generic, nested data
+
+        This will handle nested dictionaries and lists on both validation and serialization
+
+        On validation:
+          * Data in lists or other sequences will be cast to ndarrays
+          * `ndarrays` instances will be left as `ndarrays`
+
+        On serialization:
+          * Numpy arrays will be flattened
+        """
+
+        def _recursive_flatten(a):
+            """Recursively flattens numpy arrays that are part of lists, dicts, and other sequences/mappings"""
+
+            if isinstance(a, str):
+                return a
+            if isinstance(a, np.ndarray):
+                return a.flatten().tolist()
+            if isinstance(a, Mapping):
+                return {k: _recursive_flatten(v) for k, v in a.items()}
+            if isinstance(a, Sequence):
+                return [_recursive_flatten(x) for x in a]
+
+            return a
+
+        def _from_input(v, convert_list=True):
+            if isinstance(v, (float, str, np.ndarray)):
+                return v
+            if isinstance(v, int):
+                return float(v)
+            elif isinstance(v, Sequence) and convert_list:
+                return np.asarray(v)
+            elif isinstance(v, Mapping):
+                return {k: _from_input(v, False) for k, v in v.items()}
+            else:
+                return v
+
+        return core_schema.no_info_plain_validator_function(
+            _from_input,
+            serialization=core_schema.plain_serializer_function_ser_schema(_recursive_flatten, when_used="json"),
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(cls, _core_schema, handler) -> Dict[str, Any]:
+        return {}
+
+
 Array = Annotated[NDArray, ValidatableArrayAnnotation]
+NestedData = Annotated[Any, NestedDataAnnotation]

--- a/qcelemental/tests/test_model_general.py
+++ b/qcelemental/tests/test_model_general.py
@@ -14,7 +14,7 @@ def test_result_properties_default_skip(request, schema_versions):
     assert pytest.approx(obj.scf_one_electron_energy) == -5.0
 
     if "v2" in request.node.name:
-        assert obj.model_dump(exclude_unset=True).keys() == {"scf_one_electron_energy"}
+        assert obj.model_dump().keys() == {"schema_name", "scf_one_electron_energy"}
     else:
         assert obj.dict().keys() == {"scf_one_electron_energy"}
 

--- a/qcelemental/tests/test_model_general.py
+++ b/qcelemental/tests/test_model_general.py
@@ -13,10 +13,11 @@ def test_result_properties_default_skip(request, schema_versions):
 
     assert pytest.approx(obj.scf_one_electron_energy) == -5.0
 
-    if "v2" in request.node.name:
-        assert obj.model_dump().keys() == {"schema_name", "scf_one_electron_energy"}
-    else:
-        assert obj.dict().keys() == {"scf_one_electron_energy"}
+    assert (
+        obj.model_dump().keys() == {"schema_name", "scf_one_electron_energy"}
+        if ("v2" in request.node.name)
+        else {"scf_one_electron_energy"}
+    )
 
 
 def test_result_properties_default_repr(request, schema_versions):

--- a/qcelemental/tests/test_model_general.py
+++ b/qcelemental/tests/test_model_general.py
@@ -13,7 +13,10 @@ def test_result_properties_default_skip(request, schema_versions):
 
     assert pytest.approx(obj.scf_one_electron_energy) == -5.0
 
-    assert obj.dict().keys() == {"scf_one_electron_energy"}
+    if "v2" in request.node.name:
+        assert obj.model_dump(exclude_unset=True).keys() == {"scf_one_electron_energy"}
+    else:
+        assert obj.dict().keys() == {"scf_one_electron_energy"}
 
 
 def test_result_properties_default_repr(request, schema_versions):

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -785,17 +785,16 @@ def test_result_properties_array(request, schema_versions):
     obj = AtomicResultProperties(
         scf_one_electron_energy="-5.0", scf_dipole_moment=[1, 2, 3], scf_quadrupole_moment=lquad
     )
+    nominal_keys = {"scf_dipole_moment", "scf_one_electron_energy", "scf_quadrupole_moment"}
     drop_qcsk(obj, request.node.name)
 
     assert pytest.approx(obj.scf_one_electron_energy) == -5.0
     assert obj.scf_dipole_moment.shape == (3,)
     assert obj.scf_quadrupole_moment.shape == (3, 3)
 
-    assert obj.model_dump(exclude_unset=True).keys() == {
-        "scf_one_electron_energy",
-        "scf_dipole_moment",
-        "scf_quadrupole_moment",
-    }
+    assert obj.model_dump(exclude_unset=True).keys() == nominal_keys
+    assert obj.model_dump().keys() == {*nominal_keys, "schema_name"} if ("v2" in request.node.name) else nominal_keys
+
     assert np.array_equal(obj.scf_quadrupole_moment, np.array(lquad).reshape(3, 3))
     # assert obj.dict()["scf_quadrupole_moment"] == lquad  # when properties.dict() was forced json
     assert np.array_equal(
@@ -1395,7 +1394,7 @@ def test_model_survey_convertible(smodel1, smodel2, every_model_fixture, request
         # "v1-MBKw"     ,  "v2-MBKw"    ,  # TODO
         "v1-MBPtcl"   ,  "v2-MBPtcl"  ,
         "v1-MBRes"    ,  "v2-MBRes"   ,
-        # "v1-MBProp"   ,  "v2-MBProp"  ,  # TODO
+        "v1-MBProp"   ,  "v2-MBProp"  ,
     }
     # fmt: on
 

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -605,7 +605,9 @@ def test_wavefunction_protocols(
         assert wfn.wavefunction is None
     else:
         expected_keys = set(expected) | {"scf_" + x for x in expected} | {"basis", "restricted"}
-        assert wfn.wavefunction.model_dump(exclude_unset=True).keys() == expected_keys
+        if "v2" in request.node.name:
+            expected_keys.add("schema_name")
+        assert wfn.wavefunction.model_dump().keys() == expected_keys
 
 
 @pytest.mark.parametrize(
@@ -816,7 +818,11 @@ def test_result_derivatives_array(request, schema_versions):
     assert obj.calcinfo_natom == 4
     assert obj.return_gradient.shape == (4, 3)
     assert obj.scf_total_hessian.shape == (12, 12)
-    assert obj.model_dump(exclude_unset=True).keys() == {"calcinfo_natom", "return_gradient", "scf_total_hessian"}
+
+    expected_keys = {"calcinfo_natom", "return_gradient", "scf_total_hessian"}
+    if "v2" in request.node.name:
+        expected_keys.add("schema_name")
+    assert obj.model_dump().keys() == expected_keys
 
 
 @pytest.fixture(scope="function")
@@ -1339,11 +1345,7 @@ def test_model_survey_dictable(smodel1, smodel2, every_model_fixture, request, s
     instance = model(**data)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-
-        if "v2" in anskey:
-            instance = model(**instance.model_dump())
-        else:
-            instance = model(**instance.dict())
+        instance = model(**instance.dict())
 
     assert instance
 

--- a/qcelemental/tests/test_model_results.py
+++ b/qcelemental/tests/test_model_results.py
@@ -605,7 +605,7 @@ def test_wavefunction_protocols(
         assert wfn.wavefunction is None
     else:
         expected_keys = set(expected) | {"scf_" + x for x in expected} | {"basis", "restricted"}
-        assert wfn.wavefunction.model_dump().keys() == expected_keys
+        assert wfn.wavefunction.model_dump(exclude_unset=True).keys() == expected_keys
 
 
 @pytest.mark.parametrize(
@@ -789,7 +789,11 @@ def test_result_properties_array(request, schema_versions):
     assert obj.scf_dipole_moment.shape == (3,)
     assert obj.scf_quadrupole_moment.shape == (3, 3)
 
-    assert obj.model_dump().keys() == {"scf_one_electron_energy", "scf_dipole_moment", "scf_quadrupole_moment"}
+    assert obj.model_dump(exclude_unset=True).keys() == {
+        "scf_one_electron_energy",
+        "scf_dipole_moment",
+        "scf_quadrupole_moment",
+    }
     assert np.array_equal(obj.scf_quadrupole_moment, np.array(lquad).reshape(3, 3))
     # assert obj.dict()["scf_quadrupole_moment"] == lquad  # when properties.dict() was forced json
     assert np.array_equal(
@@ -812,7 +816,7 @@ def test_result_derivatives_array(request, schema_versions):
     assert obj.calcinfo_natom == 4
     assert obj.return_gradient.shape == (4, 3)
     assert obj.scf_total_hessian.shape == (12, 12)
-    assert obj.model_dump().keys() == {"calcinfo_natom", "return_gradient", "scf_total_hessian"}
+    assert obj.model_dump(exclude_unset=True).keys() == {"calcinfo_natom", "return_gradient", "scf_total_hessian"}
 
 
 @pytest.fixture(scope="function")
@@ -1335,7 +1339,12 @@ def test_model_survey_dictable(smodel1, smodel2, every_model_fixture, request, s
     instance = model(**data)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        instance = model(**instance.dict())
+
+        if "v2" in anskey:
+            instance = model(**instance.model_dump())
+        else:
+            instance = model(**instance.dict())
+
     assert instance
 
     # check model_dump-ability

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -831,6 +831,25 @@ def test_good_isotope_spec(Molecule):
     )
 
 
+def test_serialization_preserves_mass_numbers():
+    water2 = qcel.models.v2.Molecule(
+        symbols=["O", "H", "H"],
+        mass_numbers=[18, 2, None],
+        geometry=[0, 0, 0, 1, 0, 0, 0, 1, 0],
+    )
+
+    data = water2.model_dump()
+
+    assert "masses" in data
+    assert "mass_numbers" in data
+
+    expected_mass_numbers = water2.mass_numbers.tolist()
+    serialized_mass_numbers = data["mass_numbers"].tolist()
+
+    assert serialized_mass_numbers == expected_mass_numbers
+    assert serialized_mass_numbers == [18, 2, 1]
+
+
 def test_nonphysical_spec(Molecule):
     mol = Molecule(symbols=["He"], masses=[100], geometry=[0, 0, 0], nonphysical=True)
     assert compare_values([100.0], mol.masses, "nonphysical mass")

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -205,10 +205,12 @@ def test_molecule_repr_chgmult(Molecule, water_molecule_data, water_dimer_minima
 def test_water_minima_data(Molecule, water_dimer_minima_data):
     water_dimer_minima = Molecule.from_data(**water_dimer_minima_data)
 
-    # Give it a name
+    # Keep as dict() for testing backwards compatibility
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        mol_dict = water_dimer_minima.model_dump()
+        mol_dict = water_dimer_minima.dict()
+
+    # Give it a name
     mol_dict["name"] = "water dimer"
     mol = Molecule(orient=True, **mol_dict)
 

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -804,13 +804,16 @@ def test_sparse_molecule_fields(mol_string, extra_keys, Molecule):
     assert len(diff_keys) == 0, f"Diff Keys {diff_keys}"
 
 
-def test_sparse_molecule_connectivity(Molecule):
+def test_sparse_molecule_connectivity(Molecule, request):
     """
     A bit of a weird test, but because we set connectivity should be excluded if it's None
     """
     mol = Molecule(symbols=["He", "He"], geometry=[0, 0, -2, 0, 0, 2], connectivity=None)
-    assert "connectivity" not in mol.model_dump()
-    assert mol.model_dump()["connectivity"] is None
+    assert mol.connectivity is None
+    if "v2" in request.node.name:
+        assert "connectivity" not in mol.model_dump()
+    else:
+        assert "connectivity" in mol.model_dump()
 
     mol = Molecule(symbols=["He", "He"], geometry=[0, 0, -2, 0, 0, 2])
     assert mol.connectivity is None

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -808,10 +808,10 @@ def test_sparse_molecule_fields(mol_string, extra_keys, Molecule):
 
 def test_sparse_molecule_connectivity(Molecule):
     """
-    A bit of a weird test, but because we set connectivity it should carry through.
+    A bit of a weird test, but because we set connectivity should be excluded if it's None
     """
     mol = Molecule(symbols=["He", "He"], geometry=[0, 0, -2, 0, 0, 2], connectivity=None)
-    assert "connectivity" in mol.model_dump()
+    assert "connectivity" not in mol.model_dump()
     assert mol.model_dump()["connectivity"] is None
 
     mol = Molecule(symbols=["He", "He"], geometry=[0, 0, -2, 0, 0, 2])

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -475,17 +475,15 @@ def test_molecule_errors_shape(Molecule, water_molecule_data):
         Molecule(**data)
 
 
-def test_molecule_json_serialization(Molecule, water_dimer_minima_data, request):
+def test_molecule_json_serialization(Molecule, water_dimer_minima_data):
     water_dimer_minima = Molecule.from_data(**water_dimer_minima_data)
 
     assert isinstance(water_dimer_minima.model_dump_json(), str)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        if "v2" in request.node.name:
-            assert isinstance(water_dimer_minima.model_dump(mode="json")["geometry"], list)
-        else:
-            assert isinstance(water_dimer_minima.dict(encoding="json")["geometry"], list)
+        # keep dict() around to check
+        assert isinstance(water_dimer_minima.dict(encoding="json")["geometry"], list)
 
     assert water_dimer_minima == Molecule.from_data(water_dimer_minima.model_dump_json(), dtype="json")
 
@@ -802,7 +800,7 @@ def test_sparse_molecule_fields(mol_string, extra_keys, Molecule):
     if extra_keys is not None:
         expected_keys |= extra_keys
 
-    diff_keys = mol.model_dump(exclude_unset=True).keys() ^ expected_keys
+    diff_keys = mol.model_dump().keys() ^ expected_keys
     assert len(diff_keys) == 0, f"Diff Keys {diff_keys}"
 
 
@@ -816,7 +814,7 @@ def test_sparse_molecule_connectivity(Molecule):
 
     mol = Molecule(symbols=["He", "He"], geometry=[0, 0, -2, 0, 0, 2])
     assert mol.connectivity is None
-    assert "connectivity" not in mol.model_dump(exclude_unset=True)
+    assert "connectivity" not in mol.model_dump()
 
 
 def test_bad_isotope_spec(Molecule):

--- a/qcelemental/tests/test_molecule.py
+++ b/qcelemental/tests/test_molecule.py
@@ -208,7 +208,7 @@ def test_water_minima_data(Molecule, water_dimer_minima_data):
     # Give it a name
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        mol_dict = water_dimer_minima.dict()
+        mol_dict = water_dimer_minima.model_dump()
     mol_dict["name"] = "water dimer"
     mol = Molecule(orient=True, **mol_dict)
 
@@ -473,14 +473,17 @@ def test_molecule_errors_shape(Molecule, water_molecule_data):
         Molecule(**data)
 
 
-def test_molecule_json_serialization(Molecule, water_dimer_minima_data):
+def test_molecule_json_serialization(Molecule, water_dimer_minima_data, request):
     water_dimer_minima = Molecule.from_data(**water_dimer_minima_data)
 
     assert isinstance(water_dimer_minima.model_dump_json(), str)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        assert isinstance(water_dimer_minima.dict(encoding="json")["geometry"], list)
+        if "v2" in request.node.name:
+            assert isinstance(water_dimer_minima.model_dump(mode="json")["geometry"], list)
+        else:
+            assert isinstance(water_dimer_minima.dict(encoding="json")["geometry"], list)
 
     assert water_dimer_minima == Molecule.from_data(water_dimer_minima.model_dump_json(), dtype="json")
 
@@ -797,7 +800,7 @@ def test_sparse_molecule_fields(mol_string, extra_keys, Molecule):
     if extra_keys is not None:
         expected_keys |= extra_keys
 
-    diff_keys = mol.model_dump().keys() ^ expected_keys
+    diff_keys = mol.model_dump(exclude_unset=True).keys() ^ expected_keys
     assert len(diff_keys) == 0, f"Diff Keys {diff_keys}"
 
 
@@ -810,7 +813,8 @@ def test_sparse_molecule_connectivity(Molecule):
     assert mol.model_dump()["connectivity"] is None
 
     mol = Molecule(symbols=["He", "He"], geometry=[0, 0, -2, 0, 0, 2])
-    assert "connectivity" not in mol.model_dump()
+    assert mol.connectivity is None
+    assert "connectivity" not in mol.model_dump(exclude_unset=True)
 
 
 def test_bad_isotope_spec(Molecule):

--- a/qcelemental/tests/test_molparse_from_string.py
+++ b/qcelemental/tests/test_molparse_from_string.py
@@ -113,7 +113,7 @@ def test_psi4_qm_1a(Molecule):
     kmol = Molecule.from_data(subject)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        _check_eq_molrec_minimal_model([], kmol.dict(), fullans)
+        _check_eq_molrec_minimal_model([], kmol.model_dump(exclude_unset=True), fullans)
 
 
 def test_psi4_qm_1ab():
@@ -154,7 +154,7 @@ def test_psi4_qm_1c(Molecule):
     assert compare_molrecs(fullans, final["qm"], tnm() + ": full")
 
     kmol = Molecule.from_data(subject)
-    _check_eq_molrec_minimal_model([], kmol.model_dump(), fullans)
+    _check_eq_molrec_minimal_model([], kmol.model_dump(exclude_unset=True), fullans)
 
 
 def test_psi4_qm_1d():
@@ -350,7 +350,7 @@ def test_psi4_qm_2a(Molecule):
     kmol = Molecule.from_data(subject)
     _check_eq_molrec_minimal_model(
         ["fragments", "fragment_charges", "fragment_multiplicities", "mass_numbers", "masses", "atom_labels", "real"],
-        kmol.model_dump(),
+        kmol.model_dump(exclude_unset=True),
         fullans,
     )
 

--- a/qcelemental/tests/test_molparse_from_string.py
+++ b/qcelemental/tests/test_molparse_from_string.py
@@ -113,7 +113,7 @@ def test_psi4_qm_1a(Molecule):
     kmol = Molecule.from_data(subject)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        _check_eq_molrec_minimal_model([], kmol.model_dump(exclude_unset=True), fullans)
+        _check_eq_molrec_minimal_model([], kmol.dict(), fullans)
 
 
 def test_psi4_qm_1ab():
@@ -154,7 +154,7 @@ def test_psi4_qm_1c(Molecule):
     assert compare_molrecs(fullans, final["qm"], tnm() + ": full")
 
     kmol = Molecule.from_data(subject)
-    _check_eq_molrec_minimal_model([], kmol.model_dump(exclude_unset=True), fullans)
+    _check_eq_molrec_minimal_model([], kmol.model_dump(), fullans)
 
 
 def test_psi4_qm_1d():
@@ -350,7 +350,7 @@ def test_psi4_qm_2a(Molecule):
     kmol = Molecule.from_data(subject)
     _check_eq_molrec_minimal_model(
         ["fragments", "fragment_charges", "fragment_multiplicities", "mass_numbers", "masses", "atom_labels", "real"],
-        kmol.model_dump(exclude_unset=True),
+        kmol.model_dump(),
         fullans,
     )
 

--- a/qcelemental/tests/test_molutil.py
+++ b/qcelemental/tests/test_molutil.py
@@ -322,7 +322,7 @@ Rotation:
 
     assert compare_recursive(mill_dict, mill.model_dump())
     mill_dict["rotation"] = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
-    assert compare_recursive(mill_dict, mill.model_dump(encoding="json"))
+    assert compare_recursive(mill_dict, mill.model_dump(mode="json"))
 
 
 def test_scramble_specific():

--- a/qcelemental/util/serialization.py
+++ b/qcelemental/util/serialization.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Union
+from typing import Any, Mapping, Sequence, Union
 
 import numpy as np
 import pydantic
@@ -14,10 +14,6 @@ except ModuleNotFoundError:
     pass
 
 _msgpack_which_msg = "Please install via `conda install msgpack-python`."
-
-
-# Might need to do a BaseModel.model_dump because the deprecated docs have both that and to_jsonable_python
-# from pydantic import BaseModel
 
 
 ## MSGPackExt

--- a/qcelemental/util/serialization.py
+++ b/qcelemental/util/serialization.py
@@ -4,7 +4,7 @@ from typing import Any, Mapping, Sequence, Union
 import numpy as np
 import pydantic
 from pydantic.v1.json import pydantic_encoder
-from pydantic_core import PydanticSerializationError, to_jsonable_python
+from pydantic_core import to_jsonable_python
 
 from .importing import which_import
 
@@ -212,18 +212,11 @@ class JSONArrayEncoder(json.JSONEncoder):
         try:
             return to_jsonable_python(obj)
         except ValueError:
-            if isinstance(obj, pydantic.BaseModel):
-                # this block bypasses the else below for pyd v2 models to supress a warning
-                pass
-            else:
+            if not isinstance(obj, pydantic.BaseModel):
                 try:
                     return pydantic_encoder(obj)
                 except TypeError:
                     pass
-
-        # See if pydantic model can be just serialized if the above couldn't be dumped
-        if isinstance(obj, pydantic.BaseModel):
-            return obj.model_dump_json()
 
         if isinstance(obj, np.ndarray):
             if obj.shape:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
This reworks how qcelemental v2 models are serialized/dumped to bring them more inline with standard pydantic behavior.

1. Previously, models had custom options that forced unset fields to be excluded. This was generally ok, but also counterintuitive when some applications did want those default fields for compatibility/provenance reasons. The led to needing custom serializers.

2. Models had some (buggy) logic for handling serialization to/from aliased fields. This is now handled by pydantic v2 natively. (see model_config options `serialize_by_alias` and `validate_by_alias`).

3. Because of the above, models were not tolerant of `None` being passed in (`Molecule` and `WavefunctionProperties`), even though it was the default value. For example, constructing a Molecule with `fragments=None` would result in an error.

So this PR removes the customization, makes the models tolerant of `None`, and updates some of the tests.

**The somewhat breaking change:** by default now, calling `.model_dump()` will dump all fields, even unset and `None` fields. This can be controlled with `exclude_unset=True` and `exclude_none=True` (see  [pydantic docs](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_dump)). This is also true for things like `model_dump_json`, and pydantic functions like `to_jsonable_python`).

The `dict()` function is removed to also bring our terminology in line with pydantic.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [ ] Code base linted
- [ ] Ready to go
