### PR TITLE
Fix typing of FailedOperation input_data in v12 model

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -148,8 +148,8 @@ jobs:
               {"label": "dev", "path": "dev/"},
               {"label": "v1", "path": "v1/"},
               {"label": "v0.30.2", "path": "v0.30.2/"},
-              {"label": "v0.50.0rc2", "path": "v0.50.0rc2/"},
-              {"label": "v0.50.0rc3", "path": "v0.50.0rc3/"},
+              {"label": "v0.50.0", "path": "v0.50.0/"},
+              {"label": "v0.50.1", "path": "v0.50.1/"},
           ]
           lbl = os.environ.get("VERSION_LABEL", "")
           tgt = os.environ.get("TARGET_FOLDER", "")

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -49,5 +49,5 @@ keywords:
   - physical-constant
   - schema
 license: BSD-3-Clause
-version: 0.50.1
-date-released: '2026-05-21'
+version: 0.50.2
+date-released: '2026-05-28'

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,19 @@ Changelog
 .. +++++
 
 
+.. _`sec:cl0502`:
+
+0.50.2 / 2026-05-28
+-------------------
+
+:docs:`v0.50.2` for current. :docs:`v0.30.2` for QCSchema v1.
+
+Bug Fixes
++++++++++
+- (:pr:`404`) Fix the typing for the behind-the-scenes _v1v2.FailedOperation class so that numpy
+  in inputs can serialize cleanly when called from QCFractalCompute
+
+
 .. _`sec:cl0501`:
 
 0.50.1 / 2026-05-21

--- a/qcelemental/models/_v1v2/failed_operation.py
+++ b/qcelemental/models/_v1v2/failed_operation.py
@@ -10,7 +10,7 @@ from .basemodels import check_convertible_version
 
 class FailedOperation(ProtoModel):
     id: Optional[str] = Field(None)
-    input_data: Any = Field(None)
+    input_data: Optional[Union[ProtoModel, GenericData]] = Field(None)
     success: bool = Field(False)
     error: ComputeError = Field(...)
     extras: Optional[GenericData] = Field({})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->

Since `input_data` can be a dictionary with numpy arrays, it needs to be typed with GenericData to properly handle serialization.


## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `bash scripts/format.sh` in the base folder or use pre-commit. -->
- [X] Code base linted
- [X] Ready to go
