### PR TITLE
Fix circular import issue in Python 3.14.

### DIFF
--- a/qcelemental/periodic_table.py
+++ b/qcelemental/periodic_table.py
@@ -40,12 +40,12 @@ class PeriodicTable:
     """
 
     def __init__(self):
-        from . import data
+        from .data import nist_2011_atomic_weights
 
         # Of length number of elements
-        self.Z = data.nist_2011_atomic_weights["Z"]
-        self.E = data.nist_2011_atomic_weights["E"]
-        self.name = data.nist_2011_atomic_weights["name"]
+        self.Z = nist_2011_atomic_weights["Z"]
+        self.E = nist_2011_atomic_weights["E"]
+        self.name = nist_2011_atomic_weights["name"]
 
         self._el2z = dict(zip(self.E, self.Z))
         self._z2el = collections.OrderedDict(zip(self.Z, self.E))
@@ -53,10 +53,10 @@ class PeriodicTable:
         self._el2element = dict(zip(self.E, self.name))
 
         # Of length number of isotopes
-        self._EE = data.nist_2011_atomic_weights["_EE"]
-        self.EA = data.nist_2011_atomic_weights["EA"]
-        self.A = data.nist_2011_atomic_weights["A"]
-        self.mass = data.nist_2011_atomic_weights["mass"]
+        self._EE = nist_2011_atomic_weights["_EE"]
+        self.EA = nist_2011_atomic_weights["EA"]
+        self.A = nist_2011_atomic_weights["A"]
+        self.mass = nist_2011_atomic_weights["mass"]
 
         self._eliso2mass = dict(zip(self.EA, self.mass))
         self._eliso2el = dict(zip(self.EA, self._EE))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Fixes the circular import issue revealed in the QCengine build, https://github.com/MolSSI/QCEngine/issues/505

I also had another issue in rc5,
```
diff -up QCElemental-0.50.0rc5/pyproject.toml.bak QCElemental-0.50.0rc5/pyproject.toml
--- QCElemental-0.50.0rc5/pyproject.toml.bak    2026-05-18 09:07:49.332674024 +0000
+++ QCElemental-0.50.0rc5/pyproject.toml        2026-05-18 09:07:55.360201914 +0000
@@ -110,8 +110,8 @@ init_typed = true
 warn_required_dynamic_aliases = true
 warn_untyped_fields = true
 
-[tool.setuptools]
-packages = ["qcelemental"]
+[tool.setuptools.packages.find]
+include = ["qcelemental*"]
 
 [tool.setuptools.package-data]
```

but this code appears to have changed in the master branch.

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->
Fixed circular import issue in Python 3.14.

## Status
<!-- Please `poetry install; bash scripts/format.sh` in the base folder. -->
- [ ] Code base linted
- [x] Ready to go
