### PR TITLE
refactor(pydantic): remove deprecated ConstrainedInt and ConstrainedFloat

### DIFF
--- a/qcelemental/models/basis.py
+++ b/qcelemental/models/basis.py
@@ -2,16 +2,12 @@ from enum import Enum
 from typing import Dict, List, Optional
 
 try:
-    from pydantic.v1 import ConstrainedInt, Field, constr, validator
+    from pydantic.v1 import NonNegativeInt, Field, constr, validator
 except ImportError:  # Will also trap ModuleNotFoundError
-    from pydantic import ConstrainedInt, Field, constr, validator
+    from pydantic import NonNegativeInt, Field, constr, validator
 
 from ..exceptions import ValidationError
 from .basemodels import ProtoModel, qcschema_draft
-
-
-class NonnegativeInt(ConstrainedInt):
-    ge = 0
 
 
 class HarmonicType(str, Enum):
@@ -24,7 +20,7 @@ class HarmonicType(str, Enum):
 class ElectronShell(ProtoModel):
     """Information for a single electronic shell."""
 
-    angular_momentum: List[NonnegativeInt] = Field(
+    angular_momentum: List[NonNegativeInt] = Field(
         ..., description="Angular momentum for the shell as an array of integers.", min_items=1
     )
     harmonic_type: HarmonicType = Field(..., description=str(HarmonicType.__doc__))

--- a/qcelemental/models/molecule.py
+++ b/qcelemental/models/molecule.py
@@ -5,16 +5,17 @@ import collections
 import hashlib
 import json
 import warnings
+from annotated_types import Ge, Le
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Annotated, Any, Dict, Iterable, List, Optional, Tuple, Union, cast
 
 import numpy as np
 
 try:
-    from pydantic.v1 import ConstrainedFloat, ConstrainedInt, Field, constr, validator
+    from pydantic.v1 import Field, NonNegativeInt, constr, validator
 except ImportError:  # Will also trap ModuleNotFoundError
-    from pydantic import ConstrainedFloat, ConstrainedInt, Field, constr, validator
+    from pydantic import Field, NonNegativeInt, constr, validator
 
 try:
     import nglview
@@ -77,13 +78,7 @@ def float_prep(array, around):
     return array
 
 
-class NonnegativeInt(ConstrainedInt):
-    ge = 0
-
-
-class BondOrderFloat(ConstrainedFloat):
-    ge = 0
-    le = 5
+BondOrderFloat = Annotated[float, Ge(0), Le(5)]
 
 
 class Identifiers(ProtoModel):
@@ -232,7 +227,7 @@ class Molecule(ProtoModel):
     )
 
     # Fragment and connection data
-    connectivity_: Optional[List[Tuple[NonnegativeInt, NonnegativeInt, BondOrderFloat]]] = Field(  # type: ignore
+    connectivity_: Optional[List[Tuple[NonNegativeInt, NonNegativeInt, BondOrderFloat]]] = Field(  # type: ignore
         None,
         description="A list of bonds within the molecule. Each entry is a tuple "
         "of ``(atom_index_A, atom_index_B, bond_order)`` where the ``atom_index`` "


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

The classes are removed in pydantic v2.
https://docs.pydantic.dev/2.12/migration/#removed-in-pydantic-v2

partly addresses https://github.com/MolSSI/QCElemental/issues/374

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
